### PR TITLE
chore(ci): bump coverage threshold from 0 to 70 (#50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Migrate
         run: poetry run python manage.py migrate --noinput
       - name: Run tests
-        run: poetry run pytest --cov=apps --cov-report=xml --cov-fail-under=0
+        run: poetry run pytest --cov=apps --cov-report=xml --cov-fail-under=70
       - name: Upload coverage
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
Closes #50.

`.github/workflows/ci.yml:74`: `--cov-fail-under=0` → `70`. Tech debt z retro M1 #5 i podsumowania M2.

## Pomiar bazowy (M2 close, 2026-04-27)

```
TOTAL    199    28    86%
```

Bufor 16 punktów. `apps/characters/management/commands/scrape_character.py` (Twisted/crochet, 0%) jest jedyną dużą luką — i tak wlicza się do globalnego pomiaru.

## Per CLAUDE.md §15.12 + §15.13

- Osobny PR (zmiana w `.github/workflows/` nie miksowana z innymi tech debt items)
- Threshold ustawiony **powyżej** aktualnego z buforem — nie obniżamy, kolejne PR-y muszą trzymać 70%+.