### PR TITLE
feat(graphql): add JWT auth view and character(name) query (#31)

### DIFF
--- a/apps/accounts/api/views.py
+++ b/apps/accounts/api/views.py
@@ -1,7 +1,5 @@
 from rest_framework.generics import CreateAPIView
 from rest_framework.permissions import AllowAny
-
-
 from apps.accounts.api.serializers import RegisterSerializer
 from apps.accounts.models import User
 

--- a/apps/characters/schema.py
+++ b/apps/characters/schema.py
@@ -1,0 +1,28 @@
+import strawberry
+import strawberry_django
+from strawberry import auto
+from apps.characters.models import Character
+from typing import cast
+
+
+@strawberry_django.type(Character)
+class CharacterType:
+    name: auto
+    sex: auto
+    vocation: auto
+    level: auto
+    world: auto
+    residence: auto
+    house: auto
+    guild_membership: auto
+    last_login: auto
+    account_status: auto
+    last_scraped_at: auto
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    async def character(self, name: str) -> CharacterType | None:
+        result = await Character.objects.filter(name=name).afirst()
+        return cast("CharacterType | None", result)

--- a/config/schema.py
+++ b/config/schema.py
@@ -1,6 +1,7 @@
 import strawberry
-from apps.accounts.schema import Query
+from strawberry.tools import merge_types
+from apps.accounts.schema import Query as AccountsQuery
+from apps.characters.schema import Query as CharactersQuery
 
-schema = strawberry.Schema(
-    query=Query,
-)
+Query = merge_types("Query", (AccountsQuery, CharactersQuery))
+schema = strawberry.Schema(query=Query)

--- a/config/urls.py
+++ b/config/urls.py
@@ -17,12 +17,12 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
-from strawberry.django.views import AsyncGraphQLView
+from config.views import JWTAsyncGraphQLView
 from config.schema import schema
 from django.views.decorators.csrf import csrf_exempt
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/auth/", include("apps.accounts.api.urls")),
-    path("graphql/", csrf_exempt(AsyncGraphQLView.as_view(schema=schema))),
+    path("graphql/", csrf_exempt(JWTAsyncGraphQLView.as_view(schema=schema))),
 ]

--- a/config/views.py
+++ b/config/views.py
@@ -17,13 +17,11 @@ class JWTAsyncGraphQLView(AsyncGraphQLView):
             auth_result: tuple[Any, Any] | None = await sync_to_async(
                 _authenticator.authenticate  # type: ignore[arg-type]
             )(DRFRequest(request))
+        except AuthenticationFailed:
+            request.user = AnonymousUser()
+        else:
             if auth_result is not None:
                 user, _ = auth_result
                 request.user = user
-            else:
-                request.user = AnonymousUser()
-
-        except AuthenticationFailed:
-            request.user = AnonymousUser()
 
         return await super().dispatch(request, *args, **kwargs)

--- a/config/views.py
+++ b/config/views.py
@@ -1,0 +1,29 @@
+from typing import Any
+from django.http import HttpRequest, HttpResponseBase
+from asgiref.sync import sync_to_async
+from django.contrib.auth.models import AnonymousUser
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+from strawberry.django.views import AsyncGraphQLView
+from rest_framework.request import Request as DRFRequest
+
+
+class JWTAsyncGraphQLView(AsyncGraphQLView):
+    async def dispatch(  # type: ignore[override]
+        self, request: HttpRequest, *args: Any, **kwargs: Any
+    ) -> HttpResponseBase:
+        _authenticator = JWTAuthentication()
+        try:
+            auth_result: tuple[Any, Any] | None = await sync_to_async(
+                _authenticator.authenticate  # type: ignore[arg-type]
+            )(DRFRequest(request))
+            if auth_result is not None:
+                user, _ = auth_result
+                request.user = user
+            else:
+                request.user = AnonymousUser()
+
+        except AuthenticationFailed:
+            request.user = AnonymousUser()
+
+        return await super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
## Summary

Zamyka AC1+AC3+AC4 z #31 (JWT na `/graphql/`, public `character(name)` query, schema merge). Po merge zostaje tylko follow-up testowy (e2e + unit), który zamknie M2.

## Zmiany

- **`config/views.py`** (nowy): `JWTAsyncGraphQLView` — subclass `AsyncGraphQLView` z async `dispatch` wywołującym `JWTAuthentication.authenticate()` przez `sync_to_async`. Fallback `AnonymousUser` przy `AuthenticationFailed` / brakującym headerze, żeby mixed query (chronione `me` + public `character`) działała w jednej operacji.
- **`apps/characters/schema.py`** (nowy): `CharacterType` z 11 polami modelu (włącznie z `last_scraped_at` — public profile, brak sekretów). Resolver `character(name)` używa natywnego `afirst()` (Django 4.1+), bez `sync_to_async`.
- **`config/schema.py`**: `strawberry.tools.merge_types(accounts.Query + characters.Query)` z aliasowanymi importami — hard fail przy konflikcie nazw przy starcie schemy.
- **`config/urls.py`**: `/graphql/` podpięte pod `JWTAsyncGraphQLView` (zamiast gołego `AsyncGraphQLView`).
- **`apps/accounts/api/views.py`**: usunięte dead imports (`AsyncGraphQLView`, `AnonymousUser`, `JWTAuthentication`, etc.) — JWT view został przeniesiony do `config/views.py` (cross-app ownership).

## Decyzje warte odnotowania

- **Placement `JWTAsyncGraphQLView` w `config/views.py`, nie `apps/accounts/api/views.py`** — GraphQL view scali resolvery z wszystkich aplikacji (accounts, characters, później bedmages/deaths). Nie należy do `accounts.api`. Cross-app ownership = projekt-level.
- **`DRFRequest(request)` przed `authenticate()`** — `simplejwt.JWTAuthentication.authenticate()` wymaga `rest_framework.request.Request`, nie `django.http.HttpRequest`. Mypy strict to wyłapał (`HttpRequest` vs `Request` arg-type). DRF wrapper używany **tylko lokalnie** dla auth call; do `super().dispatch()` idzie oryginalny Django request (Strawberry oczekuje Django HttpRequest).
- **`# type: ignore[override]` na `dispatch`** — Django stuby twierdzą `View.dispatch` jest sync, Strawberry świadomie override'uje na async. Strawberry sam ma `# pyright: ignore` w źródle z tego powodu. Niezgodność strukturalna stubów, nie bug.
- **`merge_types` zamiast multiple inheritance** — flat merge pól, hard fail przy duplikatach (sanity sieć przy starcie). Dziedziczenie cicho rozwiązuje konflikty przez MRO = anti-pattern dla GraphQL.
- **`afirst()` zamiast `sync_to_async(filter().first)`** — Django 4.1+ ma natywne async ORM, czystsze niż wrapping. Różnica vs `me` resolver, który dotyka `request.user` (Django LazyObject) i wymaga `sync_to_async`.

## Manual smoke (przed commitem)

```bash
# 1. character bez auth (public) → 200, dane
curl -X POST http://localhost:8000/graphql/ -H "Content-Type: application/json" \
  -d '{"query":"{ character(name: \"Yhral\") { name level vocation world } }"}'
# {"data": {"character": {"name": "Yhral", "level": 124, "vocation": "Royal Paladin", "world": "Concordia"}}}

# 2. me bez auth → null
curl -X POST http://localhost:8000/graphql/ -H "Content-Type: application/json" \
  -d '{"query":"{ me { username } }"}'
# {"data": {"me": null}}

# 3. mixed query z Bearer → oba zwracają dane
curl -X POST http://localhost:8000/graphql/ \
  -H "Authorization: Bearer <access>" -H "Content-Type: application/json" \
  -d '{"query":"{ me { username } character(name: \"Yhral\") { level } }"}'
# {"data": {"me": {"username": "admin"}, "character": {"level": 124}}}
```

## Test plan

- [x] `poetry run mypy apps/ config/` → Success
- [x] `poetry run pre-commit run --all-files` → all green
- [x] Manual smoke 3 curl (powyżej)
- [ ] CI `lint` + `test` zielone na PR (#41 testy GraphQL z #30 nadal muszą przechodzić — `me` z `force_login`, async canary, introspection)
- [ ] Follow-up testowy PR (Claude napisze): `character(name)` happy/missing/anon, `me` z invalid/expired Bearer, e2e register→login→graphql

## Closes (po follow-up testowym)

`#31` — DoD #31 wymaga e2e testu, więc zamknięcie po testowym PR (analogicznie do #29 + #36, #30 + #41).