### PR TITLE
test(characters): add tests for ping Celery smoke task (M3-D14 follow-up)

### DIFF
--- a/tests/unit/characters/test_tasks.py
+++ b/tests/unit/characters/test_tasks.py
@@ -1,0 +1,25 @@
+"""Tests for apps.characters.tasks (Celery smoke tasks)."""
+
+from __future__ import annotations
+
+from pytest_django.fixtures import SettingsWrapper
+
+from apps.characters.tasks import ping
+
+
+def test_ping_returns_pong_when_called_directly() -> None:
+    """Direct sync call — sanity that ping is a plain callable returning 'pong'."""
+    assert ping() == "pong"
+
+
+def test_ping_returns_pong_via_eager_delay(settings: SettingsWrapper) -> None:
+    """Eager mode exercises the full Celery task lifecycle (publish → execute → result)
+    in-process, without a live broker or worker. CELERY_TASK_EAGER_PROPAGATES=True
+    surfaces task exceptions as raw Python exceptions instead of Celery Failure objects.
+    """
+    settings.CELERY_TASK_ALWAYS_EAGER = True
+    settings.CELERY_TASK_EAGER_PROPAGATES = True
+
+    result = ping.delay()
+
+    assert result.get(timeout=5) == "pong"


### PR DESCRIPTION
## Summary

Follow-up testowy dla M3-D14 (#59, PR #68 zmergowany). Per workflow: testy idą **osobnym PR-em** po approve implementation.

Dwa unit testy dla `apps.characters.tasks.ping`:

- **`test_ping_returns_pong_when_called_directly`** — sanity że `ping` to plain callable zwracający `"pong"`. Pokrywa to że `@shared_task` decorator nie psuje function as regular Python callable.

- **`test_ping_returns_pong_via_eager_delay`** — pełen Celery task lifecycle (`.delay()` → execute → `AsyncResult.get()`) w eager mode. `CELERY_TASK_ALWAYS_EAGER=True` wykonuje task synchronicznie w-process (bez brokera/workera). `CELERY_TASK_EAGER_PROPAGATES=True` ujawnia wyjątki jako raw Python exceptions zamiast wrappować w `Celery Failure` objects.

## Decisions

- **Per-test settings override** przez pytest-django `settings` fixture, bez globalnego `conftest.py`. Powód: tylko jeden task w D14, eager mode na poziomie globalnym mógłby maskować bugi w innych testach (np. integration tests które chciałyby real broker behavior). M3-D16 (`scrape_watched_characters`) re-use'uje ten sam pattern dla unit testów.
- **Brak `@pytest.mark.django_db`** — `ping` nie dotyka DB, transaction wrapper niepotrzebny.

## Test plan

- [x] `poetry run pytest tests/unit/characters/test_tasks.py -v` → `2 passed in 0.11s`
- [x] Pre-commit lokalnie zielony
- [ ] CI lint + test green
- [ ] Coverage threshold (70%) zachowane (oba testy podnoszą `apps/characters/tasks.py` z 0% do 100%)

## Notes

W M3-D14 retro #59 dodałem `Three-place sync checklist` — ten PR jest niezależny od tego (testy nie touchują `pyproject.toml`/pre-commit/ci.yml), więc bez chore satellite.

Closes nothing — Issue #59 już zamknięty automatycznie po PR #68 mergu.