### PR TITLE
feat(accounts): GraphQL schema with UserType and me query (#30)

### DIFF
--- a/apps/accounts/schema.py
+++ b/apps/accounts/schema.py
@@ -1,0 +1,30 @@
+import strawberry
+import strawberry_django
+from strawberry import auto
+from asgiref.sync import sync_to_async
+from typing import cast
+
+from apps.accounts.models import User
+
+
+@strawberry_django.type(User)
+class UserType:
+    username: auto
+    email: auto
+    date_joined: auto
+    discord_id: auto
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    async def me(self, info: strawberry.Info) -> UserType | None:
+        request = info.context.request
+
+        def _resolve_user() -> User | None:
+            if not request.user.is_authenticated:
+                return None
+            return cast(User, request.user)
+
+        result = await sync_to_async(_resolve_user)()
+        return cast("UserType | None", result)

--- a/config/schema.py
+++ b/config/schema.py
@@ -1,0 +1,6 @@
+import strawberry
+from apps.accounts.schema import Query
+
+schema = strawberry.Schema(
+    query=Query,
+)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -46,6 +46,7 @@ DJANGO_APPS: list[str] = [
 THIRD_PARTY_APPS: list[str] = [
     "rest_framework",
     "rest_framework_simplejwt.token_blacklist",
+    "strawberry_django",
 ]
 
 LOCAL_APPS: list[str] = [

--- a/config/urls.py
+++ b/config/urls.py
@@ -17,8 +17,12 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
+from strawberry.django.views import AsyncGraphQLView
+from config.schema import schema
+from django.views.decorators.csrf import csrf_exempt
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/auth/", include("apps.accounts.api.urls")),
+    path("graphql/", csrf_exempt(AsyncGraphQLView.as_view(schema=schema))),
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -480,6 +480,21 @@ Twisted = ">=16.0"
 wrapt = "*"
 
 [[package]]
+name = "cross-web"
+version = "0.6.0"
+description = "A library for working with web frameworks"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "cross_web-0.6.0-py3-none-any.whl", hash = "sha256:bdebf0c08d02f3a48cf67b6904d3a6d8fd8cab2cd905592ab96ab00b259cd582"},
+    {file = "cross_web-0.6.0.tar.gz", hash = "sha256:ae90570802615365ca1a781117b43bfd0d6cd3bf611649d24c3a206a82a693c9"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.14.0"
+
+[[package]]
 name = "cryptography"
 version = "46.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -619,6 +634,22 @@ tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 [package.extras]
 argon2 = ["argon2-cffi (>=23.1.0)"]
 bcrypt = ["bcrypt (>=4.1.1)"]
+
+[[package]]
+name = "django-choices-field"
+version = "4.0.0"
+description = "Django field that set/get django's new TextChoices/IntegerChoices enum."
+optional = false
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+files = [
+    {file = "django_choices_field-4.0.0-py3-none-any.whl", hash = "sha256:dfa59033685af989f5bc49d95a586e8de692999d3179bf1cb14ef99879e6ff45"},
+    {file = "django_choices_field-4.0.0.tar.gz", hash = "sha256:7b07aacb2ad2b3ee3c8be78be98302ebbcb606285d20547a4163287819364954"},
+]
+
+[package.dependencies]
+django = ">=4.2"
+typing_extensions = ">=4.0.0"
 
 [[package]]
 name = "django-environ"
@@ -764,6 +795,18 @@ groups = ["main", "dev"]
 files = [
     {file = "filelock-3.28.0-py3-none-any.whl", hash = "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db"},
     {file = "filelock-3.28.0.tar.gz", hash = "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6"},
+]
+
+[[package]]
+name = "graphql-core"
+version = "3.2.8"
+description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
+optional = false
+python-versions = "<4,>=3.7"
+groups = ["main"]
+files = [
+    {file = "graphql_core-3.2.8-py3-none-any.whl", hash = "sha256:cbee07bee1b3ed5e531723685369039f32ff815ef60166686e0162f540f1520c"},
+    {file = "graphql_core-3.2.8.tar.gz", hash = "sha256:015457da5d996c924ddf57a43f4e959b0b94fb695b85ed4c29446e508ed65cf3"},
 ]
 
 [[package]]
@@ -1782,6 +1825,21 @@ files = [
 pytest = ">=7.0.0"
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-discovery"
 version = "1.2.2"
 description = "Python interpreter discovery"
@@ -2019,6 +2077,18 @@ mypy = ["idna", "mypy", "types-pyopenssl"]
 tests = ["coverage[toml] (>=5.0.2)", "pytest"]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.5"
 description = "A non-validating SQL parser."
@@ -2053,6 +2123,65 @@ pure-eval = "*"
 
 [package.extras]
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
+
+[[package]]
+name = "strawberry-graphql"
+version = "0.315.0"
+description = "A library for creating GraphQL APIs"
+optional = false
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+files = [
+    {file = "strawberry_graphql-0.315.0-py3-none-any.whl", hash = "sha256:1432a58d5505928dc9e6c221d8dffcde0b880772053cc265731d80248604c4e0"},
+    {file = "strawberry_graphql-0.315.0.tar.gz", hash = "sha256:8ca5c93b4a8687a9fbbf1cb167c6d10d832ca30147458487f7a3d3683dac0d22"},
+]
+
+[package.dependencies]
+cross-web = ">=0.4.0"
+graphql-core = ">=3.2.0,<3.4.0"
+packaging = ">=23"
+python-dateutil = ">=2.7"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.7.4.post0,<4)"]
+apollo-federation = ["protobuf (>=3.20)"]
+asgi = ["python-multipart (>=0.0.7)", "starlette (>=0.18.0)"]
+chalice = ["chalice (>=1.22)"]
+channels = ["asgiref (>=3.2)", "channels (>=3.0.5)"]
+cli = ["libcst", "pygments (>=2.3)", "python-multipart (>=0.0.7)", "rich (>=12.0.0)", "starlette (>=0.18.0)", "typer (>=0.12.4)", "uvicorn (>=0.11.6)", "websockets (>=15.0.1,<17)"]
+debug = ["libcst", "rich (>=12.0.0)"]
+django = ["asgiref (>=3.2)", "django (>=3.2)"]
+fastapi = ["fastapi (>=0.65.2)", "python-multipart (>=0.0.7)"]
+flask = ["flask (>=1.1)"]
+litestar = ["litestar (>=2)"]
+opentelemetry = ["opentelemetry-api (<2)", "opentelemetry-sdk (<2)"]
+pydantic = ["pydantic (>1.6.1)"]
+pyinstrument = ["pyinstrument (>=4.0.0)"]
+quart = ["quart (>=0.19.3)"]
+sanic = ["sanic (>=20.12.2)"]
+
+[[package]]
+name = "strawberry-graphql-django"
+version = "0.82.1"
+description = "Strawberry GraphQL Django extension"
+optional = false
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+files = [
+    {file = "strawberry_graphql_django-0.82.1-py3-none-any.whl", hash = "sha256:4fd54cd4cd17d3dae111c433a4a3aeaa10b98e4abeefc9614cbb6f28f9dbc51c"},
+    {file = "strawberry_graphql_django-0.82.1.tar.gz", hash = "sha256:a6fa235e4ada110d8e8aff82d12317535e63123f294fbcd6287af68895167a9c"},
+]
+
+[package.dependencies]
+asgiref = ">=3.8"
+django = ">=4.2"
+strawberry-graphql = ">=0.310.1"
+
+[package.extras]
+debug-toolbar = ["django-debug-toolbar (>=6.0.0)"]
+enum = ["django-choices-field (>=2.2.2)"]
+polymorphic = ["django-polymorphic (>=4.0.0)"]
 
 [[package]]
 name = "tldextract"
@@ -2378,4 +2507,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "e2612a640d36c15bf49e69105aa580a606a9df2250a755e75c1992eb4a7b3cd3"
+content-hash = "da1a164550c7cbe2088f65e0402dba770c1423d72c22bda84f375de86cf2fbf4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ requires-python = ">=3.13,<4.0"
       "scrapy (>=2.15.0,<3.0.0)",
       "crochet (>=2.1.1,<3.0.0)",
       "djangorestframework (>=3.17.1,<4.0.0)",
-      "djangorestframework-simplejwt (>=5.5.1,<6.0.0)"
+      "djangorestframework-simplejwt (>=5.5.1,<6.0.0)",
+      "strawberry-graphql-django (>=0.82.1,<0.84.0)",
+      "django-choices-field (>=4.0.0,<5.0.0)"
   ]
 
 


### PR DESCRIPTION
## Summary

Postawia endpoint `/graphql/` ze Strawberry-Django. Dodaje `UserType` zmapowane z `accounts.User` (bez password/staff fields) oraz query `me` zwracające zalogowanego usera. Baza pod D12 (JWT w GraphQL + `character(name)`).

## Dependencies added

- **`strawberry-graphql-django`** (`>=0.82.1,<0.84.0`) — GraphQL integration for Django models, per `CLAUDE.md` §2 (preferred over Graphene).
- **`django-choices-field`** (`>=4.0.0,<5.0.0`) — **recommended (not required)** by [strawberry-graphql-django docs](https://strawberry.rocks/docs/django) for cleaner mapping of Django `TextChoices`/`IntegerChoices` to GraphQL enums. Added upfront so any future `ChoicesField` on domain models is mapped automatically.

## Pre-flight

`poetry add strawberry-graphql-django --dry-run` — zweryfikowane 2026-04-24, żaden konflikt z Django 6.0. ✅

## R2 — async canary zadziałał manualnie

Issue #30 flagowało ryzyko `SynchronousOnlyOperation` przy ORM w `AsyncGraphQLView`. Potwierdzone ręcznym testem happy-path: zalogowany user → `{me {username}}` wywalało `"You cannot call this from an async context"`.

Rozwiązanie: `async def` resolver + `sync_to_async(callable)()` wokół ORM access. Wzorzec 1:1 jak w `scrapers/tibiantis_scrapers/pipelines.py` (M1 pipeline).

```python
async def me(self, info) -> UserType | None:
    request = info.context.request

    def _resolve_user() -> User | None:
        if not request.user.is_authenticated:
            return None
        return cast(User, request.user)

    result = await sync_to_async(_resolve_user)()
    return cast("UserType | None", result)
```

## mypy workaround — `cast(User, request.user)`

`request.user` zwraca `Any` w django-stubs, bo stubs settings (`config/settings/stubs.py`) nie zawiera `apps.accounts` ani `AUTH_USER_MODEL`. Tymczasowy workaround: explicit `cast(User, ...)`. **Follow-up chore PR** doda `apps.accounts` + `AUTH_USER_MODEL` do `stubs.py` — po merge można usunąć cast.

## Manual smoke test (GraphiQL, http://localhost:8000/graphql/)

- [x] `query { me { username } }` bez auth → `{"data": {"me": null}}` (bez errors)
- [x] Login przez `/admin/login/`, potem `query { me { username } }` → `{"data": {"me": {"username": "admin"}}}`
- [x] `query { __schema { types { name } } }` → 200 z listą typów (UserType obecny)

## Test plan (automatyczne, Claude dopisze follow-upem)

- [ ] Introspection smoke — `__schema` query zwraca 200, UserType na liście typów
- [ ] `me` bez auth → `{"me": null}`
- [ ] `me` z auth przez `TestClient.force_login(user)` → `{"me": {"username": "..."}}`
- [ ] Async canary — resolver z realnym ORM query (np. `User.objects.acount()`) pod async TestClient bez `SynchronousOnlyOperation`

## Acceptance criteria (z Issue #30)

- [x] `poetry add strawberry-graphql-django` (pre-flight OK)
- [x] `INSTALLED_APPS += ["strawberry_django"]`
- [x] `apps/accounts/schema.py` — `UserType` + `Query.me: UserType | None`
- [x] `config/schema.py` — scala, eksportuje `schema`
- [x] `/graphql/` przez `AsyncGraphQLView`
- [x] Manual smoke green (happy path + null case + introspection)

Closes #30