### PR TITLE
test(accounts): REST auth endpoint tests for #29

### DIFF
--- a/tests/unit/accounts/test_login_api.py
+++ b/tests/unit/accounts/test_login_api.py
@@ -1,0 +1,44 @@
+"""Tests for POST /api/auth/login/ endpoint (simplejwt TokenObtainPairView)."""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.accounts.models import User
+
+
+@pytest.mark.django_db
+def test_login_returns_access_and_refresh_for_valid_credentials() -> None:
+    """Valid username + password returns 200 with {access, refresh} JWT pair."""
+    User.objects.create_user(
+        username="yhral", email="yhral@example.com", password="KomplexHaslo!23"
+    )
+    client = APIClient()
+    payload = {"username": "yhral", "password": "KomplexHaslo!23"}
+
+    response = client.post(reverse("accounts_api:login"), payload, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert "access" in response.data
+    assert "refresh" in response.data
+    assert isinstance(response.data["access"], str)
+    assert isinstance(response.data["refresh"], str)
+
+
+@pytest.mark.django_db
+def test_login_returns_401_for_wrong_password() -> None:
+    """Wrong password returns 401, no tokens leak."""
+    User.objects.create_user(
+        username="yhral", email="yhral@example.com", password="KomplexHaslo!23"
+    )
+    client = APIClient()
+    payload = {"username": "yhral", "password": "wrong-password"}
+
+    response = client.post(reverse("accounts_api:login"), payload, format="json")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "access" not in response.data
+    assert "refresh" not in response.data

--- a/tests/unit/accounts/test_logout_api.py
+++ b/tests/unit/accounts/test_logout_api.py
@@ -1,0 +1,59 @@
+"""Tests for POST /api/auth/logout/ endpoint (simplejwt TokenBlacklistView)."""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.accounts.models import User
+
+
+@pytest.mark.django_db
+def test_logout_blacklists_refresh_token() -> None:
+    """Logout returns 200 and blacklisted refresh can no longer be exchanged.
+
+    Flow: login → logout with refresh → same refresh to /refresh/ must 401.
+    Proves BLACKLIST_AFTER_ROTATION wiring plus token_blacklist app migrations
+    are both in place.
+    """
+    User.objects.create_user(
+        username="yhral", email="yhral@example.com", password="KomplexHaslo!23"
+    )
+    client = APIClient()
+    login = client.post(
+        reverse("accounts_api:login"),
+        {"username": "yhral", "password": "KomplexHaslo!23"},
+        format="json",
+    )
+    refresh_token = login.data["refresh"]
+
+    logout_response = client.post(
+        reverse("accounts_api:logout"),
+        {"refresh": refresh_token},
+        format="json",
+    )
+
+    assert logout_response.status_code == status.HTTP_200_OK
+
+    reuse_response = client.post(
+        reverse("accounts_api:refresh"),
+        {"refresh": refresh_token},
+        format="json",
+    )
+    assert reuse_response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_logout_returns_401_for_invalid_token() -> None:
+    """Garbage refresh token returns 401 — cannot blacklist what isn't a token."""
+    client = APIClient()
+
+    response = client.post(
+        reverse("accounts_api:logout"),
+        {"refresh": "not-a-real-jwt"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/unit/accounts/test_refresh_api.py
+++ b/tests/unit/accounts/test_refresh_api.py
@@ -1,0 +1,54 @@
+"""Tests for POST /api/auth/refresh/ endpoint (simplejwt TokenRefreshView)."""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.accounts.models import User
+
+
+@pytest.mark.django_db
+def test_refresh_returns_new_tokens_and_rotates_refresh() -> None:
+    """Valid refresh returns 200 with a NEW access and a NEW refresh token.
+
+    SIMPLE_JWT has ROTATE_REFRESH_TOKENS=True, so the response must include a
+    freshly-issued refresh token distinct from the one used in the request.
+    """
+    User.objects.create_user(
+        username="yhral", email="yhral@example.com", password="KomplexHaslo!23"
+    )
+    client = APIClient()
+    login = client.post(
+        reverse("accounts_api:login"),
+        {"username": "yhral", "password": "KomplexHaslo!23"},
+        format="json",
+    )
+    original_refresh = login.data["refresh"]
+
+    response = client.post(
+        reverse("accounts_api:refresh"),
+        {"refresh": original_refresh},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert "access" in response.data
+    assert "refresh" in response.data
+    assert response.data["refresh"] != original_refresh
+
+
+@pytest.mark.django_db
+def test_refresh_returns_401_for_invalid_token() -> None:
+    """Garbage refresh token returns 401."""
+    client = APIClient()
+
+    response = client.post(
+        reverse("accounts_api:refresh"),
+        {"refresh": "not-a-real-jwt"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/unit/accounts/test_register_api.py
+++ b/tests/unit/accounts/test_register_api.py
@@ -1,0 +1,70 @@
+"""Tests for POST /api/auth/register/ endpoint."""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.accounts.models import User
+
+
+@pytest.mark.django_db
+def test_register_creates_user_with_valid_payload() -> None:
+    """Valid payload returns 201, persists User, hashes password, never leaks it."""
+    client = APIClient()
+    payload = {
+        "username": "yhral",
+        "email": "yhral@example.com",
+        "password": "KomplexHaslo!23",
+    }
+
+    response = client.post(reverse("accounts_api:register"), payload, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert "password" not in response.data
+    assert response.data["username"] == "yhral"
+    assert response.data["email"] == "yhral@example.com"
+
+    user = User.objects.get(username="yhral")
+    assert user.email == "yhral@example.com"
+    assert user.check_password("KomplexHaslo!23")
+    assert user.password != "KomplexHaslo!23"
+
+
+@pytest.mark.django_db
+def test_register_rejects_duplicate_username() -> None:
+    """Second registration with the same username returns 400."""
+    User.objects.create_user(
+        username="yhral", email="first@example.com", password="KomplexHaslo!23"
+    )
+    client = APIClient()
+    payload = {
+        "username": "yhral",
+        "email": "second@example.com",
+        "password": "KomplexHaslo!23",
+    }
+
+    response = client.post(reverse("accounts_api:register"), payload, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "username" in response.data
+    assert User.objects.filter(username="yhral").count() == 1
+
+
+@pytest.mark.django_db
+def test_register_rejects_numeric_only_password() -> None:
+    """NumericPasswordValidator rejects all-digit passwords even if long enough."""
+    client = APIClient()
+    payload = {
+        "username": "yhral",
+        "email": "yhral@example.com",
+        "password": "12345678",
+    }
+
+    response = client.post(reverse("accounts_api:register"), payload, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "password" in response.data
+    assert not User.objects.filter(username="yhral").exists()


### PR DESCRIPTION
## Summary

Follow-up do PR #35 (merged). Dopisuje testy automatyczne dla REST auth endpointów — pokrywa wszystkie scenariusze z AC Issue #29.

**Stack:** pytest + pytest-django + DRF `APIClient` + `reverse("accounts_api:...")`.

## Pokrycie

| Endpoint | Scenariusz | Status code |
|---|---|---|
| `POST /register/` | valid payload → user w DB, hasło zahashowane, password nie wraca w response | 201 |
| `POST /register/` | duplicate `username` | 400 |
| `POST /register/` | numeric-only password (`"12345678"`, `NumericPasswordValidator`) | 400 |
| `POST /login/` | valid creds zwraca `{access, refresh}` | 200 |
| `POST /login/` | złe hasło | 401 |
| `POST /refresh/` | valid refresh zwraca NOWY `{access, refresh}` (rotacja) | 200 |
| `POST /refresh/` | śmieciowy token | 401 |
| `POST /logout/` | blacklist + replay refresh na `/refresh/` → 401 | 200 |
| `POST /logout/` | śmieciowy token | 401 |

9 testów, wszystkie zielone lokalnie (`pytest tests/unit/accounts/`).

## Test plan

- [ ] CI (pytest job) zielone
- [ ] Coverage dla `apps/accounts/` nie spada poniżej progu 70%

## Related

Follow-up do #29 / PR #35. Per workflow projektu: Claude dopisuje testy po approve implementacji.