### PR TITLE
test(accounts): add GraphQL schema and me query tests for #30

### DIFF
--- a/tests/unit/accounts/test_graphql_async_canary.py
+++ b/tests/unit/accounts/test_graphql_async_canary.py
@@ -1,0 +1,62 @@
+"""Async canary for /graphql/ — wcześnie łapie SynchronousOnlyOperation.
+
+AsyncGraphQLView trzyma resolvery w event-loopie. Każde sync ORM query bez
+`sync_to_async` rzuci `django.core.exceptions.SynchronousOnlyOperation` —
+jeśli ktoś (świadomie lub przez auto-wrap Strawberry-Django) zepsuje to w
+przyszłości, ten test pęknie zanim D12 (JWT + character query) zacznie to
+maskować swoją złożonością.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from asgiref.sync import sync_to_async
+from django.test import AsyncClient
+
+from apps.accounts.models import User
+
+
+GRAPHQL_URL = "/graphql/"
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_me_resolver_serves_full_user_payload_through_async_view() -> None:
+    """Pełny end-to-end flow przez AsyncClient: auth + serializacja wszystkich pól UserType.
+
+    Każde pole UserType (`username`, `email`, `date_joined`, `discord_id`) to
+    osobny atrybut modelu — Strawberry-Django w trakcie odpowiedzi czyta je z
+    `request.user` (Django LazyObject). Jeśli którykolwiek attribute access
+    pociągnie sync ORM call w async kontekście, dostaniemy
+    `SynchronousOnlyOperation` zamiast 200 — czyli właśnie to co canary łapie.
+
+    Dodatkowo wykonujemy native async ORM query (`User.objects.acount()`),
+    żeby potwierdzić że ścieżka async ORM w ogóle żyje w tym setupie testów.
+    """
+    await sync_to_async(User.objects.create_user)(
+        username="yhral", email="yhral@example.com", password="KomplexHaslo!23"
+    )
+
+    user_count = await User.objects.acount()
+    assert user_count == 1
+
+    user = await User.objects.aget(username="yhral")
+    client = AsyncClient()
+    await sync_to_async(client.force_login)(user)
+
+    response = await client.post(
+        GRAPHQL_URL,
+        data=json.dumps({"query": "{ me { username email dateJoined discordId } }"}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.content
+    payload = response.json()
+    assert "errors" not in payload, payload
+    me = payload["data"]["me"]
+    assert me["username"] == "yhral"
+    assert me["email"] == "yhral@example.com"
+    assert me["dateJoined"] is not None
+    assert me["discordId"] is None

--- a/tests/unit/accounts/test_graphql_me.py
+++ b/tests/unit/accounts/test_graphql_me.py
@@ -1,0 +1,64 @@
+"""Tests for GraphQL `me` query and schema introspection at /graphql/."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from asgiref.sync import sync_to_async
+from django.test import AsyncClient
+
+from apps.accounts.models import User
+
+
+GRAPHQL_URL = "/graphql/"
+
+
+async def _post_graphql(client: AsyncClient, query: str) -> dict[str, object]:
+    response = await client.post(
+        GRAPHQL_URL,
+        data=json.dumps({"query": query}),
+        content_type="application/json",
+    )
+    assert response.status_code == 200, response.content
+    return response.json()
+
+
+@pytest.mark.asyncio
+async def test_schema_introspection_returns_200_with_types() -> None:
+    """Introspection canary — wadliwa konfiguracja schema/view wywaliłaby się tutaj."""
+    client = AsyncClient()
+
+    payload = await _post_graphql(client, "{ __schema { types { name } } }")
+
+    assert "errors" not in payload
+    type_names = {t["name"] for t in payload["data"]["__schema"]["types"]}
+    assert "UserType" in type_names
+    assert "Query" in type_names
+
+
+@pytest.mark.asyncio
+async def test_me_returns_null_when_unauthenticated() -> None:
+    """Niezalogowany użytkownik dostaje `{me: null}` — resolver nie powinien rzucać."""
+    client = AsyncClient()
+
+    payload = await _post_graphql(client, "{ me { username } }")
+
+    assert "errors" not in payload
+    assert payload["data"] == {"me": None}
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_me_returns_user_when_authenticated() -> None:
+    """Po `force_login` resolver zwraca dane bieżącego usera."""
+    user = await sync_to_async(User.objects.create_user)(
+        username="yhral", email="yhral@example.com", password="KomplexHaslo!23"
+    )
+    client = AsyncClient()
+    await sync_to_async(client.force_login)(user)
+
+    payload = await _post_graphql(client, "{ me { username } }")
+
+    assert "errors" not in payload
+    assert payload["data"] == {"me": {"username": "yhral"}}


### PR DESCRIPTION
Pokrywa wszystkie 4 testy z AC #30: schema introspection smoke, me bez auth (zwraca null), me z auth (przez force_login) oraz async canary łapiący SynchronousOnlyOperation we wszystkich polach UserType i native async ORM (User.objects.acount/aget).

Wszystkie testy używają django.test.AsyncClient zamiast sync Client — sync Client zawijałby AsyncGraphQLView w async_to_sync i maskował dokładnie to zachowanie, którego canary ma szukać (CLAUDE.md spec M2 R2).