### PR TITLE
ci(pre-commit): add scrapy, crochet, twisted to mypy hook deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,9 @@ repos:
           - django-stubs[compatible-mypy]
           - djangorestframework-stubs
           - strawberry-graphql
+          - scrapy
+          - crochet
+          - twisted
 
   # Django 6.0 — automatyczna modernizacja składni
   - repo: https://github.com/adamchainz/django-upgrade


### PR DESCRIPTION
Pre-commit's mypy hook runs in an isolated env and needs these type stubs to resolve imports from management commands that use CrawlerRunner and @wait_for decorators. Without them mypy reports bogus "Class cannot subclass X (has type Any)" and "Untyped decorator" errors even though local poetry run mypy passes.