### PR TITLE
chore(pre-commit): add celery + django-celery-beat to mypy additional_dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,8 @@ repos:
           - scrapy
           - crochet
           - twisted
+          - celery
+          - django-celery-beat
 
   # Django 6.0 — automatyczna modernizacja składni
   - repo: https://github.com/adamchainz/django-upgrade


### PR DESCRIPTION
Pre-commit mypy hook biega w isolated env — wymaga jawnego deklarowania paczek importowanych w apps/. Bez tego: `ModuleNotFoundError: No module named 'celery'` przy `pre-commit run mypy` (precedens: M1 PR #24 z
  scrapy/crochet/twisted).

  Potrzebne dla:
  - M3-D14 (#59) — `apps/characters/tasks.py` importuje `from celery import shared_task`
  - M3-D16 (#61) — data migration importuje `django_celery_beat.models.IntervalSchedule`/`PeriodicTask`

  Per CLAUDE.md §12 — zmiany w pre-commit config idą osobnym PR-em, nie miksowane z kodem funkcjonalnym.