### PR TITLE
test(characters): celery e2e + scrape_watched_characters unit coverage (M3-D17, #62)

### DIFF
--- a/tests/integration/test_celery_e2e.py
+++ b/tests/integration/test_celery_e2e.py
@@ -1,0 +1,68 @@
+"""E2E integration test for M3 — `scrape_watched_characters` full flow.
+
+Spec M3 §5/D17: pełny flow `Character.objects.all()` → freshness filter →
+subprocess (mock) → counters → return summary, w eager mode (sync,
+in-process, bez live brokera ani live spidera).
+
+Trade-off: nie sprawdzamy serializacji broker→worker — to wymaga real-broker
+testów (post-M3). Tu chodzi o **logikę tasku**, nie o transport Celery.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+from django.utils import timezone
+
+from apps.characters.models import Character
+from apps.characters.tasks import scrape_watched_characters
+
+
+@pytest.mark.django_db(transaction=True)
+@mock.patch("apps.characters.tasks.subprocess.run")
+def test_scrape_watched_characters_full_flow_mixed_freshness(
+    mock_run: mock.MagicMock,
+) -> None:
+    """Pełny flow z dwiema postaciami o różnym stanie freshness.
+
+    Seed:
+      - "Yhral" (stale, 2h ago) → powinna zostać scrape'owana (subprocess wywołany)
+      - "Tester" (fresh, 5 min ago, < 30 min threshold) → skipped (subprocess pominięty)
+
+    Asercje:
+      - `result["scraped"] == 1` — tylko Yhral
+      - `result["skipped"] == 1` — tylko Tester
+      - subprocess wywołany dokładnie raz, z argumentami dla Yhral (sanity:
+        gdyby ktoś przeniósł `subprocess.run` do innego modułu, mock-path by
+        cicho ucichł i live spider waliłby w tibiantis — `assert_called_once_with`
+        wymusza pozytywną walidację, nie tylko negatywną)
+      - `Tester.last_scraped_at` niezmienione (skipped → no save → auto_now nie
+        odpala)
+    """
+    yhral = Character.objects.create(name="Yhral", level=120)
+    tester = Character.objects.create(name="Tester", level=50)
+
+    stale_ts = timezone.now() - timedelta(hours=2)
+    fresh_ts = timezone.now() - timedelta(minutes=5)
+    Character.objects.filter(pk=yhral.pk).update(last_scraped_at=stale_ts)
+    Character.objects.filter(pk=tester.pk).update(last_scraped_at=fresh_ts)
+
+    tester_last_scraped_before = Character.objects.get(pk=tester.pk).last_scraped_at
+
+    mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+
+    result = scrape_watched_characters.apply().get()
+
+    assert result == {"scraped": 1, "failed": 0, "skipped": 1}
+    mock_run.assert_called_once_with(
+        [sys.executable, "manage.py", "scrape_character", "Yhral"],
+        timeout=60,
+        check=False,
+    )
+
+    tester_last_scraped_after = Character.objects.get(pk=tester.pk).last_scraped_at
+    assert tester_last_scraped_after == tester_last_scraped_before

--- a/tests/unit/characters/test_tasks.py
+++ b/tests/unit/characters/test_tasks.py
@@ -1,10 +1,17 @@
-"""Tests for apps.characters.tasks (Celery smoke tasks)."""
+"""Tests for apps.characters.tasks (Celery smoke + scrape_watched_characters)."""
 
 from __future__ import annotations
 
+import subprocess
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+from django.utils import timezone
 from pytest_django.fixtures import SettingsWrapper
 
-from apps.characters.tasks import ping
+from apps.characters.models import Character
+from apps.characters.tasks import ping, scrape_watched_characters
 
 
 def test_ping_returns_pong_when_called_directly() -> None:
@@ -23,3 +30,72 @@ def test_ping_returns_pong_via_eager_delay(settings: SettingsWrapper) -> None:
     result = ping.delay()
 
     assert result.get(timeout=5) == "pong"
+
+
+def _make_stale_character(
+    name: str, *, level: int = 100, hours_ago: int = 2
+) -> Character:
+    """Create a Character with `last_scraped_at` forced into the past.
+
+    `Character.last_scraped_at` is `auto_now=True`, which overrides any value
+    passed to `create()` at save-time. Workaround per issue #62 Pułapka B:
+    `update()` skips model save() and bypasses auto_now.
+    """
+    char = Character.objects.create(name=name, level=level)
+    Character.objects.filter(pk=char.pk).update(
+        last_scraped_at=timezone.now() - timedelta(hours=hours_ago)
+    )
+    char.refresh_from_db()
+    return char
+
+
+@pytest.mark.django_db
+@mock.patch("apps.characters.tasks.subprocess.run")
+def test_scrape_watched_characters_handles_subprocess_failure(
+    mock_run: mock.MagicMock,
+) -> None:
+    """returncode != 0 → bumps `failed`, never `scraped`. Task swallows
+    per-character failures so Beat keeps firing on schedule (see task docstring).
+    """
+    _make_stale_character("Yhral")
+    mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1)
+
+    result = scrape_watched_characters.apply().get()
+
+    assert result == {"scraped": 0, "failed": 1, "skipped": 0}
+    mock_run.assert_called_once()
+
+
+@pytest.mark.django_db
+@mock.patch("apps.characters.tasks.subprocess.run")
+def test_scrape_watched_characters_respects_freshness_threshold(
+    mock_run: mock.MagicMock,
+) -> None:
+    """All characters within freshness window → all skipped, subprocess never
+    invoked. `assert_not_called` guards against a regression where the freshness
+    branch incorrectly falls through to the scrape (see retro #61 critical bug 2:
+    counter swap was caught only because smoke surfaced the wrong number).
+    """
+    Character.objects.create(name="FreshOne", level=50)
+    Character.objects.create(name="FreshTwo", level=80)
+
+    result = scrape_watched_characters.apply().get()
+
+    assert result == {"scraped": 0, "failed": 0, "skipped": 2}
+    mock_run.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch("apps.characters.tasks.subprocess.run")
+def test_scrape_watched_characters_handles_empty_watchlist(
+    mock_run: mock.MagicMock,
+) -> None:
+    """No Characters in DB → no-op summary, subprocess never invoked.
+    Edge case for fresh deployment / first Beat fire before any seed.
+    """
+    assert Character.objects.count() == 0
+
+    result = scrape_watched_characters.apply().get()
+
+    assert result == {"scraped": 0, "failed": 0, "skipped": 0}
+    mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

Zamykam M3-D17 — testy Celery taska `scrape_watched_characters` przed closure milestone'u M3.

- **3 unit testy** w `tests/unit/characters/test_tasks.py`:
  - `test_scrape_watched_characters_handles_subprocess_failure` — `returncode=1` → `failed += 1`, nie `scraped`. Sanity że task pochłania per-character failures (Beat dalej fire-uje).
  - `test_scrape_watched_characters_respects_freshness_threshold` — wszystkie postacie fresh → wszystkie skipped, `mock.assert_not_called()` jako positive guard. Bezpośrednia regresja na critical bug 2 z retro #61 (counter swap fresh→scraped) — gdyby ktoś znów przepisał `skipped += 1` na `scraped += 1`, ten test wybuchnie.
  - `test_scrape_watched_characters_handles_empty_watchlist` — pusta DB → `{0,0,0}`, subprocess nie ruszony.

- **1 integration e2e** w `tests/integration/test_celery_e2e.py`:
  - Seed dwóch Character z mixed freshness (Yhral 2h ago + Tester 5 min ago).
  - Mock `apps.characters.tasks.subprocess.run` → `returncode=0`.
  - Asercje: `{"scraped": 1, "failed": 0, "skipped": 1}` + `mock.assert_called_once_with(...)` z explicit argumentami subprocess (positive guard na refactor mock-path — gdyby `subprocess.run` przeniosło się do innego modułu, patch by cicho ucichł i live spider waliłby w tibiantis).
  - Verify że `Tester.last_scraped_at` nie zmienione (skipped → no save → auto_now nie odpala).

### Pułapki zaadresowane (per issue #62)

- **Pułapka B (auto_now=True na last_scraped_at):** helper `_make_stale_character` w unit testach + inline `Character.objects.filter(pk=...).update(last_scraped_at=tz_dt)` w integration. Update omija save() i auto_now.
- **Pułapka A (TZ-aware datetime):** `from django.utils import timezone` + `timezone.now()`, nie `datetime.now()`.

## Test plan

- [x] `poetry run pytest tests/unit/characters/test_tasks.py tests/integration/test_celery_e2e.py -v` → **6/6 passed (1.49s)** lokalnie
- [x] `poetry run pytest --cov=apps` → **59 passed, 1 xfailed, coverage 88%** (próg 70% spełniony, `apps/characters/tasks.py` 100%)
- [x] `poetry run pre-commit run --all-files` → wszystkie hooki zielone (ruff, ruff-format, mypy, django-upgrade, poetry-check, poetry-lock, gitleaks)
- [ ] **Smoke manualny (do zrobienia przed mergem):**
  - `docker compose -f docker-compose.dev.yml up -d` (postgres + redis)
  - 3 terminale: `runserver`, `celery -A config worker -P solo -l info`, `celery -A config beat -l info`
  - Ustaw `PeriodicTask.interval = IntervalSchedule(every=1, period=MINUTES)` w admin (na czas smoke — przywróć po teście)
  - Po 2 minutach `Character.last_scraped_at` w admin powinien się aktualizować

## Po merge

Osobny PR `docs/close-m3-tracker` od świeżego master (lekcja M1 retro #8) z:
- Sekcją `## 🎉 Milestone M3 — Celery infrastructure COMPLETED`
- Retro per Issue D13-D17 + lekcje na M4+
- DoD M3 ze spec'a §8 wszystkie [x]
- `gh issue close 62` i milestone close na GitHub jako ostatni krok

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)
