### PR TITLE
chore(settings): dev.py reads DEBUG and ALLOWED_HOSTS from env (#49)

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,5 +1,5 @@
 from .base import *
 
 
-DEBUG = True
-ALLOWED_HOSTS = ["*"]
+DEBUG = env.bool("DJANGO_DEBUG", default=True)
+ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["*"])


### PR DESCRIPTION
Closes #49.

`config/settings/dev.py` hardcodował `DEBUG=True` i `ALLOWED_HOSTS=["*"]`, ignorując `DJANGO_DEBUG` i `DJANGO_ALLOWED_HOSTS` z `.env`. Tech debt z retro M0 #3.

## Zmiana

```python
DEBUG = env.bool("DJANGO_DEBUG", default=True)
ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["*"])
```

`env` instance pochodzi z `base.py:21` (`environ.Env()`), dostępny przez `from .base import *`.

## Decyzja: defaults

- `DEBUG` default `True` — dev domyślnie debug-on, override `.env` jeśli chcesz prod-like smoke.
- `ALLOWED_HOSTS` default `["*"]` — dev permisywny. W prod jest osobny `prod.py` (poza scope).

## Smoke (lokalny)

| Scenariusz | DEBUG | ALLOWED_HOSTS |
|---|---|---|
| Bez env (`.env` puste) | `True` | `['*']` |
| `DJANGO_DEBUG=False, DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1` | `False` | `['localhost', '127.0.0.1']` |

`poetry run pytest -q` → `53 passed` (DJANGO_SETTINGS_MODULE=config.settings.dev).

## Pułapka rozwiązana w trakcie

`env("DJANGO_DEBUG")` zwraca **string**. Trzeba `env.bool(...)` żeby Django dostał prawdziwy bool — klasyczna pułapka django-environ flagowana w Issue body.