### PR TITLE
chore(env): fill example values and comments in .env.example (#55)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
+# Django secret key. Generate: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
 DJANGO_SECRET_KEY=
-DJANGO_DEBUG=
-DJANGO_ALLOWED_HOSTS=
-DATABASE_URL=
+
+# w docker-compose host będzie 'postgres', tu localhost dla lokalnego setupu
+DATABASE_URL=postgres://user:pass@localhost:5432/tibiantis
+
+# Set True only for local dev. Production must keep False.
+DJANGO_DEBUG=False
+
+# comma-separated list, np. example.com,api.example.com
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1


### PR DESCRIPTION
Closes #55.

Wcześniej `.env.example` miał 4 klucze z pustymi wartościami po `=`. Nowy dev po `cp .env.example .env` musiał szukać poza repo czego oczekuje plik (format `DATABASE_URL`, sensowny default).

## Zmiany

```
# Django secret key. Generate: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
DJANGO_SECRET_KEY=

# w docker-compose host będzie 'postgres', tu localhost dla lokalnego setupu
DATABASE_URL=postgres://user:pass@localhost:5432/tibiantis

# Set True only for local dev. Production must keep False.
DJANGO_DEBUG=False

# comma-separated list, np. example.com,api.example.com
DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
```

## Decyzje warte odnotowania

- **`DJANGO_SECRET_KEY` zostaje pusty** — zgodnie z AC #55: sekret nigdy nie ma example value w repo (gitleaks paranoia + nowy dev musi mieć własny). Komentarz wskazuje generator.
- **Host `localhost`, nie `postgres`** w `DATABASE_URL` — CLAUDE.md §10 ma `@postgres:5432` (docker-compose alias). Aktualnie nie używamy docker-compose; `localhost` działa od razu po `apt install postgresql` / Postgres.app. Komentarz wskazuje docker-compose mapping.
- **`DJANGO_DEBUG=False` jako default** — `.env.example` to "minimum prod-like"; dev który chce DEBUG=True override'uje w prywatnym `.env`. Pattern z 12factor. Per #49 default w `dev.py:4` to `True` (gdy env var nieobecne), ale po `cp .env.example .env` env var **jest** obecne (=False), więc dev.py odczyta False — bez konfliktu.
- **Komentarze tylko nad linią, nie inline** — `django-environ` nie parsuje `KEY=value # komentarz` (traktuje cały suffix jako wartość). Pułapka D z #55.

## Test plan

- [x] `poetry run pre-commit run --files .env.example` → all green (gitleaks **nie** wybrzeszczał na `user:pass@` — rozpoznał placeholder)
- [x] Smoke: `DJANGO_SECRET_KEY=test ... DATABASE_URL=postgres://postgres:postgres@localhost:5432/tibiantis poetry run python manage.py check` → `System check identified no issues (0 silenced)`
- [ ] CI `lint` + `test` zielone

## Out of scope (świadomie)

- Mongo/Redis/Celery/Discord/Scrape vars z CLAUDE.md §10 — kod jeszcze ich nie konsumuje. Dodawanie pustych placeholderów dla nieużywanych integracji = noise; lepszy pattern: dodawać razem z PR-em wprowadzającym integrację (M3 Celery → REDIS_URL/CELERY_BROKER_URL, M4 logging → MONGO_URL itd.).
