### PR TITLE
chore(pre-commit): bump django-upgrade to 1.30.0, target Django 6.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,10 +42,10 @@ repos:
 
   # Django 6.0 — automatyczna modernizacja składni
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.22.1
+    rev: 1.30.0
     hooks:
       - id: django-upgrade
-        args: [--target-version, "5.1"]
+        args: [--target-version, "6.0"]
 
 
   # Poetry — spójność pyproject.toml + poetry.lock

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -128,7 +128,6 @@ USE_TZ = True
 
 STATIC_URL = "static/"
 
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 AUTH_USER_MODEL = "accounts.User"
 

--- a/config/settings/stubs.py
+++ b/config/settings/stubs.py
@@ -16,5 +16,4 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "apps.characters",
 ]
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 USE_TZ = True


### PR DESCRIPTION
Bump django-upgrade rev z `1.22.1` → `1.30.0` (najnowszy stable) i `--target-version` z `5.1` → `6.0` — flagowane w retro M1 #5 i podsumowaniu M2.

## Auto-modernizacja przy bumpie targetu

Hook automatycznie usunął `DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"` z dwóch plików:
- `config/settings/base.py`
- `config/settings/stubs.py`

Powód: w Django 6.0 `BigAutoField` stał się **domyślnym** `DEFAULT_AUTO_FIELD` (wcześniej był `AutoField`). Explicit setting jest teraz redundantny.

## Smoke

- `poetry run pre-commit run --all-files` → wszystkie hooki zielone
- `poetry run python manage.py check` → "no issues"
- Istniejące migracje używają już `BigAutoField`, regeneracja niepotrzebna

## Per CLAUDE.md §15.12

To jedyna zmiana w `.pre-commit-config.yaml` w tym PR — żadnego mieszania ze zmianami funkcjonalnymi. Następne tech debt items (model index cleanup, dev.py, coverage threshold) idą jako osobne PR-y.