### PR TITLE
chore(mypy): override untyped-decorator + missing celery stubs for apps/*/tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,14 @@ ignore_errors = true
 module = "apps.accounts.admin"
 ignore_errors = true
 
+[[tool.mypy.overrides]]
+module = "apps.*.tasks"
+disallow_untyped_decorators = false
+
+[[tool.mypy.overrides]]
+module = ["celery", "celery.*"]
+ignore_missing_imports = true
+
 [tool.django-stubs]
 django_settings_module = "config.settings.stubs"
 


### PR DESCRIPTION
## Summary

Add two per-module mypy overrides in `pyproject.toml` to silence Celery decorator typing limitations consistently across both pre-commit isolated env and direct `poetry run mypy`.

## Why

Celery 5.6 declares inline types but `@shared_task` / `@app.task` decorator signatures aren't fully typed (community known limitation, no mature `celery-stubs` exists). Under mypy `strict = true` this surfaces as one of two errors depending on env:

- **Pre-commit isolated env (`mypy 1.13.0` + `django-stubs[compatible-mypy]` + `celery` from #66):** `error: Untyped decorator makes function "ping" untyped [misc]`
- **Direct `poetry run mypy`:** `error: Untyped decorator makes function "ping" untyped [untyped-decorator]` + `[import-untyped]` for missing `celery` py.typed marker.

Inline `# type: ignore[misc]` works in pre-commit but fails in direct env (different error code). Inline `# type: ignore[untyped-decorator]` fails the other way. Per-module override fixes both at once.

## Changes

```toml
[[tool.mypy.overrides]]
module = "apps.*.tasks"
disallow_untyped_decorators = false

[[tool.mypy.overrides]]
module = ["celery", "celery.*"]
ignore_missing_imports = true
```

**Granularity:** `disallow_untyped_decorators = false` is scoped only to `apps/*/tasks.py` — rest of `apps/` stays under full mypy strict. `ignore_missing_imports` for `celery.*` follows the existing precedent for `environ` (line 68-70).

## Impact

Needed for:
- **M3-D14 (#59)** — `apps/characters/tasks.py` with `@shared_task`-decorated `ping()` (currently blocked on this)
- **M3-D16 (#61)** — `scrape_watched_characters` task with `@shared_task(bind=True)`
- **M4** — bedmage tracker tasks (analogous decorator usage)

After merge, D14 branch needs:
1. Rebase from master to pick up overrides
2. Remove `# type: ignore[misc]` from `apps/characters/tasks.py` (would trigger `[unused-ignore]` after override takes effect)

## Test plan

- [x] `poetry run pre-commit run mypy --all-files` → `Passed`
- [x] Pre-commit hooks green (commit succeeded)
- [x] CI lint + test green

## References

- CLAUDE.md §12 (pre-commit / pyproject.toml change conventions)
- M2 retro precedent: `apps.accounts.admin` mypy override added with feature PR #33 (line 72-74 of `pyproject.toml`)
- M1 retro #8: similar pre-commit infra split landed as separate PR #24 (scrapy/crochet/twisted in `additional_dependencies`)