### PR TITLE
test(scrapers): follow-up coverage for character spider (#7)

### DIFF
--- a/tests/unit/scrapers/test_character_spider.py
+++ b/tests/unit/scrapers/test_character_spider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from pathlib import Path
 
@@ -13,6 +14,28 @@ from scrapers.tibiantis_scrapers.spiders.character_spider import CharacterSpider
 FIXTURE_PATH = (
     Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "character_yhral.html"
 )
+
+
+def _build_character_html(rows: dict[str, str]) -> bytes:
+    """Build a minimal character-page body containing a `table.tabi` with the given rows.
+
+    Matches the structure the spider actually reads: `table.tabi tr.hover` with
+    `td:first-child` label and `td:nth-child(2)` value. Other rows on the real
+    page are ignored by the spider, so we omit them.
+    """
+    tr_html = "".join(
+        f"<tr class='hover'><td>{label}:</td><td>{value}</td></tr>"
+        for label, value in rows.items()
+    )
+    body = (
+        "<html><body>"
+        "<table class='tabi'>"
+        "<tr><td colspan='2'><b>Character Information</b></td></tr>"
+        f"{tr_html}"
+        "</table>"
+        "</body></html>"
+    )
+    return body.encode("utf-8")
 
 
 @pytest.fixture
@@ -79,3 +102,138 @@ def test_parse_missing_section_yields_nothing() -> None:
     items = list(spider.parse(response))
 
     assert items == []
+
+
+def test_parse_high_level_character_with_long_guild() -> None:
+    """Edge case — level well above 118 and a long guild string parse cleanly."""
+    rows = {
+        "Name": "Powerlevel",
+        "Sex": "male",
+        "Vocation": "Elite Knight",
+        "Level": "999",
+        "World": "Concordia",
+        "Residence": "Thais",
+        "House": "Magician's Alley 7",
+        "Guild Membership": (
+            "Grandmaster of the <a href='?page=showguild&id=1'>"
+            "Very Long Guild Name Approaching The 128 Char Limit Of The Field</a>"
+        ),
+        "Last Login": "20 Apr 2026 14:15:16 CEST",
+        "Account Status": "Premium Account",
+    }
+    response = HtmlResponse(
+        url="https://tibiantis.online/?page=character&name=Powerlevel",
+        body=_build_character_html(rows),
+        encoding="utf-8",
+    )
+    spider = CharacterSpider(name="Powerlevel")
+
+    item = next(iter(spider.parse(response)))
+
+    assert item["level"] == 999
+    assert isinstance(item["level"], int)
+    assert item[
+        "guild_membership"
+    ]  # anchor text extracted by the nth-child(2) a::text path
+    assert (
+        len(item["guild_membership"]) < 128
+    )  # stays within Character.guild_membership max_length
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Known bug from #7 retro — _parse_last_login calls rsplit/strptime "
+        "unconditionally and raises ValueError on 'Never logged in'. "
+        "Remove xfail after the bug is fixed."
+    ),
+)
+def test_parse_character_never_logged_handles_gracefully() -> None:
+    """Fresh characters have `Last Login: Never logged in` — spider must not crash.
+
+    Expected behavior after fix: yield one item with last_login=None.
+    """
+    rows = {
+        "Name": "Newbie",
+        "Sex": "female",
+        "Vocation": "None",
+        "Level": "1",
+        "World": "Concordia",
+        "Residence": "Thais",
+        "House": "",
+        "Guild Membership": "",
+        "Last Login": "Never logged in",
+        "Account Status": "Free Account",
+    }
+    response = HtmlResponse(
+        url="https://tibiantis.online/?page=character&name=Newbie",
+        body=_build_character_html(rows),
+        encoding="utf-8",
+    )
+    spider = CharacterSpider(name="Newbie")
+
+    items = list(spider.parse(response))
+
+    assert len(items) == 1
+    assert items[0]["last_login"] is None
+    assert items[0]["name"] == "Newbie"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Known bug from #7 retro — `self.logger.warning(f'Character not found: "
+        "{self.name}')` uses the spider class attr ('character') instead of "
+        "self.character_name. Remove xfail after the bug is fixed."
+    ),
+)
+def test_warning_log_contains_queried_character_name(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`not found` warning must name the queried character, not the spider itself."""
+    body = b"<html><body><div>404</div></body></html>"
+    response = HtmlResponse(
+        url="https://tibiantis.online/?page=character&name=Ghost",
+        body=body,
+        encoding="utf-8",
+    )
+    spider = CharacterSpider(name="Ghost")
+
+    with caplog.at_level(logging.WARNING, logger=spider.logger.logger.name):
+        list(spider.parse(response))
+
+    assert any("Ghost" in record.getMessage() for record in caplog.records)
+
+
+def test_spider_settings_respect_contact_and_throttling() -> None:
+    """Scrapy settings module enforces the netiquette rules from CLAUDE.md §6."""
+    from scrapers.tibiantis_scrapers import settings as scrapy_settings
+
+    assert scrapy_settings.USER_AGENT.startswith("TibiantisMonitor/")
+    assert "contact" in scrapy_settings.USER_AGENT.lower()
+    assert scrapy_settings.ROBOTSTXT_OBEY is True
+    assert scrapy_settings.DOWNLOAD_DELAY >= 2.0
+    assert scrapy_settings.CONCURRENT_REQUESTS_PER_DOMAIN == 1
+
+
+def test_item_fields_match_model_fields() -> None:
+    """CharacterItem must expose the same fields the Character model persists.
+
+    Drift between the scraper boundary and the ORM shape is a common bug
+    source in Scrapy pipelines — guard against it at the type-system level.
+    """
+    from apps.characters.models import Character
+    from scrapers.tibiantis_scrapers.items import CharacterItem
+
+    item_fields = set(CharacterItem.fields.keys())
+    model_fields = {
+        f.name
+        for f in Character._meta.get_fields()
+        if f.name not in {"id", "last_scraped_at"}  # auto-managed, not scraped
+    }
+
+    assert item_fields == model_fields, (
+        f"Drift between CharacterItem and Character model. "
+        f"Only in item: {item_fields - model_fields}. "
+        f"Only in model: {model_fields - item_fields}."
+    )


### PR DESCRIPTION
## Summary
Adds the 4 tests from the "Testing plan (Claude dopisze po PR)" section of issue #7, plus 2 **xfail-strict** tests that pin the two bugs surfaced in the retrospective review of PR #18.

## New tests
| Test | Purpose |
|---|---|
| `test_parse_high_level_character_with_long_guild` | Edge case — level 999 + long guild string parse cleanly and stay within model `max_length` |
| `test_parse_character_never_logged_handles_gracefully` ⚠️ xfail-strict | Fresh character page has `Last Login: Never logged in` — currently crashes `_parse_last_login` with `ValueError` |
| `test_warning_log_contains_queried_character_name` ⚠️ xfail-strict | "Not found" warning uses `self.name` (spider class attr = `"character"`) instead of `self.character_name` |
| `test_spider_settings_respect_contact_and_throttling` | Enforces CLAUDE.md §6 netiquette: `USER_AGENT` with contact, `ROBOTSTXT_OBEY`, `DOWNLOAD_DELAY ≥ 2s`, concurrency 1 |
| `test_item_fields_match_model_fields` | Parity check — `CharacterItem.fields` ↔ `Character._meta.get_fields()` (minus auto-managed `id`/`last_scraped_at`) |

## Why `xfail(strict=True)` for the two known bugs
Rather than wait for the fix to land before adding coverage, the tests describe the **expected post-fix behavior** and are marked `xfail(strict=True)`. When either bug is fixed, its test flips to `XPASS`, `strict=True` makes the suite fail, and whoever fixes the bug must remove the `xfail` marker deliberately. This way:
- The test already exists (no "we'll add it later" drift).
- The specification is visible in the test file, not buried in a retro note.
- The fix is forced to prove itself against the existing test, not just to run it.

Both bugs will be tracked in a separate issue (separate scope: tests here, fix there — per project workflow).

## Minor refactor
Introduces `_build_character_html(rows)` helper so the two new edge-case tests use inline minimal HTML. This matches the pattern already established by `test_parse_missing_section_yields_nothing` and avoids adding `.html` fixture files for synthetic cases.

## Test plan
- [x] `poetry run pytest tests/unit/scrapers/test_character_spider.py -v` → 8 passed, 2 xfailed
- [x] `poetry run pre-commit run --files tests/unit/scrapers/test_character_spider.py` → all hooks green
- [ ] CI green after push

Part of post-merge cleanup for #7. Does not depend on / is not blocked by #19 (PROGRESS.md).