### PR TITLE
test(graphql): add JWT auth, character query and M2 e2e tests for #31

### DIFF
--- a/tests/integration/test_m2_e2e.py
+++ b/tests/integration/test_m2_e2e.py
@@ -1,0 +1,81 @@
+"""E2E integration test for M2 — register → login → JWT → GraphQL mixed query.
+
+Spec M2 §5/D12: jeden e2e łączący wszystkie warstwy (REST register/login,
+JWT, GraphQL public + chronione query). Po tym M2 może zostać zamknięty.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from asgiref.sync import sync_to_async
+from django.test import AsyncClient
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.characters.models import Character
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_m2_e2e_register_login_graphql_mixed_query() -> None:
+    """5-krokowy flow z spec D12 §5.
+
+    Klient REST (`APIClient`, sync) dla /api/auth/* i klient GraphQL
+    (`AsyncClient`, async) dla /graphql/ — sync REST view zawinięty przez
+    AsyncClient zamaskowałby SynchronousOnlyOperation, na odwrót Strawberry
+    AsyncGraphQLView wymaga prawdziwego async clienta. Dwa klienty są
+    konieczne (lekcja z mini-retro M2 #30).
+    """
+    rest = APIClient()
+    register_response = await sync_to_async(rest.post)(
+        reverse("accounts_api:register"),
+        data={
+            "username": "yhral",
+            "email": "yhral@example.com",
+            "password": "KomplexHaslo!23",
+        },
+        format="json",
+    )
+    assert (
+        register_response.status_code == status.HTTP_201_CREATED
+    ), register_response.content
+
+    login_response = await sync_to_async(rest.post)(
+        reverse("accounts_api:login"),
+        data={"username": "yhral", "password": "KomplexHaslo!23"},
+        format="json",
+    )
+    assert login_response.status_code == status.HTTP_200_OK, login_response.content
+    access = login_response.data["access"]
+    assert isinstance(access, str) and access
+
+    await sync_to_async(Character.objects.create)(
+        name="Yhral",
+        level=120,
+        vocation="Knight",
+        world="Tibiantis",
+        sex="male",
+        residence="Edron",
+        account_status="Free Account",
+    )
+
+    graphql = AsyncClient()
+    response = await graphql.post(
+        "/graphql/",
+        data=json.dumps(
+            {"query": '{ me { username } character(name: "Yhral") { level } }'}
+        ),
+        content_type="application/json",
+        headers={"Authorization": f"Bearer {access}"},
+    )
+
+    assert response.status_code == 200, response.content
+    payload = response.json()
+    assert "errors" not in payload, payload
+    assert payload["data"] == {
+        "me": {"username": "yhral"},
+        "character": {"level": 120},
+    }

--- a/tests/unit/accounts/test_graphql_jwt_auth.py
+++ b/tests/unit/accounts/test_graphql_jwt_auth.py
@@ -1,0 +1,83 @@
+"""Tests for JWT-based authentication on /graphql/ via JWTAsyncGraphQLView.
+
+D11 testowało `me` przez `force_login` (session). D12 dopina JWT — te testy
+sprawdzają że `me` zwraca usera dla validnego Bearera, null dla invalid,
+null dla expired.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+import pytest
+from asgiref.sync import sync_to_async
+from django.test import AsyncClient
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.accounts.models import User
+
+
+GRAPHQL_URL = "/graphql/"
+
+
+async def _post_me(client: AsyncClient, bearer: str | None) -> dict[str, object]:
+    headers = {"Authorization": f"Bearer {bearer}"} if bearer is not None else {}
+    response = await client.post(
+        GRAPHQL_URL,
+        data=json.dumps({"query": "{ me { username } }"}),
+        content_type="application/json",
+        headers=headers,
+    )
+    assert response.status_code == 200, response.content
+    return response.json()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_me_with_valid_bearer_returns_user() -> None:
+    """`me` z poprawnym JWT zwraca dane usera — JWT-first path."""
+    user = await sync_to_async(User.objects.create_user)(
+        username="yhral", email="yhral@example.com", password="KomplexHaslo!23"
+    )
+    access = await sync_to_async(lambda: str(AccessToken.for_user(user)))()
+
+    payload = await _post_me(AsyncClient(), access)
+
+    assert "errors" not in payload
+    assert payload["data"] == {"me": {"username": "yhral"}}
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_me_with_invalid_bearer_returns_null() -> None:
+    """Zły token (np. random string) → AuthenticationFailed → AnonymousUser → null."""
+    payload = await _post_me(AsyncClient(), "this.is.not.a.valid.jwt")
+
+    assert "errors" not in payload
+    assert payload["data"] == {"me": None}
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_me_with_expired_bearer_returns_null() -> None:
+    """Token wygasły → AuthenticationFailed (TokenError) → AnonymousUser → null.
+
+    `set_exp(lifetime=timedelta(seconds=-1))` cofa exp w przeszłość zachowując
+    walidny podpis — trafia w gałąź TokenExpired w simplejwt, nie w InvalidToken.
+    """
+    user = await sync_to_async(User.objects.create_user)(
+        username="yhral", email="yhral@example.com", password="KomplexHaslo!23"
+    )
+
+    def _expired_token() -> str:
+        token = AccessToken.for_user(user)
+        token.set_exp(lifetime=timedelta(seconds=-1))
+        return str(token)
+
+    expired = await sync_to_async(_expired_token)()
+
+    payload = await _post_me(AsyncClient(), expired)
+
+    assert "errors" not in payload
+    assert payload["data"] == {"me": None}

--- a/tests/unit/characters/test_graphql_character.py
+++ b/tests/unit/characters/test_graphql_character.py
@@ -1,0 +1,74 @@
+"""Tests for GraphQL `character(name)` public query.
+
+`character(name)` jest **public** (AC #31) — działa bez auth. Resolver używa
+natywnego `afirst()` (Django 4.1+ async ORM), więc null gdy postaci brak,
+dane gdy istnieje.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from asgiref.sync import sync_to_async
+from django.test import AsyncClient
+
+from apps.characters.models import Character
+
+
+GRAPHQL_URL = "/graphql/"
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_character_returns_data_when_exists_without_auth() -> None:
+    """Public query — brak Authorization headera → resolver zwraca dane."""
+    await sync_to_async(Character.objects.create)(
+        name="Yhral",
+        level=124,
+        vocation="Royal Paladin",
+        world="Concordia",
+        sex="male",
+        residence="Edron",
+        account_status="Free Account",
+    )
+
+    response = await AsyncClient().post(
+        GRAPHQL_URL,
+        data=json.dumps(
+            {
+                "query": '{ character(name: "Yhral") '
+                "{ name level vocation world sex } }"
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.content
+    payload = response.json()
+    assert "errors" not in payload
+    assert payload["data"]["character"] == {
+        "name": "Yhral",
+        "level": 124,
+        "vocation": "Royal Paladin",
+        "world": "Concordia",
+        "sex": "male",
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_character_returns_null_when_not_found() -> None:
+    """Postaci nie ma w bazie → afirst() zwraca None → resolver `null` (NIE error)."""
+    response = await AsyncClient().post(
+        GRAPHQL_URL,
+        data=json.dumps(
+            {"query": '{ character(name: "NotInDatabase") { name level } }'}
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.content
+    payload = response.json()
+    assert "errors" not in payload
+    assert payload["data"] == {"character": None}


### PR DESCRIPTION
## Summary

Follow-up testowy do #31 (impl zmerge'owany w PR #43). Zamyka DoD #31 i M2: e2e + dodatkowe testy jednostkowe.

## Pliki

- **`tests/unit/accounts/test_graphql_jwt_auth.py`** (3 testy) — `me` z validnym Bearer (`AccessToken.for_user`), invalid Bearer (random string → `AuthenticationFailed`), expired Bearer (`set_exp(timedelta(seconds=-1))` → TokenExpired). Pokrywa wszystkie 3 ścieżki w `JWTAsyncGraphQLView.dispatch`.
- **`tests/unit/characters/test_graphql_character.py`** (2 testy) — `character(name)` public happy path (bez auth, zwraca dane) i `character(name="NotInDatabase")` → `null` (NIE error). Convention GraphQL: nieistniejący zasób = null pole, nie 4xx.
- **`tests/integration/test_m2_e2e.py`** (1 test) — pełny 5-krokowy flow z spec D12 §5: REST register → REST login → seed Character → mixed query `me+character` z Bearer.

Pierwszy plik w `tests/integration/` (zgodnie z CLAUDE.md §3 i spec D12 §7 — "integration e2e tylko w D12").

## Decyzje warte odnotowania

- **Dwa klienty w e2e** — `APIClient` (DRF, sync) dla `/api/auth/*` i `AsyncClient` (Django, async) dla `/graphql/`. Lekcja z mini-retro M2 #30: sync DRF view zawinięty przez AsyncClient zamaskowałby SynchronousOnlyOperation w DRF auth, na odwrót Strawberry AsyncGraphQLView wymaga prawdziwego async clienta. Udokumentowane w docstring testu.
- **Expired token przez `set_exp(timedelta(seconds=-1))`** — czysty simplejwt API zamiast freezegun (nowa zależność niepotrzebna). Trafia w gałąź `TokenExpired` w `JWTAuthentication`, nie w `InvalidToken` (czyli `AuthenticationFailed`, ten sam handler co invalid).
- **Brak testu "valid Bearer + force_login łączą się"** — celowo. Testy #41 z #30 pokrywają session+force_login. Tu skupiamy się na JWT path.

## Test plan

- [x] `poetry run pytest tests/unit/accounts/test_graphql_jwt_auth.py tests/unit/characters/test_graphql_character.py tests/integration/test_m2_e2e.py -v` → 6 passed lokalnie
- [x] `poetry run pre-commit run --files <wszystkie 4>` → all green
- [x] Testy GraphQL z #41 (force_login, async canary, introspection) nadal przechodzą
- [ ] CI `lint` + `test` zielone na PR

## Zamyka M2

Po merge tego PR:
- DoD #31 spełnione (e2e zielony)
- Można zamknąć Issue #31 i milestone M2
- Następny krok (osobny docs PR analogicznie do #42): PROGRESS.md → "🎉 M2 COMPLETED" + retro per Issue (D9-D12)
