### PR TITLE
docs(m5): add Bedmage tracker design spec + implementation plan + issue bodies

### DIFF
--- a/.github/issue-bodies/m5-d23.md
+++ b/.github/issue-bodies/m5-d23.md
@@ -1,0 +1,155 @@
+**Milestone:** M5 — Bedmage tracker (backend)
+**Czas:** 2-3h
+**Branch:** `feat/<this-issue-#>-bedmages-app-model`
+**Type:** `feat`
+**Zależy od:** M4 closed + chore PR #92 (stubs.py single source of truth) merged
+**Spec:** [`docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md`](../blob/master/docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md) §5/D23
+**Plan:** [`docs/superpowers/plans/2026-05-08-m5-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-08-m5-implementation-plan.md) Task #1
+
+---
+
+## 🎯 Cel
+
+Aplikacja `apps/bedmages/` zarejestrowana w Django, model `BedmageWatch` w bazie, widoczny w admin pod `/admin/bedmages/bedmagewatch/`. Migracja initial przechodzi czysto na świeżej bazie. Mirror M4-D18 struktury (apps.py + models.py + admin.py + migration), ale z FK do User i Character zamiast samodzielnego rekordu.
+
+## 🧠 Czego się nauczysz
+
+- **`settings.AUTH_USER_MODEL` jako string FK target** zamiast direct `from apps.accounts.models import User`. Django convention dla custom User model — bez tego runtime crashes gdy AUTH_USER_MODEL byłby kiedyś swapped, plus eliminuje circular import (M2-D9 lekcja).
+- **`UniqueConstraint(name=...)` w `Meta.constraints`** zamiast deprecated `unique_together` tuple — Django 4+ idiom. M4-D18 precedens dla DeathEvent (`unique_death_event_per_character_time`).
+- **`related_name="bedmage_watches"`** na FK — daje reverse access `user.bedmage_watches.all()` i `character.bedmage_watches.all()`. Bez tego default `bedmagewatch_set` jest mniej czytelny w D24 services.
+- **`on_delete=CASCADE` semantics dla obu FK** — gdy User lub Character zostanie usunięty, BedmageWatch idzie razem (decyzje §4.7). Inne opcje (PROTECT, SET_NULL) nie pasują dla M5 use case.
+- **`BigAutoField` na nowych modelach** — Django 6.0 wymóg, bo INTEGER (4 bytes) byłby wąskim gardłem dla kolejnych modeli (M2-D9 retro #28 lekcja).
+
+## ✅ Acceptance criteria
+
+### Aplikacja Django
+
+- [ ] `apps/bedmages/__init__.py` (pusty plik).
+- [ ] `apps/bedmages/apps.py`:
+  ```python
+  from django.apps import AppConfig
+
+
+  class BedmagesConfig(AppConfig):
+      default_auto_field = "django.db.models.BigAutoField"
+      name = "apps.bedmages"
+      label = "bedmages"
+  ```
+- [ ] `config/settings/base.py` — `LOCAL_APPS` rozszerzone o `"apps.bedmages"`. Stubs.py automatycznie widzi przez chore PR #92.
+
+### Model
+
+- [ ] `apps/bedmages/models.py`:
+  ```python
+  from django.conf import settings
+  from django.db import models
+
+
+  class BedmageWatch(models.Model):
+      user = models.ForeignKey(
+          settings.AUTH_USER_MODEL,
+          on_delete=models.CASCADE,
+          related_name="bedmage_watches",
+      )
+      character = models.ForeignKey(
+          "characters.Character",
+          on_delete=models.CASCADE,
+          related_name="bedmage_watches",
+      )
+      created_at = models.DateTimeField(auto_now_add=True)
+      last_notified_login = models.DateTimeField(null=True, blank=True)
+      active = models.BooleanField(default=True)
+
+      class Meta:
+          ordering = ["-created_at"]
+          constraints = [
+              models.UniqueConstraint(
+                  fields=["user", "character"],
+                  name="unique_bedmage_watch_per_user_character",
+              ),
+          ]
+
+      def __str__(self) -> str:
+          return f"{self.user.username} watching {self.character.name}"
+  ```
+
+### Migration
+
+- [ ] `python manage.py makemigrations bedmages` — wygeneruj `0001_initial.py`.
+- [ ] Sprawdź że migration ma:
+  - `dependencies = [("characters", "0001_initial"), ("accounts", "0001_initial"), ...]` (auto-generated, weryfikuj).
+  - `CreateModel` operation z 5 polami + `ConstraintsAddField` lub `AddConstraint` operation dla UniqueConstraint.
+- [ ] `python manage.py migrate bedmages --plan` pokazuje `bedmages.0001_initial` jako pending.
+- [ ] `python manage.py migrate` bez błędu.
+
+### Admin
+
+- [ ] `apps/bedmages/admin.py`:
+  ```python
+  from django.contrib import admin
+
+  from apps.bedmages.models import BedmageWatch
+
+
+  @admin.register(BedmageWatch)
+  class BedmageWatchAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
+      list_display = ("user", "character", "active", "last_notified_login", "created_at")
+      list_filter = ("active",)
+      search_fields = ("user__username", "character__name")
+      ordering = ("-created_at",)
+  ```
+
+### Smoke manual
+
+- [ ] `python manage.py shell -c "from apps.bedmages.models import BedmageWatch; from apps.accounts.models import User; from apps.characters.models import Character; u = User.objects.first(); c = Character.objects.first(); w = BedmageWatch.objects.create(user=u, character=c); print(w)"` → `username watching character_name`.
+- [ ] Otwórz `/admin/bedmages/bedmagewatch/` w przeglądarce — widoczna lista, search działa, filter `active` pokazuje 2 opcje.
+- [ ] Sanity: `BedmageWatch.objects.create(user=u, character=c)` po raz **drugi** → `IntegrityError` (UniqueConstraint enforcement).
+
+## 📋 Sugerowane kroki
+
+1. `git checkout master && git pull && git checkout -b feat/<#>-bedmages-app-model`.
+2. Utwórz strukturę katalogów: `mkdir apps/bedmages apps/bedmages/migrations`, `touch apps/bedmages/__init__.py apps/bedmages/migrations/__init__.py`.
+3. Napisz `apps.py` (mirror M4-D18 `apps/deaths/apps.py`).
+4. Dodaj `"apps.bedmages"` do `LOCAL_APPS` w `config/settings/base.py`.
+5. Napisz `models.py` (per AC).
+6. `python manage.py makemigrations bedmages` — sprawdź wygenerowany plik.
+7. Napisz `admin.py`.
+8. `python manage.py migrate` + smoke (3 punkty).
+9. Pre-commit + commit + push + PR.
+
+## ⚠️ Pułapki do uwagi
+
+- **A — `settings.AUTH_USER_MODEL` jako string, nie import:** `models.ForeignKey(settings.AUTH_USER_MODEL, ...)` (NIE `from apps.accounts.models import User`). Direct import powoduje circular gdy accounts kiedyś zaimportuje bedmages.
+- **B — FK `to="characters.Character"` jako lazy string:** mirror M4-D18 used direct import bo wtedy Character był w innym dependency graph. W M5 stosuj string form — bezpieczniej dla potencjalnych circular cases (D26 modyfikuje characters/tasks.py które importuje bedmages.services).
+- **C — `# type: ignore[type-arg]` na admin** — mirror `apps/characters/admin.py:6` i `apps/deaths/admin.py:6`. Carry-over M2 tech debt: `ModelAdmin[BedmageWatch]` generic subscript wymaga `django_stubs_ext.monkeypatch()` w `base.py`, jeszcze nie wdrożone.
+- **D — `auto_now_add=True` na `created_at`** w przyszłych testach (D24+) — gdy chcesz force timestamp w przeszłość, `BedmageWatch.objects.filter(pk=...).update(created_at=...)` (M3-D17 retro #5). Save'owanie modelu z passed `created_at` value jest ignorowane.
+- **E — `related_name="bedmage_watches"` collision check** — sprawdź że ani User ani Character nie ma już atrybutu o tej nazwie. Sprawdzono 2026-05-08, fresh.
+- **F — Migration deterministic check:** po `makemigrations bedmages` zweryfikuj że migration **nie** generuje "ghost" migrations w innych apps (np. `accounts/0004_alter_user_...`). Jeśli generuje — schema drift z poprzednich M, nie blokuj się tym, ale flaguj jako tech debt.
+
+## 🧪 Testing plan
+
+Unit testy w D23 są **opcjonalne** (model minimalny, kluczowe testy logiki w D24). Jeśli decydujesz się dopisać:
+
+- `tests/unit/bedmages/__init__.py` (pusty).
+- `tests/unit/bedmages/test_bedmage_watch_model.py`:
+  - `test_create_with_required_fields_works` — happy path + verify `active=True` default + `last_notified_login=None` default.
+  - `test_unique_constraint_user_character_pair_raises_integrity_error` — stwórz raz, drugi raz `pytest.raises(IntegrityError)`.
+  - `test_str_repr_format` — assert `str(watch) == f"{user.username} watching {character.name}"`.
+
+(M4-D18 nie miało testów modelu — równie dobrze możesz odpuścić w D23 i pokryć w D24.)
+
+## 🔗 Dokumentacja pomocnicza
+
+- Django `UniqueConstraint`: https://docs.djangoproject.com/en/6.0/ref/models/constraints/#uniqueconstraint
+- `settings.AUTH_USER_MODEL`: https://docs.djangoproject.com/en/6.0/topics/auth/customizing/#referencing-the-user-model
+- `related_name`: https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.ForeignKey.related_name
+- `on_delete=CASCADE`: https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.CASCADE
+- M4-D18 issue body (precedens): `.github/issue-bodies/m4-d18.md`
+
+## 📦 Definition of Done
+
+- [ ] AC spełnione (apps/bedmages/, model, admin, migration, smoke manual).
+- [ ] PR zmergowany squash (`feat(bedmages): add BedmageWatch model + admin + initial migration (M5-D23, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] `apps/bedmages/migrations/0001_initial.py` w master.
+- [ ] Issue zamknięty.

--- a/.github/issue-bodies/m5-d24.md
+++ b/.github/issue-bodies/m5-d24.md
@@ -1,0 +1,235 @@
+**Milestone:** M5 — Bedmage tracker (backend)
+**Czas:** 3h
+**Branch:** `feat/<this-issue-#>-bedmage-services`
+**Type:** `feat`
+**Zależy od:** D23 merged
+**Spec:** [`docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md`](../blob/master/docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md) §5/D24
+**Plan:** [`docs/superpowers/plans/2026-05-08-m5-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-08-m5-implementation-plan.md) Task #2
+
+---
+
+## 🎯 Cel
+
+Service layer dla bedmage tracking — `add_bedmage_watch`, `remove_bedmage_watch`, `check_bedmage_watches_for_character`. `BedmagePayload` types w osobnym pliku (mirror M1 #6 pattern). Settings `BEDMAGE_REGEN_MINUTES` (default 100) widoczne w `base.py` + `.env.example`. **Notification handler dispatch jest STUBEM** w D24 — D25 zamieni stub na real `get_bedmage_handler().notify(watch)`.
+
+## 🧠 Czego się nauczysz
+
+- **`Character.objects.get_or_create(name=...)`** dla auto-create lazy fetch — race-safe w Django ORM (Postgres `SELECT FOR UPDATE` semantics). M1-D8 retry pattern niepotrzebny tutaj.
+- **`timezone.now() - timedelta(minutes=N)`** dla delta comparison. UTC normalizacja przez `USE_TZ = True` w base.py — naive datetime byłby bug.
+- **Idempotency invariant `last_notified_login != character.last_login`** — kluczowy dla M5 tracker logic (CLAUDE.md §7). Pierwsze logowanie (last_notified=None, char.last=Y) → fires. Drugi scrape (te same Y) → `Y != Y` is False → skip. Trzeci scrape po fresh login (Y2) → `Y != Y2` → fires again. **Wzór do internalizacji** — to jest core M5 logic.
+- **`select_related("user", "character")`** żeby uniknąć N+1 query w `check_bedmage_watches_for_character` iteracji. Dla 100 active watches bez select_related = 201 queries, z select_related = 1.
+- **`BedmagePayload` TypedDict pattern** mirror `CharacterPayload` (apps/characters/types.py) z M1 #6 — types osobno od services dla testowalności + reusability.
+- **`transaction.atomic()` wokół create + raise** (M4-D20 lekcja, Pułapka B) — gdy IntegrityError (race przez równoczesne `add_bedmage_watch`), atomic = savepoint, IntegrityError aborts tylko savepoint, outer transaction zostaje czysta.
+
+## ✅ Acceptance criteria
+
+### Settings + env
+
+- [ ] `config/settings/base.py` rozszerzone o:
+  ```python
+  BEDMAGE_REGEN_MINUTES = env.int("BEDMAGE_REGEN_MINUTES", default=100)
+  ```
+  W sekcji już istniejących bedmage/celery settings, np. po `DEATH_LEVEL_THRESHOLD`.
+- [ ] `.env.example` rozszerzone o `BEDMAGE_REGEN_MINUTES=100`.
+- [ ] Sanity: `manage.py shell -c "from django.conf import settings; print(settings.BEDMAGE_REGEN_MINUTES)"` → `100`.
+
+### Types
+
+- [ ] `apps/bedmages/types.py`:
+  ```python
+  from datetime import datetime
+  from typing import TypedDict
+
+
+  class BedmagePayload(TypedDict, total=False):
+      """Payload shape for add_bedmage_watch service input.
+
+      Mirror of `apps/characters/types.py::CharacterPayload` pattern (M1 #6) —
+      types separated from services for reusability and testability.
+      """
+      user_id: int
+      character_name: str
+      created_at: datetime
+      last_notified_login: datetime | None
+      active: bool
+  ```
+
+  *(Adjust `total=False` decyzja — w M5 konsumenci typu są flexibili. Jeśli prefer strict, użyj `total=True` + Optional na nullable fields.)*
+
+### Service `add_bedmage_watch`
+
+- [ ] `apps/bedmages/services.py`:
+  ```python
+  import logging
+
+  from django.contrib.auth import get_user_model
+  from django.db import transaction
+  from django.utils import timezone
+  from datetime import timedelta
+
+  from apps.bedmages.models import BedmageWatch
+  from apps.characters.models import Character
+
+  logger = logging.getLogger(__name__)
+  User = get_user_model()
+
+
+  def add_bedmage_watch(user, character_name: str) -> BedmageWatch:
+      """Create BedmageWatch for user+character. Auto-create Character if missing.
+
+      Raises ValueError if active watch already exists for this user+character pair.
+      Reactivates inactive watch if found instead of creating duplicate.
+
+      §4.1 design decision: lazy fetch — first scrape will populate Character.last_login
+      via the next Beat fire of scrape_watched_characters.
+      """
+      character, _ = Character.objects.get_or_create(name=character_name)
+
+      with transaction.atomic():
+          watch, created = BedmageWatch.objects.get_or_create(
+              user=user,
+              character=character,
+              defaults={"active": True},
+          )
+
+      if not created and watch.active:
+          raise ValueError(
+              f"BedmageWatch for {character_name!r} already exists for user "
+              f"{user.username!r}"
+          )
+      if not created and not watch.active:
+          watch.active = True
+          watch.last_notified_login = None  # reset cycle on reactivation
+          watch.save()
+
+      return watch
+  ```
+
+### Service `remove_bedmage_watch`
+
+- [ ] ```python
+  def remove_bedmage_watch(user, character_name: str) -> bool:
+      """Hard-delete BedmageWatch for user+character. Idempotent (returns False
+      when no match found, doesn't raise).
+
+      §4.2 design decision: hard delete (not soft via active=False) — M5 doesn't
+      need watch history; unique_together resets cycle cleanly on re-add.
+      """
+      deleted_count, _ = BedmageWatch.objects.filter(
+          user=user,
+          character__name=character_name,
+      ).delete()
+      return deleted_count > 0
+  ```
+
+### Service `check_bedmage_watches_for_character` (stub for D25 handler integration)
+
+- [ ] ```python
+  def check_bedmage_watches_for_character(character: Character) -> int:
+      """Iterate active BedmageWatch'es for character; fire handler when delta >= threshold
+      AND notification not yet sent for this login.
+
+      §4.4 design decision: invoked post-success in scrape_watched_characters task (D26).
+      §4.5 design decision: scope = all watches for character (no further filtering).
+
+      Returns count of watches that triggered notification (for logging/metrics).
+
+      D24 NOTE: handler dispatch is currently a placeholder logger.info() — D25 replaces
+      with `get_bedmage_handler().notify(watch)` from apps.notifications.
+      """
+      from django.conf import settings
+
+      if character.last_login is None:
+          return 0
+
+      threshold = settings.BEDMAGE_REGEN_MINUTES
+      cutoff = timezone.now() - timedelta(minutes=threshold)
+
+      if character.last_login > cutoff:
+          return 0  # not yet 100 min since login
+
+      fired = 0
+      watches = BedmageWatch.objects.filter(
+          character=character, active=True
+      ).select_related("user", "character")
+
+      for watch in watches:
+          if watch.last_notified_login == character.last_login:
+              continue  # already notified for this login
+
+          # D25 will replace this stub with: get_bedmage_handler().notify(watch)
+          logger.info(
+              "BEDMAGE [STUB]: user=%s character=%s last_login=%s",
+              watch.user.username, character.name, character.last_login,
+          )
+          watch.last_notified_login = character.last_login
+          watch.save(update_fields=["last_notified_login"])
+          fired += 1
+
+      return fired
+  ```
+
+### Unit testy
+
+- [ ] `tests/unit/bedmages/__init__.py` (jeśli D23 nie utworzyło).
+- [ ] `tests/unit/bedmages/test_services.py` — 8-9 testów:
+  - `test_add_bedmage_watch_creates_character_if_missing` — Character nie istnieje przed call'em, po call'u istnieje + watch istnieje.
+  - `test_add_bedmage_watch_uses_existing_character_if_present` — Character istnieje, count nie rośnie.
+  - `test_add_bedmage_watch_raises_on_duplicate_active` — drugi `add` z tymi samymi user+character → ValueError.
+  - `test_add_bedmage_watch_reactivates_inactive` — set `active=False`, call add, assert `active=True` + `last_notified_login=None` (reset cycle).
+  - `test_remove_bedmage_watch_deletes_existing_returns_true`.
+  - `test_remove_bedmage_watch_idempotent_returns_false_when_not_found`.
+  - `test_check_returns_zero_when_character_has_no_last_login`.
+  - `test_check_returns_zero_when_delta_below_threshold` — `last_login = now - 50min`, threshold 100, expect skip.
+  - `test_check_fires_when_delta_above_threshold_and_not_yet_notified` — `last_login = now - 120min`, expect 1 fired + watch.last_notified_login set.
+  - `test_check_skips_when_already_notified_for_this_login` — manually set `last_notified_login = character.last_login`, expect 0 fired.
+  - `test_check_filters_only_active_watches` — 2 watches dla character, jeden `active=False`, expect 1 fired.
+
+### Smoke manual
+
+- [ ] `manage.py shell -c "..."` — call `add_bedmage_watch(user, 'TestChar')`, verify w DB.
+- [ ] Force `Character.objects.filter(name='TestChar').update(last_login=timezone.now() - timedelta(minutes=120))` — bypass auto_now.
+- [ ] Call `check_bedmage_watches_for_character(character)` — sprawdź log entry "BEDMAGE [STUB]:" + DB `BedmageWatch.last_notified_login` ustawione.
+- [ ] Drugi call → 0 fired (idempotency).
+
+## ⚠️ Pułapki do uwagi
+
+- **A — `Character.last_login` może być `None`** (świeża postać, jeszcze nie scrape'owana lub last login nieznany). `check_bedmage_watches_for_character` MUSI early-return `if character.last_login is None`. Bez tego `timedelta` comparison rzuca `TypeError`.
+- **B — `last_notified_login` set BEFORE vs AFTER handler dispatch** — w D24 stubie set'ujemy AFTER (logger.info success → save). W D25, jeśli `handler.notify()` rzuci exception, NIE chcemy set `last_notified_login` (retry on next scrape). Decyzja: `try: handler.notify(); watch.last_notified_login = ...; watch.save(); except Exception: logger.exception(...)`. W D24 jeszcze nie ma try/except — D25 dorzuci.
+- **C — `add_bedmage_watch` re-activation logic** — gdy `active=False` (po D25 + handler crash scenario), set `active=True` + reset `last_notified_login=None` żeby cycle startował od nowa. Bez resetu, gdy character od dawna ma stary `last_login`, ponowna aktywacja nie fired'uje notyfikacji (idempotency myli).
+- **D — `select_related` w `check_bedmage_watches_for_character`** — bez `select_related("user", "character")`, każdy `watch.user.username` w log call wyzwala SELECT. Dla 100 watches → 201 queries. Z select_related → 1.
+- **E — `timezone.now()` zamiast `datetime.now()`** — Django USE_TZ=True wymaga timezone-aware. `datetime.now()` daje naive — comparison z `character.last_login` (timezone-aware) rzuca `TypeError`.
+- **F — `transaction.atomic()` wokół `get_or_create` + raise** — bez atomic, IntegrityError przez race między `get_or_create` lookup a INSERT może zepsuć outer transaction (w testach z `@pytest.mark.django_db`). M4-D20 Pułapka B precedens.
+- **G — `User = get_user_model()`** zamiast `from apps.accounts.models import User`. Django convention, robust against AUTH_USER_MODEL swap. Mirror M2-D9 lekcja.
+- **H — `auto_now_add` na `created_at` w testach** — `BedmageWatch.objects.filter(pk=...).update(created_at=...)` workaround (M3-D17 retro #5). Save'owanie z passed value jest ignorowane.
+
+## 🧪 Testing plan
+
+8-9 unit testów per AC — service'y są core M5 logic, coverage 100% wymagane.
+
+**Coverage cel:** `apps/bedmages/services.py` 100%, `apps/bedmages/types.py` 100% (TypedDict ma 0 statements).
+
+**Claude weryfikuje po PR:**
+- Idempotency invariant `last_notified_login == character.last_login` faktycznie chroni przed double-fire.
+- `Character.last_login is None` early-return present.
+- `transaction.atomic()` wokół `get_or_create` w `add_bedmage_watch`.
+- `select_related` w `check` query.
+- `BedmagePayload` w osobnym `types.py`, nie inline w `services.py`.
+- Re-activation case w `add_bedmage_watch` resetuje `last_notified_login`.
+
+## 🔗 Dokumentacja pomocnicza
+
+- `Character.objects.get_or_create`: https://docs.djangoproject.com/en/6.0/ref/models/querysets/#get-or-create
+- `transaction.atomic`: https://docs.djangoproject.com/en/6.0/topics/db/transactions/#django.db.transaction.atomic
+- `select_related`: https://docs.djangoproject.com/en/6.0/ref/models/querysets/#select-related
+- `get_user_model`: https://docs.djangoproject.com/en/6.0/topics/auth/customizing/#django.contrib.auth.get_user_model
+- M4-D20 service precedens: `apps/deaths/services.py`
+- M1-D6 service precedens: `apps/characters/services.py`
+
+## 📦 Definition of Done
+
+- [ ] AC spełnione (Settings, Types, 3 services, 8-9 unit testów, Smoke).
+- [ ] PR zmergowany squash (`feat(bedmages): services + types + BEDMAGE_REGEN_MINUTES (M5-D24, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] `apps/bedmages/services.py` 100% coverage.
+- [ ] Issue zamknięty.

--- a/.github/issue-bodies/m5-d25.md
+++ b/.github/issue-bodies/m5-d25.md
@@ -1,0 +1,199 @@
+**Milestone:** M5 — Bedmage tracker (backend)
+**Czas:** 2h
+**Branch:** `feat/<this-issue-#>-bedmage-notifications-handler`
+**Type:** `feat`
+**Zależy od:** D24 merged
+**Spec:** [`docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md`](../blob/master/docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md) §4.3, §5/D25
+**Plan:** [`docs/superpowers/plans/2026-05-08-m5-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-08-m5-implementation-plan.md) Task #3
+
+---
+
+## 🎯 Cel
+
+Notifications abstraction layer w nowej apce `apps/notifications/` — Protocol-based interface + `LoggingHandler` default implementation + settings switch dla future M6 `DiscordHandler` swap. Replace D24 stub `logger.info("BEDMAGE [STUB]:")` w `check_bedmage_watches_for_character` na real `get_bedmage_handler().notify(watch)` dispatch. Plus defensive try/except wokół notify w D24 service (decyzja przekładana z D24 Pułapki B).
+
+## 🧠 Czego się nauczysz
+
+- **Python `Protocol` vs `ABC`** — Protocol jest **structural typing** ("if it has notify(), it's a handler"), ABC wymaga explicit `class DiscordHandler(BedmageNotificationHandler)`. Protocol bardziej Pythonic dla M6 swap, ABC bardziej defensywny dla shared base logic. M5 wybiera Protocol — żaden shared logic nie istnieje, M6 DiscordHandler będzie standalone.
+- **`django.utils.module_loading.import_string`** — Django convention dla pluggable backends. Mirror `CACHES['default']['BACKEND']`, `EMAIL_BACKEND`, `MIDDLEWARE`. Settings wartość = dotted path string, runtime resolution.
+- **Lazy handler resolution vs cached** — `get_bedmage_handler()` może być cached przez `functools.lru_cache(maxsize=1)`. Trade-off: cache = szybciej (jedna `import_string` allokacja), ale `@override_settings(BEDMAGE_NOTIFICATION_HANDLER=...)` w testach NIE podmieni handler'a (cache'ed before override). **M5 wybór: bez cache** (per-call resolution) — prosta i test-friendly.
+- **Forward reference w Protocol** — `def notify(self, watch: "BedmageWatch") -> None: ...` używa string forward reference + `if TYPE_CHECKING:` block. Eliminuje circular `apps.notifications → apps.bedmages.models → apps.notifications.handlers`.
+- **`update_fields` w `watch.save(update_fields=["last_notified_login"])`** — optimization, save tylko jednego pola zamiast całego rekordu. M3-D17 nie używał, M5 ma sens (watch ma 5 pól, oszczędność marginal w prod ale dobry pattern).
+
+## ✅ Acceptance criteria
+
+### Aplikacja `apps/notifications/`
+
+- [ ] `apps/notifications/__init__.py` z `get_bedmage_handler()`:
+  ```python
+  from django.conf import settings
+  from django.utils.module_loading import import_string
+
+  from apps.notifications.handlers import BedmageNotificationHandler
+
+
+  def get_bedmage_handler() -> BedmageNotificationHandler:
+      """Resolve BedmageNotificationHandler from settings.BEDMAGE_NOTIFICATION_HANDLER.
+
+      Per-call resolution (NOT cached) — @override_settings in tests must work.
+      Resolution cost is one import_string call (~microseconds), negligible at
+      Beat-fire interval (1h scrape cycle).
+      """
+      handler_class = import_string(settings.BEDMAGE_NOTIFICATION_HANDLER)
+      return handler_class()
+  ```
+- [ ] `apps/notifications/apps.py`:
+  ```python
+  from django.apps import AppConfig
+
+
+  class NotificationsConfig(AppConfig):
+      default_auto_field = "django.db.models.BigAutoField"
+      name = "apps.notifications"
+      label = "notifications"
+  ```
+- [ ] `apps/notifications/handlers.py`:
+  ```python
+  from __future__ import annotations
+
+  import logging
+  from typing import TYPE_CHECKING, Protocol
+
+  if TYPE_CHECKING:
+      from apps.bedmages.models import BedmageWatch
+
+  logger = logging.getLogger(__name__)
+
+
+  class BedmageNotificationHandler(Protocol):
+      """Protocol for handling bedmage notifications.
+
+      M5 default: LoggingHandler (this module). M6 will add DiscordHandler.
+      Implementations swap via settings.BEDMAGE_NOTIFICATION_HANDLER (dotted path).
+      """
+
+      def notify(self, watch: BedmageWatch) -> None: ...
+
+
+  class LoggingHandler:
+      """Default M5 handler — emits log entry per notification.
+
+      M6 DiscordHandler will replace this for prod via settings switch.
+      """
+
+      def notify(self, watch: BedmageWatch) -> None:
+          logger.info(
+              "BEDMAGE: user=%s character=%s last_login=%s",
+              watch.user.username,
+              watch.character.name,
+              watch.character.last_login,
+          )
+  ```
+
+### Settings + env
+
+- [ ] `config/settings/base.py` rozszerzone o:
+  ```python
+  BEDMAGE_NOTIFICATION_HANDLER = env(
+      "BEDMAGE_NOTIFICATION_HANDLER",
+      default="apps.notifications.handlers.LoggingHandler",
+  )
+  ```
+  Po `BEDMAGE_REGEN_MINUTES` z D24.
+- [ ] `.env.example` rozszerzone o `BEDMAGE_NOTIFICATION_HANDLER=apps.notifications.handlers.LoggingHandler`.
+- [ ] `LOCAL_APPS` w `base.py` rozszerzone o `"apps.notifications"`.
+- [ ] Sanity: `manage.py shell -c "from apps.notifications import get_bedmage_handler; h = get_bedmage_handler(); print(type(h).__name__)"` → `LoggingHandler`.
+
+### D24 service modyfikacja
+
+- [ ] `apps/bedmages/services.py:check_bedmage_watches_for_character` — replace stub logger.info na real handler dispatch + defensive try/except:
+  ```python
+  from apps.notifications import get_bedmage_handler
+
+  def check_bedmage_watches_for_character(character: Character) -> int:
+      # ... (early returns z D24)
+
+      handler = get_bedmage_handler()
+      fired = 0
+      watches = BedmageWatch.objects.filter(
+          character=character, active=True
+      ).select_related("user", "character")
+
+      for watch in watches:
+          if watch.last_notified_login == character.last_login:
+              continue
+
+          try:
+              handler.notify(watch)
+          except Exception:
+              logger.exception(
+                  "Notification handler failed for watch user=%s character=%s",
+                  watch.user.username, character.name,
+              )
+              continue  # don't set last_notified_login on failure — retry next scrape
+
+          watch.last_notified_login = character.last_login
+          watch.save(update_fields=["last_notified_login"])
+          fired += 1
+
+      return fired
+  ```
+
+### Unit testy
+
+- [ ] `tests/unit/notifications/__init__.py`.
+- [ ] `tests/unit/notifications/test_handler_resolution.py`:
+  - `test_get_bedmage_handler_returns_logging_handler_by_default` — sanity że LoggingHandler jest default class.
+  - `test_get_bedmage_handler_resolves_custom_class_via_settings` — `@override_settings(BEDMAGE_NOTIFICATION_HANDLER="path.to.MockHandler")` + assert.
+  - `test_logging_handler_emits_expected_log_line` — caplog'em capture, assert format `"BEDMAGE: user=X character=Y last_login=Z"`.
+
+- [ ] `tests/unit/bedmages/test_services.py` extend o:
+  - `test_check_invokes_handler_when_delta_exceeds_threshold` — mock `get_bedmage_handler` zwraca MagicMock, assert `.notify(watch)` called.
+  - `test_check_does_not_set_last_notified_login_when_handler_raises` — handler.notify side_effect=Exception, assert `watch.last_notified_login` stays None + log.exception emitted.
+
+### Smoke manual
+
+- [ ] `manage.py shell` z aktywnym BedmageWatch (z D24 smoke):
+  - `from apps.notifications import get_bedmage_handler; get_bedmage_handler().notify(watch)` → log entry "BEDMAGE: user=... character=... last_login=...".
+- [ ] `@override_settings` simulation:
+  - `with override_settings(BEDMAGE_NOTIFICATION_HANDLER="apps.notifications.handlers.LoggingHandler"): print(type(get_bedmage_handler()).__name__)` → LoggingHandler.
+
+## ⚠️ Pułapki do uwagi
+
+- **A — Protocol w runtime check** — `isinstance(obj, BedmageNotificationHandler)` wymaga `@runtime_checkable` decorator na Protocol class. M5 nie potrzebuje runtime check (tylko type hints), więc decorator zbędny. Jeśli kiedyś chcesz `isinstance` — dorzuć `@runtime_checkable`.
+- **B — `lru_cache` na `get_bedmage_handler`** — kuszące optimization, ALE `@override_settings` w testach nie podmieni cache'ed handler'a. Pierwszy call cache'uje, drugi (z `@override_settings`) zwraca stare. Per-call resolution kosztuje microseconds, prawdopodobnie nie warto cache. Decyzja M5: bez cache.
+- **C — Circular import `apps.notifications → apps.bedmages → apps.notifications`** — D25 service'u w bedmages importuje `get_bedmage_handler` z notifications. Notifications handlers importują BedmageWatch jako TYPE_CHECKING (forward ref). **Ten plan eliminuje circular bo type-only import nie jest wykonywany w runtime.** Sanity: `python -c "import apps.notifications; import apps.bedmages.services"` → no errors.
+- **D — `try/except Exception` jest **broad** — Pythonic style preferowałby `except (RequestException, OSError)` dla M6 DiscordHandler (specific failure modes). M5 LoggingHandler nie rzuca normalnie, więc broad except akceptowalne. M6 doprecyzuje przy DiscordHandler implementation.
+- **E — `update_fields=["last_notified_login"]`** — Django ORM optimization, save tylko tego pola. **Pułapka:** jeśli `BedmageWatch` model ma `auto_now=True` na innym polu (jak `updated_at`), `update_fields` GO POMIJA — `auto_now` nie odpala. M5 model nie ma `updated_at`, więc nie problem. M-future jeśli dorzucamy `updated_at`: rozważyć.
+- **F — Dotted path w settings** — `"apps.notifications.handlers.LoggingHandler"` (NIE `"apps.notifications.LoggingHandler"`). Class musi być pod pełną path. Sanity przez `import_string` (rzuca jasny `ImportError` przy złej path).
+- **G — `BEDMAGE_NOTIFICATION_HANDLER` env var w CI** — `default=` znaczy CI nie wymaga env (Pułapka B z M4-D21). CI pytest używa default'owego LoggingHandler — testy mogą polegać na tym.
+
+## 🧪 Testing plan
+
+3 testy resolution + 2 testy service integration = 5 testów.
+
+**Coverage cel:** `apps/notifications/__init__.py` 100%, `apps/notifications/handlers.py` 100%, plus extension w `apps/bedmages/services.py` (handler dispatch path) 100%.
+
+**Claude weryfikuje po PR:**
+- Per-call resolution (NIE cached) — sprawdź że `@override_settings` test przechodzi.
+- Defensive try/except wokół `handler.notify` w services.
+- `last_notified_login` NIE set'ed gdy handler rzuca exception.
+- `update_fields=["last_notified_login"]` w `watch.save()` (optimization).
+- Forward reference Protocol bez circular import.
+
+## 🔗 Dokumentacja pomocnicza
+
+- Python Protocol: https://docs.python.org/3/library/typing.html#typing.Protocol
+- `import_string`: https://docs.djangoproject.com/en/6.0/ref/utils/#django.utils.module_loading.import_string
+- `@override_settings`: https://docs.djangoproject.com/en/6.0/topics/testing/tools/#django.test.override_settings
+- `update_fields`: https://docs.djangoproject.com/en/6.0/ref/models/instances/#specifying-which-fields-to-save
+- M4-D21 settings precedens: `apps/deaths/tasks.py` (DEATH_LEVEL_THRESHOLD pattern)
+
+## 📦 Definition of Done
+
+- [ ] AC spełnione (apps/notifications/, settings, D24 integration, 5 testów, smoke).
+- [ ] PR zmergowany squash (`feat(notifications): handler abstraction + LoggingHandler + settings switch (M5-D25, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] `apps/notifications/*.py` 100% coverage.
+- [ ] D24 service `check_bedmage_watches_for_character` używa real handler dispatch (stub usunięty).
+- [ ] Issue zamknięty.

--- a/.github/issue-bodies/m5-d26.md
+++ b/.github/issue-bodies/m5-d26.md
@@ -1,0 +1,183 @@
+**Milestone:** M5 — Bedmage tracker (backend)
+**Czas:** 2-3h
+**Branch:** `feat/<this-issue-#>-tracker-scrape-integration`
+**Type:** `feat`
+**Zależy od:** D25 merged
+**Spec:** [`docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md`](../blob/master/docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md) §4.4, §5/D26
+**Plan:** [`docs/superpowers/plans/2026-05-08-m5-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-08-m5-implementation-plan.md) Task #4
+
+---
+
+## 🎯 Cel
+
+Integracja tracker'a M5 z istniejącym `scrape_watched_characters` task'iem (M3-D16). Po każdym `result.returncode == 0` w pętli scrape'owania, fire `check_bedmage_watches_for_character(character)`. Defensive isolation — tracker exception NIE wpływa na scrape success metrics.
+
+## 🧠 Czego się nauczysz
+
+- **Lazy import w funkcji** zamiast top-of-module — pattern dla unikania circular imports w Django app graph. M3-D16 task już używał lazy import dla `scrape_character` (Twisted reactor isolation), kontynuacja patternu dla `apps.bedmages.services`.
+- **Defensive isolation z `try/except`** + `logger.exception(...)` — tracker bug nie powinien obciążać scrape success metrics. `logger.exception` automatycznie dorzuca traceback (Python logging idiom).
+- **`Character.objects.get(name=name)` po scrape success** — postać ZAWSZE istnieje (pętla iteruje po `Character.objects.values_list`), ale defensive `try/except DoesNotExist` na wypadek deletion race między iteracją a get'em.
+- **Mock patches dla lazy imports** — `mock.patch("apps.bedmages.services.check_bedmage_watches_for_character")` patchuje namespace przed lazy import. Wewnątrz `scrape_watched_characters`, lazy import czyta świeżą referencję z patched namespace — działa poprawnie.
+
+## ✅ Acceptance criteria
+
+### Modyfikacja `apps/characters/tasks.py:scrape_watched_characters`
+
+- [ ] Po `if result.returncode == 0: scraped += 1`, dorzucić tracker fire:
+  ```python
+  if result.returncode == 0:
+      scraped += 1
+      try:
+          character = Character.objects.get(name=name)
+          from apps.bedmages.services import (  # lazy: avoid circular at module load
+              check_bedmage_watches_for_character,
+          )
+          check_bedmage_watches_for_character(character)
+      except Character.DoesNotExist:
+          # Race: character deleted between values_list iteration and get()
+          logger.warning("Character %s vanished mid-scrape, skipping bedmage check", name)
+      except Exception:
+          # Tracker bug shouldn't bump `failed` count — scrape itself succeeded.
+          logger.exception("bedmage check failed for character %s", name)
+  ```
+- [ ] Sprawdź że `else` branch (scrape failure) **NIE wywołuje** tracker'a — failed scrape oznacza że `last_login` może być stale, tracker decision na stale data byłby bug.
+
+### Test extending `tests/integration/test_celery_e2e.py`
+
+- [ ] Dorzucić test `test_scrape_watched_characters_invokes_bedmage_check_on_success`:
+  ```python
+  @pytest.mark.django_db
+  @mock.patch("apps.bedmages.services.check_bedmage_watches_for_character")
+  @mock.patch("apps.characters.tasks.subprocess.run")
+  def test_scrape_watched_characters_invokes_bedmage_check_on_success(
+      mock_run: mock.MagicMock,
+      mock_check: mock.MagicMock,
+  ) -> None:
+      """Tracker called per scraped character (returncode=0). Failed scrapes
+      do NOT trigger tracker (stale last_login would cause bad decisions).
+      """
+      stale_char = _make_stale_character("Yhral")  # helper z M3-D17
+
+      mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+
+      result = scrape_watched_characters.apply().get()
+
+      assert result["scraped"] == 1
+      mock_check.assert_called_once()
+      called_with = mock_check.call_args[0][0]
+      assert called_with.name == "Yhral"
+  ```
+
+- [ ] Dorzucić test `test_scrape_watched_characters_does_not_invoke_tracker_on_failure`:
+  ```python
+  @pytest.mark.django_db
+  @mock.patch("apps.bedmages.services.check_bedmage_watches_for_character")
+  @mock.patch("apps.characters.tasks.subprocess.run")
+  def test_scrape_watched_characters_does_not_invoke_tracker_on_failure(
+      mock_run: mock.MagicMock,
+      mock_check: mock.MagicMock,
+  ) -> None:
+      """Failed scrape (returncode != 0) skips tracker — last_login potentially stale."""
+      _make_stale_character("Yhral")
+      mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1)
+
+      scrape_watched_characters.apply().get()
+
+      mock_check.assert_not_called()
+  ```
+
+- [ ] Dorzucić test `test_scrape_watched_characters_logs_but_continues_on_tracker_exception`:
+  ```python
+  @pytest.mark.django_db
+  @mock.patch("apps.bedmages.services.check_bedmage_watches_for_character")
+  @mock.patch("apps.characters.tasks.subprocess.run")
+  def test_scrape_watched_characters_logs_but_continues_on_tracker_exception(
+      mock_run: mock.MagicMock,
+      mock_check: mock.MagicMock,
+      caplog: pytest.LogCaptureFixture,
+  ) -> None:
+      """Tracker exception is caught and logged — scrape success metrics intact."""
+      _make_stale_character("Yhral")
+      mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+      mock_check.side_effect = RuntimeError("tracker boom")
+
+      with caplog.at_level(logging.ERROR, logger="apps.characters.tasks"):
+          result = scrape_watched_characters.apply().get()
+
+      assert result == {"scraped": 1, "failed": 0, "skipped": 0}
+      assert any("bedmage check failed" in r.message for r in caplog.records)
+  ```
+
+### Smoke manual
+
+- [ ] Setup w shell:
+  ```python
+  from apps.bedmages.services import add_bedmage_watch
+  from apps.accounts.models import User
+  from apps.characters.models import Character
+  from django.utils import timezone
+  from datetime import timedelta
+
+  user = User.objects.first()
+  add_bedmage_watch(user, "Yhral")  # creates Character if missing
+  Character.objects.filter(name="Yhral").update(
+      last_login=timezone.now() - timedelta(minutes=120)
+  )
+  ```
+- [ ] Force `scrape_watched_characters.apply().get()` (z `-P solo` worker albo `apply()` synchronous w shell):
+  ```python
+  from apps.characters.tasks import scrape_watched_characters
+  result = scrape_watched_characters.apply().get()
+  print(result)  # {"scraped": 1, "failed": 0, "skipped": 0} (lub większe)
+  ```
+- [ ] Sprawdź log entry **"BEDMAGE: user=... character=Yhral last_login=..."** w worker logu.
+- [ ] Drugi run:
+  ```python
+  scrape_watched_characters.apply().get()
+  ```
+- [ ] Sprawdź **brak** "BEDMAGE: ..." log w drugim run'ie (idempotency: `last_notified_login == character.last_login` przy drugim sprawdzeniu).
+
+## ⚠️ Pułapki do uwagi
+
+- **A — Lazy import w pętli vs przed pętlą** — pierwszy import jest wolny (~50ms cold), kolejne cached przez `sys.modules`. Dla 50 characters wolisz import RAZ przed pętlą (ale wewnątrz funkcji), ale dla circular safety musi być wewnątrz funkcji. Sugerowane: import wewnątrz `try` block (eager przy pierwszym fire, cached na resztę pętli przez sys.modules).
+- **B — `mock.patch` lazy importów** — `mock.patch("apps.bedmages.services.check_bedmage_watches_for_character")` patchuje namespace SYS.MODULES dla `apps.bedmages.services`. Lazy import wewnątrz `scrape_watched_characters` czyta `from apps.bedmages.services import check_...`, dostaje patched MagicMock. Działa.
+- **C — Circular import test** — sanity przed unit test'ami: `python -c "import apps.characters.tasks; import apps.bedmages.services"` (oba kierunki) — żaden nie powinien rzucić ImportError. Jeśli rzuca, lazy import w D26 nie jest faktycznie lazy (top-level import gdzieś).
+- **D — `Character.DoesNotExist` race** — defensive `try/except` chroni przed deletion race między `values_list` iteracją (linia ~40) a `Character.objects.get(name=name)` (po success). W praktyce mało prawdopodobne (admin musiałby usunąć character w trakcie task'u), ale logger.warning i continue jest tani.
+- **E — `else` branch tracker call** — spec'owy invariant: tracker fired TYLKO przy `result.returncode == 0`. Failed scrape = stale `last_login` = decyzje na stale data byłyby bug ("postać 'wstała' z bedmage" gdy w rzeczywistości scrape failował). Test `test_scrape_watched_characters_does_not_invoke_tracker_on_failure` sprawdza ten invariant.
+- **F — Defensive `try/except Exception`** wokół tracker call — broad catch jest świadome. Tracker jest "best effort" w M5 — bug w `check_bedmage_watches_for_character` (np. None pointer, DB connection) NIE powinien obciążać `scraped` counter. M3 retro #61 lekcja "single failure mode": bug w D26 widoczny w logach, nie w wynikach scrape'a.
+- **G — `caplog.at_level(logging.ERROR, logger="apps.characters.tasks")`** — `logger.exception` emituje na poziom ERROR + traceback. Filter w teście musi patrzeć na `apps.characters.tasks` logger (gdzie scrape_watched_characters mieszka), nie `apps.bedmages` (gdzie services mieszkają).
+
+## 🧪 Testing plan
+
+3 nowe unit testy w `tests/integration/test_celery_e2e.py` (extension):
+- Tracker called on scrape success.
+- Tracker NOT called on scrape failure.
+- Tracker exception logged but scrape metrics intact.
+
+**Coverage cel:** `apps/characters/tasks.py` line coverage włączające nową gałąź — ścieżka try/except + lazy import + tracker call.
+
+**Smoke manual** (3 punkty AC) — kluczowe dla weryfikacji full chain z D24+D25 logic.
+
+**Claude weryfikuje po PR:**
+- Lazy import wewnątrz `try` block (nie top-level).
+- `Character.DoesNotExist` defensive catch.
+- Tracker call TYLKO w `if result.returncode == 0` branch.
+- `logger.exception` (z traceback), NIE `logger.error`.
+- Test `_does_not_invoke_tracker_on_failure` jest tam (regression guard dla §4.5 invariant).
+
+## 🔗 Dokumentacja pomocnicza
+
+- Python lazy imports: https://docs.python.org/3/library/sys.html#sys.modules (caching mechanism)
+- `mock.patch` namespace targeting: https://docs.python.org/3/library/unittest.mock.html#where-to-patch
+- `logger.exception`: https://docs.python.org/3/library/logging.html#logging.Logger.exception
+- M3-D16 task precedens: `apps/characters/tasks.py:scrape_watched_characters`
+- M3-D17 e2e test precedens: `tests/integration/test_celery_e2e.py`
+
+## 📦 Definition of Done
+
+- [ ] AC spełnione (modyfikacja task, 3 nowe testy w celery_e2e, smoke manual 3 punkty).
+- [ ] PR zmergowany squash (`feat(bedmages): integrate tracker in scrape_watched_characters task (M5-D26, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] `tests/integration/test_celery_e2e.py` extension covers tracker integration.
+- [ ] Smoke manual potwierdza end-to-end chain z D24+D25.
+- [ ] Issue zamknięty.

--- a/.github/issue-bodies/m5-d27.md
+++ b/.github/issue-bodies/m5-d27.md
@@ -1,0 +1,295 @@
+**Milestone:** M5 — Bedmage tracker (backend)
+**Czas:** 4h
+**Branch:** `feat/<this-issue-#>-bedmages-graphql` + osobny `docs/close-m5-tracker`
+**Type:** `feat` (kod) + `docs` (PROGRESS.md)
+**Zależy od:** D26 merged
+**Spec:** [`docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md`](../blob/master/docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md) §5/D27, §8 DoD
+**Plan:** [`docs/superpowers/plans/2026-05-08-m5-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-08-m5-implementation-plan.md) Task #5
+
+---
+
+## 🎯 Cel
+
+GraphQL surface dla bedmage management — query `myBedmages` (lista user'a, JWT-protected) + 2 mutations (`addBedmageWatch`, `removeBedmageWatch`, JWT-protected). E2E integration test pokrywa pełny flow task → spider → service → handler. **`Mutation` type wprowadzony pierwszy raz w projekcie** — `config/schema.py` rozszerza się o `merge_types("Mutation", ...)` + `mutation=Mutation` parameter w `strawberry.Schema`. M5 zamyka się PROGRESS.md retro per Issue + milestone closed via `gh api`.
+
+## 🧠 Czego się nauczysz
+
+- **Strawberry mutation pattern** — `@strawberry.mutation` decorator (lub `@strawberry.field` w `Mutation` class). Mutations w Strawberry to też zwykłe async resolvers — kontekst dispatch identyczny jak query. Auth pattern z M4-D22 reused.
+- **`merge_types("Mutation", (...))` first time** — analogicznie do `merge_types("Query", ...)` z M2/M4. `config/schema.py` rozszerza się o:
+  ```python
+  schema = strawberry.Schema(query=Query, mutation=Mutation)
+  ```
+  Bez `mutation=` parameter, mutations NIE są dostępne w GraphQL endpoint.
+- **Nested type resolution** — `BedmageWatchType.character` zwraca `CharacterType` z `apps.characters.schema`. Strawberry-Django auto-resolves przez FK relacje, ale **async ORM** wymaga uwagi (sync access do FK rzuca `SynchronousOnlyOperation`).
+- **`closes #<N>` semantics w GitHub** — feature PR `Closes #82` zamknie issue automatycznie przy merge. Closure PR ma osobny issue (lub po prostu tytuł). Workflow z M4-D22 (PR #90 + #91).
+- **Milestone close via `gh api`** — `gh api -X PATCH repos/:owner/:repo/milestones/<#> -f state=closed` (REST API direct). Nie przez `gh milestone close` (nie istnieje w gh CLI).
+
+## ✅ Acceptance criteria
+
+### Schema — `apps/bedmages/schema.py`
+
+- [ ] Plik `apps/bedmages/schema.py`:
+  ```python
+  from typing import cast
+
+  import strawberry
+  import strawberry_django
+  from strawberry import auto
+
+  from apps.bedmages.models import BedmageWatch
+  from apps.bedmages.services import (
+      add_bedmage_watch,
+      remove_bedmage_watch,
+  )
+  from apps.characters.schema import CharacterType
+
+
+  @strawberry_django.type(BedmageWatch)
+  class BedmageWatchType:
+      id: auto
+      created_at: auto
+      last_notified_login: auto
+      active: auto
+      character: CharacterType
+
+
+  @strawberry.type
+  class Query:
+      @strawberry.field
+      async def my_bedmages(self, info: strawberry.Info) -> list[BedmageWatchType]:
+          request = info.context.request
+          if not request.user.is_authenticated:
+              raise PermissionError("Authentication required")
+
+          qs = (
+              BedmageWatch.objects
+              .filter(user=request.user)
+              .select_related("character")
+              .order_by("-created_at")
+          )
+          return cast("list[BedmageWatchType]", [w async for w in qs])
+
+
+  @strawberry.type
+  class Mutation:
+      @strawberry.mutation
+      async def add_bedmage_watch(
+          self, info: strawberry.Info, character_name: str
+      ) -> BedmageWatchType:
+          request = info.context.request
+          if not request.user.is_authenticated:
+              raise PermissionError("Authentication required")
+
+          from asgiref.sync import sync_to_async
+          watch = await sync_to_async(add_bedmage_watch)(
+              request.user, character_name
+          )
+          return cast("BedmageWatchType", watch)
+
+      @strawberry.mutation
+      async def remove_bedmage_watch(
+          self, info: strawberry.Info, character_name: str
+      ) -> bool:
+          request = info.context.request
+          if not request.user.is_authenticated:
+              raise PermissionError("Authentication required")
+
+          from asgiref.sync import sync_to_async
+          deleted = await sync_to_async(remove_bedmage_watch)(
+              request.user, character_name
+          )
+          return deleted
+  ```
+
+### Schema merge — `config/schema.py`
+
+- [ ] `config/schema.py` rozszerzone:
+  ```python
+  import strawberry
+  from strawberry.tools import merge_types
+
+  from apps.accounts.schema import Query as AccountsQuery
+  from apps.bedmages.schema import Mutation as BedmagesMutation, Query as BedmagesQuery
+  from apps.characters.schema import Query as CharactersQuery
+  from apps.deaths.schema import Query as DeathsQuery
+
+  Query = merge_types("Query", (AccountsQuery, CharactersQuery, DeathsQuery, BedmagesQuery))
+  Mutation = merge_types("Mutation", (BedmagesMutation,))
+  schema = strawberry.Schema(query=Query, mutation=Mutation)
+  ```
+- [ ] Sanity: `manage.py shell -c "from config.schema import schema; print(schema.as_str())"` pokazuje `type Mutation { ... }` + `addBedmageWatch(...)` + `removeBedmageWatch(...)` w SDL.
+
+### Unit testy GraphQL
+
+- [ ] `tests/unit/bedmages/test_graphql_bedmages.py` — 8 testów (mirror `tests/unit/deaths/test_graphql_recent_deaths.py` patternu):
+  - `test_my_bedmages_filters_by_request_user` — User A ma 2 watche, User B ma 1, query jako User A → 2 elementy.
+  - `test_my_bedmages_requires_authentication` — bez JWT → `errors[0].message` zawiera "Authentication".
+  - `test_my_bedmages_returns_empty_list_for_user_without_watches` — 0 watches → empty list (NIE null, NIE error).
+  - `test_add_bedmage_watch_creates_with_existing_character` — Character istnieje, mutation zwraca BedmageWatchType.
+  - `test_add_bedmage_watch_creates_character_lazily` — Character NIE istnieje, mutation creates oba.
+  - `test_add_bedmage_watch_raises_on_duplicate_active_watch` — drugie call → errors.
+  - `test_add_bedmage_watch_requires_authentication` — bez JWT → errors.
+  - `test_remove_bedmage_watch_returns_true_when_existing` — happy delete.
+  - `test_remove_bedmage_watch_returns_false_when_not_found` — idempotent.
+  - `test_remove_bedmage_watch_requires_authentication` — bez JWT → errors.
+
+### E2E integration test
+
+- [ ] `tests/integration/test_m5_bedmages_e2e.py`:
+  ```python
+  """E2E integration test for M5 — full flow add → scrape → handler fires.
+
+  Spec M5 §5/D27: addBedmageWatch via service → mock subprocess that updates
+  Character.last_login → invoke check_bedmage_watches_for_character → verify
+  handler called once with correct watch.
+  """
+
+  from datetime import timedelta
+  from unittest import mock
+
+  import pytest
+  from django.test import override_settings
+  from django.utils import timezone
+
+  from apps.accounts.models import User
+  from apps.bedmages.models import BedmageWatch
+  from apps.bedmages.services import (
+      add_bedmage_watch,
+      check_bedmage_watches_for_character,
+  )
+  from apps.characters.models import Character
+
+
+  @pytest.mark.django_db(transaction=True)
+  @override_settings(BEDMAGE_REGEN_MINUTES=100)
+  @mock.patch("apps.notifications.handlers.LoggingHandler.notify")
+  def test_e2e_add_bedmage_watch_then_check_fires_handler(
+      mock_notify: mock.MagicMock,
+  ) -> None:
+      """Full M5 chain: addBedmageWatch → set last_login >100min ago → check fires
+      → handler.notify called once → second check is no-op (idempotency).
+      """
+      user = User.objects.create_user(
+          username="tester", email="t@example.com", password="ComplexPass!123"
+      )
+
+      watch = add_bedmage_watch(user, "Yhral")
+      assert watch.character.name == "Yhral"
+      assert watch.active
+
+      Character.objects.filter(name="Yhral").update(
+          last_login=timezone.now() - timedelta(minutes=120)
+      )
+      character = Character.objects.get(name="Yhral")
+
+      fired = check_bedmage_watches_for_character(character)
+      assert fired == 1
+      assert mock_notify.call_count == 1
+      assert mock_notify.call_args[0][0].character.name == "Yhral"
+
+      watch.refresh_from_db()
+      assert watch.last_notified_login == character.last_login
+
+      mock_notify.reset_mock()
+      fired = check_bedmage_watches_for_character(character)
+      assert fired == 0
+      assert mock_notify.call_count == 0
+  ```
+
+### Smoke manual via GraphiQL playground
+
+- [ ] `runserver` running.
+- [ ] Login via REST `POST /api/auth/login/` → JWT.
+- [ ] Otwórz `http://localhost:8000/graphql/` w przeglądarce, HTTP Headers:
+  ```json
+  { "Authorization": "Bearer <JWT>" }
+  ```
+- [ ] Mutation:
+  ```graphql
+  mutation {
+    addBedmageWatch(characterName: "Yhral") {
+      id
+      character { name level }
+      active
+    }
+  }
+  ```
+  → response z `BedmageWatchType` + nested `CharacterType`.
+- [ ] Query:
+  ```graphql
+  { myBedmages { id character { name } active createdAt } }
+  ```
+  → list z 1 element.
+- [ ] Mutation remove:
+  ```graphql
+  mutation { removeBedmageWatch(characterName: "Yhral") }
+  ```
+  → `true`.
+- [ ] Drugi remove → `false` (idempotency).
+- [ ] Query bez JWT → errors[].
+
+### PROGRESS.md closure (osobny PR `docs/close-m5-tracker`)
+
+- [ ] Header sekcji M5: `🚧 IN PROGRESS` → `🎉 Milestone M5 — Bedmage tracker (backend) COMPLETED (YYYY-MM-DD)`.
+- [ ] Lista Ukończone (M5): wszystkie 5 issues z PR linkami + squash hashes.
+- [ ] Notatki retro per Issue (D23-D27).
+- [ ] Definition of Done M5 (ze spec'a §8) — wszystkie [x].
+- [ ] Podsumowanie M5 (data range, dni vs budżet, lekcje).
+- [ ] Tech debt z M5 (carry-over do M6+).
+
+### Milestone close
+
+- [ ] Po merge feature PR'a: `gh api -X PATCH repos/bgozlinski/tibiantis-scraper/milestones/<#> -f state=closed`.
+- [ ] Sanity: `gh issue list --milestone "M5 — ..." --state all` — wszystkie 5 CLOSED.
+
+## ⚠️ Pułapki do uwagi
+
+- **A — Mutation auth pattern** — mirror M4-D22 `recentDeaths`: `info.context.request.user.is_authenticated`. Dla mutation zwracającego non-null type (BedmageWatchType lub Boolean), `raise` semantically jasne (klient widzi `errors[]` + `data: null`).
+- **B — `await sync_to_async(service)(...)` dla service'ów synchronicznych** — Strawberry resolvers są async. Service'y w `apps.bedmages.services` to sync (Django ORM sync). Wrap przez `sync_to_async`. M2-D11 `me` query precedens (linia 29 w `apps/accounts/schema.py`).
+- **C — Nested `character: CharacterType` resolution** — Strawberry-Django auto-resolves FK przez ORM. Ale w **async resolver** może wymagać explicit prefetch. Test `test_my_bedmages_filters_by_request_user` powinien pokryć — jeśli rzuca `SynchronousOnlyOperation`, dorzuć `.select_related("character")` w queryset.
+- **D — `merge_types("Mutation", (BedmagesMutation,))` z 1 source** — `merge_types` wymaga tuple. Jeden element MUSI mieć trailing comma: `(BedmagesMutation,)`. Bez przecinka `(BedmagesMutation)` to redundant parens, nie tuple → TypeError przy starcie.
+- **E — `strawberry.Schema(query=Query, mutation=Mutation)`** — bez `mutation=` parameter, mutations NIE są dostępne w GraphQL endpoint. Easy miss — pierwszy raz w projekcie.
+- **F — `add_bedmage_watch` test z `Character.objects.get_or_create`** — testuj **oba** scenariusze (Character istnieje + Character lazy create) żeby mieć pewność że auto-create §4.1 działa przez GraphQL warstwę.
+- **G — `auto_now_add` na `created_at`** w testach kontrolujących timeline — `BedmageWatch.objects.filter(pk=...).update(created_at=...)` workaround (M3-D17 retro #5).
+- **H — `discord/close-m5-tracker` branch z FRESH master** (M1 retro #8 lekcja, powtórka z M3, M4) — `git checkout master && git pull && git checkout -b docs/close-m5-tracker`. NIE od feature brancha.
+- **I — `gh issue close` jeśli `Closes #<N>` w PR nie zadziałał** — sanity po merge: `gh issue list --milestone "M5 ..." --state open` powinno być puste. Jeśli nie — `gh issue close <#>` ręcznie.
+- **J — Mutation idempotency dla `removeBedmageWatch`** — return `False` (NIE raise), żeby user mógł spamować bez błędów. Spec §4.6.
+
+## 🧪 Testing plan
+
+**Unit testy GraphQL:** 8 testów (3 my_bedmages, 4 add, 3 remove).
+
+**E2E integration test:** 1 test (full chain z mock handler).
+
+**Smoke manual:** AC GraphiQL (5 punktów) — kluczowe dla weryfikacji `Mutation` schema integration end-to-end.
+
+**Coverage cel:** `apps/bedmages/schema.py` 100%. Cumulative `apps/bedmages/*.py` ≥ 95% (DoD M5).
+
+**Claude weryfikuje po PR:**
+- `merge_types("Mutation", ...)` z trailing comma w tuple.
+- `strawberry.Schema(query=..., mutation=...)` z oba parametrami.
+- Auth guard explicit `if not request.user.is_authenticated` w obu mutations + query.
+- `await sync_to_async(service)(...)` wrap dla service'ów sync.
+- Test `test_add_bedmage_watch_creates_character_lazily` — pokrywa §4.1 lazy fetch przez GraphQL.
+- Idempotency: `removeBedmageWatch` zwraca False, NIE raise.
+- E2E test asercjuje BOTH counters (mock_notify call_count 1 vs 0 w drugim run'ie).
+- PROGRESS.md retro ma sekcję per D23-D27 z PR linkami + squash hashes.
+
+## 🔗 Dokumentacja pomocnicza
+
+- Strawberry mutations: https://strawberry.rocks/docs/general/mutations
+- `merge_types`: https://strawberry.rocks/docs/guides/schema-extensions
+- `sync_to_async`: https://docs.djangoproject.com/en/6.0/topics/async/#sync-to-async
+- `gh api` PATCH milestone: https://docs.github.com/en/rest/issues/milestones?apiVersion=2022-11-28#update-a-milestone
+- M4-D22 GraphQL precedens: `apps/deaths/schema.py`, `tests/unit/deaths/test_graphql_recent_deaths.py`
+- M2-D11 sync_to_async precedens: `apps/accounts/schema.py:29`
+
+## 📦 Definition of Done
+
+- [ ] AC spełnione (Schema, Merge, Unit testy 8, E2E test, PROGRESS.md, Smoke manual via GraphiQL).
+- [ ] **Feature PR** zmergowany squash (`feat(bedmages): GraphQL queries + mutations + e2e (M5-D27, #<#>)`).
+- [ ] **Closure PR** zmergowany squash (`docs(progress): close M5 — Bedmage tracker backend COMPLETED + retro D27`).
+- [ ] CI lint + test zielone na obu PR-ach.
+- [ ] `apps/bedmages/*.py` cumulative coverage ≥ 95%.
+- [ ] Issue zamknięty (oba — feature i closure).
+- [ ] Milestone M5 zamknięty na GitHub via `gh api -X PATCH ...`.

--- a/docs/superpowers/plans/2026-05-08-m5-implementation-plan.md
+++ b/docs/superpowers/plans/2026-05-08-m5-implementation-plan.md
@@ -1,0 +1,376 @@
+# M5 — Bedmage tracker (backend) — Implementation plan
+
+**Data:** 2026-05-08
+**Spec:** [`docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md`](../specs/2026-05-08-m5-bedmage-tracker-design.md)
+**Status:** READY (spec accepted, decyzje 4.1-4.7 zaakceptowane przez developera 2026-05-08).
+
+---
+
+## Źródła
+
+- **CLAUDE.md** §1 (cel biznesowy: Bedmage tracker), §3 (struktura `apps/bedmages/`), §5 (model `BedmageWatch` szkic), §7 (Bedmage tracker logic — 100 min delta + idempotency), §9 (GraphQL `myBedmages` query, `addBedmageWatch` + `removeBedmageWatch` mutations), §10 (settings).
+- **Design spec M5** — kluczowy dokument referencyjny. Każdy issue body linkuje do spec'a §X dla konkretnej sekcji.
+- **Precedensy M2/M3/M4:**
+  - M2-D9 `apps/accounts/` — app structure + custom User model + admin (mirror dla D23 BedmageWatch admin).
+  - M2-D11 `apps/accounts/schema.py` — Strawberry schema + `info.context.request.user.is_authenticated` auth pattern (mirror dla D27 GraphQL).
+  - M2-D12 JWT auth dispatch w `/graphql/` — auth pattern reused dla D27 mutations + queries.
+  - M3-D16 `scrape_watched_characters` task — D26 modification point (post-success hook).
+  - M4-D18 `apps/deaths/` model + admin — exact mirror dla D23 (apps.py + models.py + admin.py + migration).
+  - M4-D20 `apps/deaths/services.py` — service pattern (transaction.atomic, IntegrityError handling) — mirror dla D24.
+  - M4-D22 `apps/deaths/schema.py` — `@strawberry_django.type` + auth guard + clamping pattern. D27 dorzuca **mutations** czego M4 nie miało.
+
+---
+
+## Pre-flight checklist (przed startem D23)
+
+- [ ] **`apps/bedmages/` nie istnieje** — sprawdzone 2026-05-08, fresh creation.
+- [ ] **`apps/notifications/` nie istnieje** — sprawdzone 2026-05-08, fresh creation.
+- [ ] **`Character.last_login: DateTimeField(null=True, blank=True, db_index=True)`** — istnieje od M1, indexed. Tracker query'uje przez ten atrybut.
+- [ ] **`User` model ma `discord_id` field** — istnieje od M2-D9 (jeszcze niewykorzystywany, M6 użyje).
+- [ ] **`scrape_watched_characters` post-success hook** — D26 dorzuca `check_bedmage_watches_for_character(char)` wywołanie po `result.returncode == 0`. M3-D16 task obecnie nie ma hook'a, ale punkt insercji jest jasny (linia ~58 w `apps/characters/tasks.py`).
+- [ ] **`AUTH_USER_MODEL = "accounts.User"`** — w `config/settings/base.py:134`. `BedmageWatch.user` FK używa `settings.AUTH_USER_MODEL`, nie hard-coded import (Django convention).
+- [ ] **`Mutation` GraphQL type pierwszy raz w projekcie** — D27 wprowadza, sprawdź `config/schema.py` przed D27 dla integracji `merge_types("Mutation", ...)`.
+- [ ] **Stubs.py single source of truth** (chore PR #92, 2026-05-08) — nowe `LOCAL_APPS` entries dla `apps.bedmages` + `apps.notifications` + nowe settings (`BEDMAGE_REGEN_MINUTES`, `BEDMAGE_NOTIFICATION_HANDLER`) widoczne dla mypy automatycznie. Zero `stubs.py` edycji w M5.
+- [ ] **`celery-types` package** (carry-over z M3 tech debt) — D26 modyfikuje task istniejący, NIE dorzuca `@shared_task`. Najpewniej nie uderzy w M5. Jeśli uderzy → side chore PR.
+- [ ] **`DeathPayload` extract** (carry-over z M4 tech debt) — opcjonalny side cleanup w D24 razem z `BedmagePayload` w `apps/bedmages/types.py`. Decyzja per-task w D24.
+
+---
+
+## Otwarte pytania do developera (rozstrzygnięte 2026-05-08, spec §4)
+
+Wszystkie 7 decyzji designowych ze spec'a §4 zaakceptowane bez modyfikacji:
+
+1. ✅ **§4.1** Auto-create Character w `addBedmageWatch` — TAK (lazy fetch).
+2. ✅ **§4.2** Hard delete dla `removeBedmageWatch` (idempotent), nie soft.
+3. ✅ **§4.3** Notification handler abstraction `apps/notifications/` — TAK, Protocol-based.
+4. ✅ **§4.4** Tracker fire trigger w `scrape_watched_characters` post-success.
+5. ✅ **§4.5** Tracker scope — wszystkie Characters scrape'owane (M3 zachowanie), filter w trackerze.
+6. ✅ **§4.6** GraphQL mutations error handling — `raise` dla add-duplicate, idempotent (return False) dla remove non-existing, `raise` dla auth fail.
+7. ✅ **§4.7** FK `on_delete=CASCADE` dla `user` i `character`.
+
+**Open questions z §9** (do M-future, NIE w M5 scope):
+- Per-watch custom interval (`BedmageWatch.regen_minutes`).
+- Bedmage statistics query.
+- Watchdog "character no longer being scraped" alarm.
+- Rate limit dla mutations.
+- Bedmage notification history model.
+- Discord channel routing dla M6.
+
+---
+
+## Risk + mitigation
+
+| Ryzyko | Prawdopodobieństwo | Impact | Mitigation |
+|---|---|---|---|
+| **Circular import** `apps.bedmages.services ↔ apps.characters.tasks` | Średnie | Worker crash przy starcie | Lazy import w D26: `from apps.bedmages.services import check_bedmage_watches_for_character` **wewnątrz** `scrape_watched_characters`, nie na top of `tasks.py`. |
+| **Strawberry mutation context** różni się od query context | Niskie | Auth dispatch może nie działać w mutation | M2-D12 dispatch jest type-agnostic (operuje na `request`, nie operation type). Ale **świadomy smoke** w D27 mutation z JWT przed unit testami. |
+| **Race: `addBedmageWatch` + `scrape_watched_characters` symultanicznie** | Niskie | Watch utworzony, ale Character w trakcie scrape — `last_login` może być stale | Idempotency przez `last_notified_login` chroni. Tracker wywołany później (Beat next fire) wykrywa fresh `last_login`. |
+| **Handler resolution failure** (`BEDMAGE_NOTIFICATION_HANDLER` invalid path) | Niskie | Tracker rzuca exception per scraped character | D26 ma `try/except Exception` wrapper z `logger.exception` — błąd logowany, scrape success metrics nie dotknięte. |
+| **`auto_now_add=True` na `created_at`** w testach | Średnie | Test'y kontrolujące `created_at` muszą używać `update()` workaround | M3-D17 retro #5 lekcja zachowana — `BedmageWatch.objects.filter(pk=...).update(created_at=...)`. Wzmianka w D24/D27 issue bodies. |
+| **Auto-create Character race** w `addBedmageWatch` | Niskie | Dwa równoczesne `add` dla tego samego user+character może spowodować IntegrityError na `unique_together` | `Character.objects.get_or_create` jest race-safe. `BedmageWatch.objects.get_or_create` także. M1-D8 race retry pattern niepotrzebny tutaj. |
+
+---
+
+## Task overview
+
+| # | ID | Tytuł | Czas | Zależy od | Branch |
+|---|---|---|---|---|---|
+| 1 | M5-D23 | `apps/bedmages/` + `BedmageWatch` model + admin + migration | 2-3h | M4 closed + chore #92 merged | `feat/<#>-bedmages-app-model` |
+| 2 | M5-D24 | Services (add/remove/check) + `BedmagePayload` types | 3h | D23 merged | `feat/<#>-bedmage-services` |
+| 3 | M5-D25 | `apps/notifications/` package + `LoggingHandler` + settings switch | 2h | D24 merged | `feat/<#>-bedmage-notifications-handler` |
+| 4 | M5-D26 | Tracker integration w `scrape_watched_characters` | 2-3h | D25 merged | `feat/<#>-tracker-scrape-integration` |
+| 5 | M5-D27 | GraphQL `myBedmages` query + mutations + e2e + closure | 4h | D26 merged | `feat/<#>-bedmages-graphql` + `docs/close-m5-tracker` |
+
+**Total:** ~13-15h, 5 dni roboczych z bufor'em (mirror M3/M4 budgetu, M3 = 2 dni real, M4 = 3 dni real, M5 też powinno być 2-3 dni real time).
+
+---
+
+## Task #1 — [M5-D23] `apps/bedmages/` + `BedmageWatch` model + admin + migration
+
+### 🎯 Cel
+
+Aplikacja `apps/bedmages/` zarejestrowana w Django, model `BedmageWatch` w bazie, widoczny w admin pod `/admin/bedmages/bedmagewatch/`. Migracja initial przechodzi czysto na świeżej bazie.
+
+### 🧠 Czego się nauczysz
+
+- **`settings.AUTH_USER_MODEL` w FK** zamiast direct `User` import — Django convention dla custom User. Bez tego runtime crashes gdy AUTH_USER_MODEL jest swapped (M2-D9 lekcja).
+- **`UniqueConstraint(name=...)` w `Meta.constraints`** zamiast deprecated `unique_together` tuple — Django 4+ idiom (M4-D18 precedens dla DeathEvent).
+- **`related_name="bedmage_watches"`** na FK — daje reverse access `user.bedmage_watches.all()`. Bez tego default `bedmagewatch_set` jest mniej czytelny.
+- **`on_delete=CASCADE` semantics** — gdy User lub Character zostanie usunięty, BedmageWatch idzie razem. Inne opcje (PROTECT, SET_NULL) nie pasują dla M5 use case (decyzje §4.7).
+
+### ✅ Acceptance criteria
+
+(Pełne AC w issue body — `.github/issue-bodies/m5-d23.md`.)
+
+**Kluczowe punkty:**
+- `apps/bedmages/__init__.py`, `apps.py` (`BedmagesConfig`, label="bedmages"), `models.py`, `admin.py`, `migrations/__init__.py`.
+- `LOCAL_APPS` w `base.py` rozszerzone o `"apps.bedmages"`.
+- `BedmageWatch` model z 5 polami + `Meta.constraints` UniqueConstraint + `Meta.ordering` + `__str__`.
+- Migration `0001_initial.py`.
+- Admin `BedmageWatchAdmin` z `list_display`, `list_filter`, `search_fields`.
+- Sanity: `migrate bedmages --plan`, `migrate bedmages`, `BedmageWatch.objects.create(...)` w shell.
+
+### 📋 Sugerowane kroki
+
+1. `git checkout -b feat/<#>-bedmages-app-model` od master.
+2. `mkdir apps/bedmages apps/bedmages/migrations`, dotknij `__init__.py` w obu.
+3. `apps.py` (mirror `apps/deaths/apps.py` z M4-D18).
+4. `models.py` — exactly per spec §5/D23.
+5. `LOCAL_APPS` extend w `base.py`.
+6. `python manage.py makemigrations bedmages` — sprawdź że tworzy `0001_initial.py` z FK do `accounts.User` i `characters.Character`.
+7. `admin.py` z `@admin.register(BedmageWatch)` decorator.
+8. Smoke: `migrate`, admin manually create, `__str__` returns "user watching character".
+9. Pre-commit + commit + push + PR.
+
+### ⚠️ Pułapki do uwagi
+
+- **A — `settings.AUTH_USER_MODEL` jako string, nie import:** `models.ForeignKey(settings.AUTH_USER_MODEL, ...)`. Direct `from apps.accounts.models import User` powoduje circular import jeśli accounts kiedyś zaimportuje bedmages.
+- **B — `auto_now_add` w testach:** dla `created_at` field, gdy chcesz force timestamp w przeszłość → `BedmageWatch.objects.filter(pk=...).update(created_at=...)` (M3-D17 retro #5).
+- **C — FK `to="characters.Character"`** jako string lub `to=Character` z import. String form jest lazy (rozwiązuje circular). Mirror M4-D18 used direct import bo wtedy Character był w innym app graph. W bedmages preferuj string — bezpieczniej.
+- **D — `# type: ignore[type-arg]` na admin** — mirror `apps/characters/admin.py:6` i `apps/deaths/admin.py` (M4 tech debt: ModelAdmin generic subscript wymaga `django_stubs_ext.monkeypatch()`, jeszcze nie wdrożone).
+
+### 🧪 Testing plan
+
+Unit testy `tests/unit/bedmages/test_bedmage_watch_model.py`:
+- `test_create_with_required_fields_works` (happy path + default `active=True`).
+- `test_unique_constraint_user_character_pair` — IntegrityError przy duplikacie.
+- `test_str_repr_format` — sprawdzić format `"username watching character_name"`.
+
+(Tests w D23 są opcjonalne — model minimalny, kluczowe testy logiki w D24. Decyzja per developer's preference, M4-D18 nie miało testów modelu.)
+
+### 🔗 Dokumentacja pomocnicza
+
+- Django `UniqueConstraint`: https://docs.djangoproject.com/en/6.0/ref/models/constraints/#uniqueconstraint
+- `settings.AUTH_USER_MODEL`: https://docs.djangoproject.com/en/6.0/topics/auth/customizing/#referencing-the-user-model
+- `related_name`: https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.ForeignKey.related_name
+
+### 📦 Definition of Done
+
+- [ ] AC spełnione (apps/bedmages/, model, admin, migration, sanity).
+- [ ] PR zmergowany squash (`feat(bedmages): add BedmageWatch model + admin + initial migration (M5-D23, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] `apps/bedmages/migrations/0001_initial.py` w master.
+- [ ] Issue zamknięty.
+
+---
+
+## Task #2 — [M5-D24] Services (`add_bedmage_watch`, `remove_bedmage_watch`, `check_bedmage_watches_for_character`) + types
+
+### 🎯 Cel
+
+Service'y biznesowe dla bedmage tracking — add/remove watch + per-character check po scrape. Bez integracji z task'iem (D26) ani notyfikacji (D25 dorzuca handler dispatch).
+
+### 🧠 Czego się nauczysz
+
+- **`Character.objects.get_or_create(name=...)`** dla auto-create lazy fetch (§4.1). Race-safe w Django ORM (M1-D8 retry pattern niepotrzebny — `unique=True` + retry w models manager handluje).
+- **`timezone.now() - timedelta(minutes=N)`** dla delta comparison. UTC normalizacja przez `USE_TZ = True` (default w base.py).
+- **Idempotency invariant `last_notified_login != character.last_login`** — kluczowy dla M5 tracker logic (CLAUDE.md §7). Pierwsze logowanie (last_notified_login=None, char.last_login=Y) → delta check fires. Drugie scrape (te same Y) → `Y != Y` is False → skip. Trzeci scrape po fresh login (Y2) → `Y != Y2` → fires again.
+- **`select_related("user", "character")`** żeby uniknąć N+1 w `check_bedmage_watches_for_character` iteracji.
+- **`BedmagePayload` TypedDict pattern** mirror `CharacterPayload` z M1 #6 — types osobno od services.
+
+### ✅ Acceptance criteria
+
+(Pełne AC w `.github/issue-bodies/m5-d24.md`.)
+
+**Kluczowe:**
+- `apps/bedmages/types.py` z `BedmagePayload` TypedDict.
+- `apps/bedmages/services.py` z 3 funkcjami:
+  - `add_bedmage_watch(user, character_name) -> BedmageWatch` (auto-create Character, raise jeśli active watch already exists).
+  - `remove_bedmage_watch(user, character_name) -> bool` (hard delete, idempotent).
+  - `check_bedmage_watches_for_character(character)` — iteruje aktywne watche, sprawdza delta, **placeholder dla handler dispatch** (D25 dorzuca real call, w D24 zostawiamy stub `# TODO: D25 handler.notify(watch)` lub minimalistyczny direct `logger.info`).
+- `BEDMAGE_REGEN_MINUTES = env.int("BEDMAGE_REGEN_MINUTES", default=100)` w `base.py` + `.env.example`.
+- 5-7 unit testów (services).
+- Smoke: services w shell.
+
+### ⚠️ Pułapki do uwagi
+
+- **A — `Character.last_login` może być `None`** (postać nie scrape'owana yet) — `check_bedmage_watches_for_character` musi `if char.last_login is None: return` early.
+- **B — `last_notified_login` set BEFORE handler.notify** vs **AFTER**: jeśli handler.notify rzuci exception, czy chcemy retry? Zalecenie: set `last_notified_login` AFTER successful notify, owinąć w try/except — jeśli notify fails, watch retry na next scrape (idempotency wciąż chroni przed dup'em w happy path). Decyzja w D25 razem z handler — w D24 stub'ujemy.
+- **C — `add_bedmage_watch` re-activation case** (§4.1): jeśli watch istnieje ale `active=False`, set `active=True` + return. Spec mówi "raise jeśli already active", `active=False` to inny scenariusz. W M5 hard delete przez remove znaczy że `active=False` rzadko się pojawia. Ale dla bezpieczeństwa: re-activation logic.
+- **D — `select_related` nie jest potrzebny** dla single-watch lookup w `add_bedmage_watch`/`remove_bedmage_watch`, ale **JEST** w `check_bedmage_watches_for_character` żeby uniknąć N+1.
+
+### 🧪 Testing plan
+
+Unit testy `tests/unit/bedmages/test_services.py`:
+- `test_add_bedmage_watch_creates_character_if_missing`.
+- `test_add_bedmage_watch_raises_on_duplicate_active`.
+- `test_add_bedmage_watch_reactivates_inactive`.
+- `test_remove_bedmage_watch_deletes_existing_returns_true`.
+- `test_remove_bedmage_watch_idempotent_returns_false_when_not_found`.
+- `test_check_skips_when_character_has_no_last_login`.
+- `test_check_skips_when_delta_below_threshold`.
+- `test_check_fires_when_delta_above_threshold_and_not_yet_notified`.
+- `test_check_skips_when_already_notified_for_this_login`.
+
+(D25 doda 1-2 testy dla handler dispatch wewnątrz check.)
+
+### 📦 Definition of Done
+
+- [ ] AC spełnione.
+- [ ] PR zmergowany squash.
+- [ ] `apps/bedmages/services.py` ~100% coverage.
+- [ ] Issue zamknięty.
+
+---
+
+## Task #3 — [M5-D25] `apps/notifications/` package + `LoggingHandler` + settings switch
+
+### 🎯 Cel
+
+Notifications abstraction layer — Protocol interface + LoggingHandler default + settings switch dla future M6 DiscordHandler swap.
+
+### 🧠 Czego się nauczysz
+
+- **Python Protocol vs ABC** dla interface'ów — Protocol jest **structural typing** (duck), ABC wymusza explicit subclassing. Protocol bardziej Pythonic dla M6 swap (DiscordHandler z M6 nie musi inheritować z LoggingHandler — wystarczy że ma `notify(watch)` method).
+- **`django.utils.module_loading.import_string`** dla dotted-path resolution z settings — Django convention dla pluggable backends (mirror `CACHES['default']['BACKEND']`).
+- **Lazy handler resolution** — `get_bedmage_handler()` może być cached przez `functools.lru_cache(maxsize=1)` lub re-resolved każdym call'em. Trade-off: cache = szybciej, ale `@override_settings(BEDMAGE_NOTIFICATION_HANDLER=...)` w testach nie podmieni handler'a (cache'ed). Zalecenie M5: bez cache (per-call resolution), prosta i test-friendly.
+
+### ✅ Acceptance criteria
+
+**Kluczowe:**
+- `apps/notifications/` package: `__init__.py` (z `get_bedmage_handler()`), `apps.py` (`NotificationsConfig`), `handlers.py` (Protocol + LoggingHandler).
+- `BEDMAGE_NOTIFICATION_HANDLER = env("BEDMAGE_NOTIFICATION_HANDLER", default="apps.notifications.handlers.LoggingHandler")` w `base.py` + `.env.example`.
+- `LOCAL_APPS` w `base.py` rozszerzone o `"apps.notifications"`.
+- `apps/bedmages/services.py:check_bedmage_watches_for_character` zintegrowane z `get_bedmage_handler().notify(watch)` (zamienia stub z D24).
+- Unit testy: handler resolution, LoggingHandler emits expected log line.
+
+### ⚠️ Pułapki do uwagi
+
+- **A — Protocol w runtime check** — `isinstance(obj, BedmageNotificationHandler)` wymaga `@runtime_checkable` decorator na Protocol. M5 nie potrzebuje runtime check (tylko type), więc decorator zbędny.
+- **B — Settings testing** — `@override_settings(BEDMAGE_NOTIFICATION_HANDLER="...")` w testach + per-call resolution = działa. Cache (`lru_cache`) by zepsuł.
+- **C — Circular: `apps.notifications` importuje `BedmageWatch` for type hint?** — Protocol method signature `notify(self, watch: "BedmageWatch") -> None` używa string forward reference + `if TYPE_CHECKING: from apps.bedmages.models import BedmageWatch` block. Eliminuje circular.
+
+### 📦 Definition of Done
+
+- [ ] AC spełnione.
+- [ ] PR zmergowany squash.
+- [ ] `apps/notifications/*.py` 100% coverage.
+- [ ] Issue zamknięty.
+
+---
+
+## Task #4 — [M5-D26] Tracker integration w `scrape_watched_characters`
+
+### 🎯 Cel
+
+Po każdym successful character scrape w `scrape_watched_characters` task, fire `check_bedmage_watches_for_character(char)`. Bezpieczne against tracker exceptions (defensive wrap).
+
+### 🧠 Czego się nauczysz
+
+- **Lazy import w funkcji** zamiast top-of-module — pattern dla unikania circular imports gdy A→B→A graph istnieje. M3-D16 task już używał lazy import dla characters/spider — kontynuacja patternu.
+- **`logger.exception(...)`** vs `logger.error(...)` — `exception` automatycznie dorzuca traceback do log entry (Python logging idiom dla try/except tutaj).
+- **Defensive isolation** — tracker bug nie powinien wpływać na scrape success metrics. Try/except wrap z `logger.exception`, nie re-raise.
+
+### ✅ Acceptance criteria
+
+- Modyfikacja `apps/characters/tasks.py:scrape_watched_characters`:
+  ```python
+  if result.returncode == 0:
+      scraped += 1
+      character = Character.objects.get(name=name)
+      try:
+          from apps.bedmages.services import check_bedmage_watches_for_character
+          check_bedmage_watches_for_character(character)
+      except Exception:
+          logger.exception("bedmage check failed for %s", name)
+  ```
+- Unit test extending `tests/integration/test_celery_e2e.py` — mock tracker, verify called per scraped character.
+- Smoke: ręczne `addBedmageWatch` (przez D24 service) + force `scrape_watched_characters.delay()` na character z fresh `last_login` → log entry z `LoggingHandler`.
+
+### ⚠️ Pułapki do uwagi
+
+- **A — `Character.objects.get(name=name)` po `result.returncode == 0`** — postać MUSI istnieć w DB (pętla iteruje po `Character.objects.values_list`), więc `DoesNotExist` nie powinien się zdarzyć. Ale defensive `try/except` na ten case też (deletion race).
+- **B — Lazy import w pętli vs przed pętlą** — pierwszy import jest wolny (~50ms), kolejne są cached. Dla 50 characters wolisz import RAZ przed pętlą (pewny optimization), ale dla circular safety musi być wewnątrz funkcji. Sugerowane: import wewnątrz `try` block (eager przy pierwszym fire, cached na resztę).
+- **C — `mock.patch` lazy importów** — `mock.patch("apps.bedmages.services.check_bedmage_watches_for_character")` nie patchuje gdy import jest lazy (patches namespace na poziomie module, lazy import czyta świeżą referencję). Workaround: `mock.patch("apps.characters.tasks.check_bedmage_watches_for_character")` po lazy import — ale wtedy import musi być na top of `tasks.py` (sprzeczne z circular safety). Compromise: rozważ czy unit test mockuje na poziomie services (`mock.patch("apps.bedmages.services.get_bedmage_handler")`) zamiast tracker function. Decyzja w D26.
+
+### 📦 Definition of Done
+
+- [ ] AC spełnione.
+- [ ] PR zmergowany squash.
+- [ ] `tests/integration/test_celery_e2e.py` extension covers tracker integration.
+- [ ] Issue zamknięty.
+
+---
+
+## Task #5 — [M5-D27] GraphQL `myBedmages` + `addBedmageWatch` + `removeBedmageWatch` + e2e + M5 closure
+
+### 🎯 Cel
+
+GraphQL surface dla bedmage management — query (lista user'a) + 2 mutations (add/remove). E2E integration test pokrywa pełny flow: addBedmageWatch → mock scrape → tracker fires → handler called. M5 zamyka się z PROGRESS.md retro + milestone closed.
+
+### 🧠 Czego się nauczysz
+
+- **Strawberry mutation pattern:** `@strawberry.mutation` decorator (lub `@strawberry.field` w `Mutation` class). Mutations w Strawberry to też zwykłe async resolvers — kontekst dispatch identyczny jak query.
+- **`merge_types("Mutation", (...))` first time** — analogicznie do `merge_types("Query", ...)` z M2/M4. `config/schema.py` rozszerza się o:
+  ```python
+  schema = strawberry.Schema(query=Query, mutation=Mutation)
+  ```
+- **Nested type resolution** — `BedmageWatchType.character` zwraca `CharacterType` z `apps.characters.schema`. Strawberry-Django auto-resolves przez FK.
+- **`auto_now_add` w testach (powtórka z M3-D17 retro #5):** test'y kontrolujące `created_at` muszą używać `update()` workaround.
+
+### ✅ Acceptance criteria
+
+(Pełne AC w `.github/issue-bodies/m5-d27.md`.)
+
+**Kluczowe:**
+- `apps/bedmages/schema.py` z `BedmageWatchType` + `Query.my_bedmages` + `Mutation.add_bedmage_watch` + `Mutation.remove_bedmage_watch`.
+- `config/schema.py` rozszerzone o `Mutation` merge + `mutation=Mutation` parameter.
+- 6-8 unit testów GraphQL (mirror M4-D22 patternu).
+- E2E test `tests/integration/test_m5_bedmages_e2e.py` (full flow).
+- PROGRESS.md sekcja `🎉 Milestone M5 — Bedmage tracker (backend) COMPLETED (YYYY-MM-DD)` w osobnym `docs/close-m5-tracker` PR.
+- Milestone closed via `gh api -X PATCH .../milestones/<#> -f state=closed`.
+
+### ⚠️ Pułapki do uwagi
+
+- **A — Mutation auth pattern** — `info.context.request.user.is_authenticated` (mirror M4-D22). Mutations bez JWT → `raise Exception("Authentication required")`. Strawberry serializes jako `errors[]`.
+- **B — Nested `character: CharacterType` resolution** — Strawberry-Django auto-resolves FK relacje, ale **async ORM** wymaga explicit handling. Sprawdź czy `await watch.character` musi być explicit lub czy auto-prefetch działa. Test najlepszy w D27.
+- **C — `merge_types("Mutation", (BedmageMutation,))` z 1 source** — `merge_types` wymaga tuple, jeden element to `(BedmageMutation,)` (z trailing comma). Bez przecinka Python parsuje `(BedmageMutation)` jako redundant parens, nie tuple.
+- **D — `strawberry.Schema(query=Query, mutation=Mutation)`** — bez `mutation=` parameter, mutations nie są dostępne w GraphQL endpoint. Easy miss.
+- **E — `add_bedmage_watch` test z `Character.objects.get_or_create`** — test w D27 może zakładać że Character istnieje, lub testować lazy fetch. Decyzja: testuj **oba** scenariusze (fresh + existing) żeby mieć pewność że auto-create działa.
+
+### 🧪 Testing plan
+
+Unit testy GraphQL `tests/unit/bedmages/test_graphql_bedmages.py`:
+- `test_my_bedmages_filters_by_request_user`.
+- `test_my_bedmages_requires_authentication`.
+- `test_add_bedmage_watch_creates_with_existing_character`.
+- `test_add_bedmage_watch_creates_character_lazily`.
+- `test_add_bedmage_watch_raises_on_duplicate`.
+- `test_add_bedmage_watch_requires_authentication`.
+- `test_remove_bedmage_watch_returns_true_when_existing`.
+- `test_remove_bedmage_watch_returns_false_when_not_found`.
+
+E2E `tests/integration/test_m5_bedmages_e2e.py`:
+- `test_e2e_add_then_scrape_then_handler_fires` — full flow z mock subprocess + manual handler verification.
+
+### 📦 Definition of Done
+
+- [ ] AC spełnione (Schema, Merge, Unit testy 6-8, E2E test, PROGRESS.md, Smoke manual).
+- [ ] **Feature PR** zmergowany squash (`feat(bedmages): GraphQL queries + mutations + e2e (M5-D27, #<#>)`).
+- [ ] **Closure PR** zmergowany squash (`docs(progress): close M5 — Bedmage tracker backend COMPLETED`).
+- [ ] CI lint + test zielone na obu PR-ach.
+- [ ] `apps/bedmages/*.py` cumulative coverage ≥ 95%.
+- [ ] Issue zamknięty (oba — feature i closure).
+- [ ] Milestone M5 zamknięty na GitHub.
+
+---
+
+## Spec section refs
+
+| Spec section | Realizowane przez |
+|---|---|
+| §2 Scope w/poza | All tasks |
+| §3 Architektura — flow diagram | D24 + D25 + D26 (full chain) |
+| §4.1 Auto-create Character | D24 service `add_bedmage_watch` |
+| §4.2 Hard delete | D24 service `remove_bedmage_watch` |
+| §4.3 Notification handler abstraction | D25 |
+| §4.4 Tracker fire trigger | D26 |
+| §4.5 Tracker scope | D24 (filter logic) + D26 (integration) |
+| §4.6 GraphQL mutations error handling | D27 |
+| §4.7 FK on_delete | D23 |
+| §5 Daily tasks split | This document |
+| §6.1 M3 task integration | D26 |
+| §6.2 M2 GraphQL integration + first Mutation | D27 |
+| §7 Test plan | All tasks |
+| §8 DoD M5 | M5 closure (D27 closure PR) |
+| §9 Open questions | M-future, NIE w M5 |

--- a/docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md
+++ b/docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md
@@ -1,0 +1,461 @@
+# M5 — Bedmage tracker (backend) — Design
+
+**Data:** 2026-05-08
+**Milestone:** M5 (GitHub milestone TBD)
+**Budżet:** 5 dni roboczych (~16-20h, mirror M4 budgetu po lekcji "świadomie wąski scope" zadziałała w 3 dni real time).
+**Poprzedni milestone:** M4 — Deaths monitor (backend) (zamknięty 2026-05-07, retro w `PROGRESS.md`).
+**Następny:** M6 — Discord bot integration (dorzuca real Discord publisher ponad notification abstraction z M5).
+
+---
+
+## 1. Cel
+
+Dodać trzecią funkcjonalność biznesową aplikacji — **bedmage tracker** — przypominanie użytkownikom, że minęło 100 minut od logowania ich obserwowanej postaci (koniec regeneracji many w łóżku). Po M5 backend potrafi:
+
+1. User przez GraphQL `addBedmageWatch(characterName)` zapisuje "obserwuję postać X".
+2. Co 1h Beat fires `scrape_watched_characters` (M3 infra) — tylko Characters które mają BedmageWatch'e są w to scope, nie cały DB (mitigation: nie scrape'uj postaci nikomu nie potrzebnych).
+3. Po każdym successful scrape postaci, tracker wywołuje `check_bedmage_watches_for_character(character)` — sprawdza czy `now - character.last_login >= 100 min` AND czy notyfikacja dla tego logowania jeszcze nie poszła.
+4. Gdy oba warunki spełnione, tracker wywołuje `BedmageNotificationHandler.notify(watch)` — w M5 default `LoggingHandler` loguje do app logs, w M6 `DiscordHandler` publikuje przez webhook do user'owego DM.
+5. `last_notified_login = character.last_login` ustawione → nie spamujemy każdym scrape (idempotency per logowanie).
+
+**Świadomie wąski scope:** zero Discord, zero realnej komunikacji z user'em, zero discord_id mapping. Backend tylko wykrywa + flag'uje + odpala dummy handler. M6 wymieni handler na real Discord publisher.
+
+**Świadomie odroczone:**
+- Discord bot proces, slash commands `/bedmage add|list|remove` (M6) — wymaga osobnego container'a, py-cord vs discord.py decision, OAuth lub auto-create User mapping.
+- Real Discord webhook publisher (M6) — wymieni `LoggingHandler` na `DiscordHandler` przez settings switch.
+- Per-watch custom interval (60/100/150 min override) — domyślnie 100 min hardcoded w settings; przyszłe `BedmageWatch.regen_minutes: PositiveIntegerField(null=True)` field z fallback do `settings.BEDMAGE_REGEN_MINUTES`.
+- Multi-tenant Discord (multiple servers) — UserY na serwerze A vs B widzi inne BedmageWatch'e? Decyzja: nie, BedmageWatch jest per-User, niezależnie od serwera Discord. M6 wybierze gdzie powiadomić.
+- Pause/resume bulk operations (`pauseAllBedmages` GraphQL mutation) — `active` field jest set/unset przez add/remove, batch ops poza M5.
+
+---
+
+## 2. Scope
+
+**W scope:**
+- Nowa aplikacja `apps/bedmages/` zarejestrowana w `INSTALLED_APPS` jako `apps.bedmages.apps.BedmagesConfig`.
+- Model `BedmageWatch` (`user FK`, `character FK`, `created_at auto_now_add`, `last_notified_login DateTime null`, `active BooleanField default=True`) + migracja initial + Django admin + `unique_together = ("user", "character")`.
+- Service `apps/bedmages/services.py`:
+  - `add_bedmage_watch(user, character_name)` — auto-create `Character` jeśli nie istnieje (lazy fetch, scrape przez najbliższy Beat fire), tworzy `BedmageWatch` lub raise jeśli juz istnieje.
+  - `remove_bedmage_watch(user, character_name)` — soft delete przez `active=False` lub hard delete (decyzja w `decisions` poniżej).
+  - `check_bedmage_watches_for_character(character)` — invoke'owane post-scrape; iteruje aktywne watche dla character, sprawdza delta + idempotency, wywołuje notification handler.
+- Notifications abstraction `apps/notifications/`:
+  - `BedmageNotificationHandler` interface (Protocol lub ABC).
+  - `LoggingHandler` default — `logger.info("BEDMAGE: user=%s character=%s last_login=%s", ...)`.
+  - Settings `BEDMAGE_NOTIFICATION_HANDLER` (env-based, default `"apps.notifications.handlers.LoggingHandler"`) z dotted-path resolution.
+- Settings `BEDMAGE_REGEN_MINUTES` (env-based, default 100) — używany w tracker dla delta comparison.
+- Integration z `apps.characters.tasks.scrape_watched_characters` — po każdym `result.returncode == 0`, fire `check_bedmage_watches_for_character(character)` (lazy import żeby uniknąć circular).
+- GraphQL w `apps/bedmages/schema.py`:
+  - Query `myBedmages: [BedmageWatchType!]!` — JWT-protected, filtruje przez `request.user`.
+  - Mutation `addBedmageWatch(characterName: String!): BedmageWatchType!` — JWT-protected.
+  - Mutation `removeBedmageWatch(characterName: String!): Boolean!` — JWT-protected.
+- Tests: unit model, unit services (3 funkcje), unit notification handler dispatch, unit GraphQL (queries + mutations + auth), integration e2e (full flow: addBedmageWatch → mocked scrape → handler fires).
+- PROGRESS.md retro M5 + DoD checklist + Podsumowanie M5.
+
+**Poza scope (post-M5):**
+- Discord bot proces, slash commands, webhook publisher, channel config (M6).
+- Real Discord notification handler (M6) — wymiana `LoggingHandler` na `DiscordHandler`.
+- `discord_id` field już istnieje na `User` z M2-D9, ale auto-link w M5 nie używa go.
+- Per-watch custom regen interval (M-future field).
+- Bedmage statistics ("user X has 5 active watches, total notifications sent: 47") — backend ma logi ale brak query'ego (M6+).
+- Watchdog "character no longer being scraped" alarm (M5+ tech debt).
+
+---
+
+## 3. Architektura
+
+```
+┌─────────────────┐     addBedmageWatch       ┌──────────────────┐
+│  GraphQL client │ ────────────────────────► │ apps/bedmages/   │
+│   (M6: bot)     │     myBedmages            │   schema.py      │
+└─────────────────┘                           └────────┬─────────┘
+                                                       │
+                                              services.py
+                                                       │
+                                              ┌────────▼─────────┐
+                                              │  BedmageWatch    │
+                                              │     model        │
+                                              └────────┬─────────┘
+                                                       │
+   Beat (5 min)                                        │
+        │                                              │
+        ▼                                              │
+┌─────────────────┐    per scraped char               │
+│ scrape_watched_ │ ──────────────────────► check_bedmage_watches_for_character(char)
+│  characters     │                                    │
+└─────────────────┘                          ┌─────────▼────────────┐
+                                              │ delta = now - last_login
+                                              │ if delta >= 100 min  │
+                                              │   AND last_notified_login != last_login:
+                                              │     handler.notify(watch)
+                                              │     watch.last_notified_login = char.last_login
+                                              └─────────┬────────────┘
+                                                       │
+                                              ┌────────▼─────────┐
+                                              │ apps/notifications/
+                                              │  LoggingHandler  │ ◄── M5 default
+                                              │  DiscordHandler  │ ◄── M6 dorzuca
+                                              └──────────────────┘
+```
+
+**Kluczowy invariant:** `last_notified_login` przechowuje `character.last_login` z momentu kiedy notyfikacja poszła. Każde nowe logowanie postaci (`character.last_login` się zmienia po fresh scrape) reset'uje cycle — tracker widzi `last_notified_login != character.last_login`, czeka 100 min, fires nowa notyfikacja, set'uje znowu.
+
+---
+
+## 4. Kluczowe decyzje designowe
+
+### 4.1 Auto-create Character w `addBedmageWatch`
+
+**Decyzja:** TAK, lazy fetch.
+
+`add_bedmage_watch(user, character_name)`:
+```python
+character, _ = Character.objects.get_or_create(name=character_name)
+watch, created = BedmageWatch.objects.get_or_create(
+    user=user, character=character, defaults={"active": True}
+)
+if not created and watch.active:
+    raise ValueError(f"BedmageWatch for {character_name} already exists")
+if not created and not watch.active:
+    watch.active = True
+    watch.save()
+return watch
+```
+
+**Why:**
+- UX: user dodaje watch nie znając stanu DB. System sam handluje "Character nie istnieje".
+- Pierwsza scrape postaci nadejdzie z najbliższym Beat fire (ścieżka: scrape_watched_characters → loop przez Character → spider → upsert_character ustawia `last_login`). Tracker zaczyna działać po tym pierwszym scrape.
+- Edge case: postać nie istnieje na tibiantis.online (literówka, deleted account) → spider zaloguje warning, `Character.last_login = None`, tracker robi `if char.last_login is None: skip`. Watch zostaje "uśpiony" do momentu poprawienia nazwy lub usunięcia.
+
+**Alternative (rejected):** reject jeśli Character nie istnieje. UX gorszy ("manualnie scrape postaci, dopiero potem watch") + race condition (postać scrape'owana między user'a check a watch creation = niepotrzebny error).
+
+### 4.2 Soft vs hard delete dla `removeBedmageWatch`
+
+**Decyzja:** HARD delete.
+
+```python
+def remove_bedmage_watch(user, character_name) -> bool:
+    deleted, _ = BedmageWatch.objects.filter(
+        user=user, character__name=character_name
+    ).delete()
+    return deleted > 0
+```
+
+**Why:**
+- M5 nie ma "history of watches" jako feature — soft delete byłby YAGNI.
+- Hard delete + `unique_together("user", "character")` znaczy że `addBedmageWatch` tej samej postaci później = fresh start (cycle resetuje, `last_notified_login = None`).
+- Soft delete (`active=False`) by complikował `addBedmageWatch` (re-activation logic) bez korzyści.
+
+**`active` field zostaje** — używany dla "pause" przyszłych operacji (M-future), w M5 zawsze `True` po `addBedmageWatch`. Hard delete usuwa wpis całkowicie.
+
+### 4.3 Notification handler abstraction w M5
+
+**Decyzja:** TAK, `apps/notifications/` package z Protocol-based interface + `LoggingHandler` default.
+
+```python
+# apps/notifications/handlers.py
+from typing import Protocol
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class BedmageNotificationHandler(Protocol):
+    def notify(self, watch: "BedmageWatch") -> None: ...
+
+
+class LoggingHandler:
+    def notify(self, watch: "BedmageWatch") -> None:
+        logger.info(
+            "BEDMAGE: user=%s character=%s last_login=%s",
+            watch.user.username, watch.character.name, watch.character.last_login,
+        )
+
+
+# apps/notifications/__init__.py
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+
+def get_bedmage_handler() -> BedmageNotificationHandler:
+    handler_class = import_string(settings.BEDMAGE_NOTIFICATION_HANDLER)
+    return handler_class()
+```
+
+Service `check_bedmage_watches_for_character`:
+```python
+from apps.notifications import get_bedmage_handler
+
+handler = get_bedmage_handler()  # cached at module level lub per-call?
+handler.notify(watch)
+```
+
+**Why:**
+- Otwiera M6 path bez M5 refactor — M6 doda `DiscordHandler` w `apps/notifications/handlers.py`, zmienia `BEDMAGE_NOTIFICATION_HANDLER=apps.notifications.handlers.DiscordHandler` w `.env`, rebuild — koniec.
+- Test'owalność — w M5 testach wsadzamy `mock.patch("apps.notifications.get_bedmage_handler")` i sprawdzamy że został wywołany.
+- Settings switch jest standard Django pattern (mirror `CACHES['default']['BACKEND']`).
+
+**Alternative (rejected):** dummy handler bez abstraction (just `logger.info` w service). Daje shorter M5, ale M6 wymaga refactor service'u — coupling tracker logic do Discord. Reject — abstraction kosztuje 30 linii w M5, oszczędza dni refactoru w M6.
+
+### 4.4 Tracker fire trigger — gdzie wywołać `check_bedmage_watches`?
+
+**Decyzja:** Wewnątrz `scrape_watched_characters` task (M3-D16), per-character po `result.returncode == 0`.
+
+```python
+# apps/characters/tasks.py — D26 modification
+result = subprocess.run([...])
+if result.returncode == 0:
+    scraped += 1
+    character = Character.objects.get(name=name)
+    from apps.bedmages.services import check_bedmage_watches_for_character
+    check_bedmage_watches_for_character(character)
+```
+
+**Why:**
+- Coupling natural — tracker depends na świeżo updated `character.last_login`. Najświeższy moment to **right after scrape**.
+- Reuse infrastruktury — Beat schedule, worker pool, error handling z M3 są zachowane.
+- Single failure mode — jeśli tracker rzuci exception, scrape counter'y nie są dotknięte (subprocess już succeed). Tracker exceptions logowane, nie eskalują do retry.
+
+**Alternative (rejected):**
+- (A) Osobny periodic task `check_bedmages` co 5 min — duplicates Beat traffic, race condition gdy scrape interval pokrywa się z check interval.
+- (B) Django signal post_save na Character — implicit coupling, trudniejsze do debugowania, signal handlers ciężko mockować w testach.
+- (C) Query-time tracker (lazy fetch w `myBedmages`) — nie wysyła notyfikacji proactively.
+
+### 4.5 Tracker scope — wszystkie Characters czy tylko z aktywnymi watch'ami?
+
+**Decyzja:** `scrape_watched_characters` skanuje **wszystkie** Characters w DB (M3-D16 zachowanie), tracker filtruje **tylko** przez `BedmageWatch.objects.filter(character=char, active=True)`.
+
+**Why:**
+- M5 ma świadomie wąski scope. Optymalizacja "scrape only watched characters" to oszczędność zasobów ale dodaje sprzężenie (jeśli BedmageWatch nie istnieje, postać nie jest scrape'owana — co jeśli w przyszłości chcemy scrape'ować postaci dla deaths threshold lub innego feature'u?). M3 task scope = "wszystkie Characters", M5 nie zmienia.
+- W praktyce: dev/test ma <50 Characters, prod może mieć kilka tysięcy ale nadal scrapowanie 1 postaci = ~3s, więc 1000 chars = ~50 min. Beat 1h interval daje bufor.
+- Future optimization: M-future doda `Character.is_watched` lub query-side join (`Character.objects.filter(bedmagewatch__active=True).distinct()`) jeśli scale wymaga. M5 nie premature-optimizuje.
+
+**Alternative (rejected):** scrape only Characters z aktywnymi BedmageWatch'ami. Sprzęga M3 (characters) z M5 (bedmages), regress'uje jeśli M-future wymaga scrape'a postaci dla innych powodów.
+
+### 4.6 GraphQL mutations error handling
+
+**Decyzja:** `addBedmageWatch` + `removeBedmageWatch` rzucają `Exception` (Strawberry serializuje jako `errors[]` field). Mirror M4-D22 `recentDeaths` auth pattern.
+
+- `addBedmageWatch` z istniejącym aktywnym watch'em → `raise Exception("BedmageWatch for X already exists")`
+- `removeBedmageWatch` z nieistniejącym watch'em → return `False` (idempotent), NIE raise.
+- Auth fail (no JWT) → `raise Exception("Authentication required")` (mirror M4-D22 `recentDeaths`).
+
+**Why:**
+- Mutations zwracają `BedmageWatchType!` (non-null) lub `Boolean!` — error response jest semantycznie inny niż "no result".
+- Idempotent remove (no-op if not exists) jest UX-friendly (user może spamować "remove" bez błędów).
+
+### 4.7 `BedmageWatch.character` FK on_delete behavior
+
+**Decyzja:** `on_delete=models.CASCADE` (M5 default Django convention).
+
+**Why:**
+- Jeśli ktoś usuwa Character z DB (admin operation lub future scrape failure pruning), BedmageWatch dla tego Character traci sens — cascade czyści.
+- Alternative `PROTECT` blokowałby Character delete dopóki user ręcznie nie usuwa wszystkich watch'y — UX gorszy.
+- `SET_NULL` wymagałby `character` field jako nullable — komplikuje query'y.
+
+`BedmageWatch.user` FK → `on_delete=models.CASCADE` także (User delete = wszystkie watch'e idą).
+
+---
+
+## 5. Daily tasks split (5 D-tasks)
+
+### D23 — `apps/bedmages/` app + `BedmageWatch` model + admin + initial migration
+
+**Czas:** 2-3h
+**Branch:** `feat/<issue#>-bedmages-app-model`
+**Zależy od:** M4 closed.
+
+- Stwórz `apps/bedmages/` z `apps.py` (`BedmagesConfig`, `default_auto_field = "django.db.models.BigAutoField"`, `name = "apps.bedmages"`, `label = "bedmages"`).
+- Dodaj `"apps.bedmages"` do `LOCAL_APPS` w `config/settings/base.py` (single source of truth z chore PR #92 widzi automatycznie).
+- `BedmageWatch` model:
+  ```python
+  class BedmageWatch(models.Model):
+      user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="bedmage_watches")
+      character = models.ForeignKey("characters.Character", on_delete=models.CASCADE, related_name="bedmage_watches")
+      created_at = models.DateTimeField(auto_now_add=True)
+      last_notified_login = models.DateTimeField(null=True, blank=True)
+      active = models.BooleanField(default=True)
+
+      class Meta:
+          constraints = [
+              models.UniqueConstraint(
+                  fields=["user", "character"],
+                  name="unique_bedmage_watch_per_user_character",
+              ),
+          ]
+          ordering = ["-created_at"]
+
+      def __str__(self) -> str:
+          return f"{self.user.username} watching {self.character.name}"
+  ```
+- Initial migration `0001_initial.py`.
+- Django admin z `list_display=("user", "character", "active", "last_notified_login", "created_at")`, `list_filter=("active",)`, `search_fields=("user__username", "character__name")`.
+- Smoke: `migrate bedmages` clean, model visible w admin, `BedmageWatch.objects.create(...)` w shell działa.
+
+### D24 — Services: `add_bedmage_watch` + `remove_bedmage_watch` + `check_bedmage_watches_for_character`
+
+**Czas:** 3h
+**Branch:** `feat/<issue#>-bedmage-services`
+**Zależy od:** D23 merged.
+
+- `apps/bedmages/types.py` — `BedmagePayload` TypedDict mirror M1 #6 pattern (chore: nawiasem ten sam pattern poszedł odroczony w M4 dla DeathPayload, w M5 robimy go od razu).
+- `apps/bedmages/services.py`:
+  - `add_bedmage_watch(user, character_name)` — auto-create Character, get_or_create watch, raise jeśli already active.
+  - `remove_bedmage_watch(user, character_name) -> bool` — hard delete, idempotent.
+  - `check_bedmage_watches_for_character(character)` — iteruje aktywne watche, sprawdza delta + idempotency, wywołuje handler, set's `last_notified_login`.
+- `BEDMAGE_REGEN_MINUTES = env.int("BEDMAGE_REGEN_MINUTES", default=100)` w `config/settings/base.py` + `.env.example`.
+- Unit testy services (5-6 testów: happy path add, duplicate add raise, remove existing, remove non-existing idempotent, check fires handler when delta>=100, check skips when last_notified_login matches).
+- Smoke: ręczne `add_bedmage_watch` w shell, weryfikacja DB.
+
+### D25 — Notifications abstraction + LoggingHandler + settings switch
+
+**Czas:** 2h
+**Branch:** `feat/<issue#>-bedmage-notifications-handler`
+**Zależy od:** D24 merged.
+
+- `apps/notifications/` package: `__init__.py` (z `get_bedmage_handler()`), `handlers.py` (Protocol + LoggingHandler), `apps.py`.
+- Settings: `BEDMAGE_NOTIFICATION_HANDLER = env("BEDMAGE_NOTIFICATION_HANDLER", default="apps.notifications.handlers.LoggingHandler")` w `base.py` + `.env.example`.
+- D24 service `check_bedmage_watches_for_character` integruje przez `get_bedmage_handler()` zamiast direct `logger.info`.
+- Unit testy: handler dispatch przez `get_bedmage_handler()` resolves correct class, `LoggingHandler.notify(watch)` emits expected log line.
+- `apps.notifications` zarejestrowane w `LOCAL_APPS`.
+
+### D26 — Integration tracker w `scrape_watched_characters` task
+
+**Czas:** 2-3h
+**Branch:** `feat/<issue#>-tracker-scrape-integration`
+**Zależy od:** D25 merged.
+
+- Modyfikacja `apps/characters/tasks.py:scrape_watched_characters`:
+  ```python
+  if result.returncode == 0:
+      scraped += 1
+      character = Character.objects.get(name=name)
+      from apps.bedmages.services import check_bedmage_watches_for_character
+      try:
+          check_bedmage_watches_for_character(character)
+      except Exception:
+          logger.exception("bedmage check failed for %s", name)
+          # Don't propagate — scrape itself succeeded, tracker error shouldn't bump `failed`
+  ```
+- Lazy import (bedmages → characters → bedmages cycle prevention).
+- Defensive try/except (tracker bug nie powinien wpływać na scrape success metrics).
+- Unit test extending M3-D17 `test_celery_e2e.py` — mock tracker, verify it gets called per scraped character.
+- Smoke: ręcznie addBedmageWatch + force scrape, weryfikacja log entry z `LoggingHandler`.
+
+### D27 — GraphQL: `myBedmages` query + `addBedmageWatch` + `removeBedmageWatch` mutations + e2e + M5 closure
+
+**Czas:** 4h (longest task, 2 PR-y jak M4-D22)
+**Branch:** `feat/<issue#>-bedmages-graphql` + osobny `docs/close-m5-tracker`
+**Zależy od:** D26 merged.
+
+- `apps/bedmages/schema.py`:
+  - `BedmageWatchType` (`@strawberry_django.type(BedmageWatch)`, fields: `id`, `created_at`, `last_notified_login`, `active`, plus nested `character: CharacterType` via FK).
+  - Query `my_bedmages` — JWT-protected, filter by `request.user`.
+  - Mutation `add_bedmage_watch(character_name: str) -> BedmageWatchType` — JWT, calls service.
+  - Mutation `remove_bedmage_watch(character_name: str) -> bool` — JWT, idempotent.
+- `config/schema.py` rozszerzone o `Mutation` type (first time w projekcie):
+  ```python
+  from apps.bedmages.schema import Mutation as BedmageMutation, Query as BedmageQuery
+
+  Query = merge_types("Query", (AccountsQuery, CharactersQuery, DeathsQuery, BedmageQuery))
+  Mutation = merge_types("Mutation", (BedmageMutation,))
+  schema = strawberry.Schema(query=Query, mutation=Mutation)
+  ```
+- 6-8 unit testów GraphQL: my_bedmages auth+filter, add success, add duplicate raise, remove existing, remove non-existing idempotent, mutation auth required, nested character resolution.
+- E2E integration test `tests/integration/test_m5_bedmages_e2e.py` — full flow: addBedmageWatch (mocks Character.last_login set in past >100min) → manual call to `check_bedmage_watches_for_character` → assert handler called with expected watch.
+- PROGRESS.md sekcja `## 🎉 Milestone M5 — Bedmage tracker (backend) COMPLETED (YYYY-MM-DD)` (osobny `docs/close-m5-tracker` PR).
+- DoD M5 spełnione, milestone closed via `gh api -X PATCH ...milestones/<id> -f state=closed`.
+
+---
+
+## 6. Integration points
+
+### 6.1 M3 `scrape_watched_characters` task
+- D26 dorzuca `check_bedmage_watches_for_character(character)` po success'ie scrape.
+- Lazy import + defensive try/except dla isolation.
+
+### 6.2 M2 GraphQL schema
+- D27 dorzuca `BedmageQuery` do `merge_types("Query", ...)`.
+- D27 wprowadza `Mutation` type **pierwszy raz** w projekcie — dotąd tylko Query. Strawberry schema z `mutation=Mutation` parameter.
+- JWT auth pattern z M2-D12 + M4-D22 reused (dispatch z `JWTAsyncGraphQLView`).
+
+### 6.3 M4 carry-over tech debt rozważyć
+- `DeathPayload` extract do `apps/deaths/types.py` (soft blocker z M4-D20 review). M5 robi to dla `BedmagePayload` od razu (good pattern), opcjonalnie chore w D24 razem dla DeathPayload.
+- `celery-types` package (carry-over z M3) — jeśli D26 task modification wprowadzi mypy issues z `@shared_task`, dorzucić jako M5 chore.
+
+### 6.4 Future M6 (Discord bot)
+- M6 doda `DiscordHandler` w `apps/notifications/handlers.py` — implementuje `BedmageNotificationHandler` Protocol.
+- M6 ustawia `BEDMAGE_NOTIFICATION_HANDLER=apps.notifications.handlers.DiscordHandler` w prod `.env`.
+- M6 dorzuca slash commands `/bedmage add|remove|list` jako wrapper na M5 GraphQL mutations.
+
+---
+
+## 7. Test plan
+
+**Unit testy:**
+- D23 model: 2-3 testy (default values, unique constraint enforcement, str repr).
+- D24 services: 5-6 testów (add happy/duplicate/character-doesn't-exist-yet, remove existing/non-existing, check happy/below-threshold/already-notified).
+- D25 notifications: 2-3 testy (handler resolution by setting, LoggingHandler emits log).
+- D26 task integration: 1-2 testy w `test_celery_e2e.py` extension (mock tracker, assert called once per scraped char).
+- D27 GraphQL: 6-8 testów (my_bedmages auth+filter, add success/duplicate, remove existing/non-existing, mutation auth, nested character).
+
+**Integration / e2e:**
+- D27 `test_m5_bedmages_e2e.py` — full flow add → mock scrape sets last_login → manual check → handler called.
+
+**Coverage cel:** `apps/bedmages/*.py` 100%, `apps/notifications/*.py` 100%, cumulative ≥ 95% (mirror M4 cel).
+
+**Smoke manual:**
+- D23: `migrate bedmages` clean, admin shows BedmageWatch.
+- D24: `add_bedmage_watch(user, "TestChar")` w shell, weryfikacja DB.
+- D25: `get_bedmage_handler()` resolves LoggingHandler, manual `.notify(watch)` emituje log.
+- D26: `addBedmageWatch` + force `scrape_watched_characters.delay()` → log entry z `LoggingHandler`.
+- D27: GraphiQL `/graphql/`: addBedmageWatch mutation + myBedmages query z JWT.
+
+---
+
+## 8. Definition of Done (M5)
+
+- [ ] **5 PR merged, 5 Issues zamknięte** (D23-D27).
+- [ ] **`apps.bedmages` + `apps.notifications` zarejestrowane w `INSTALLED_APPS`**, migracje aplikują się czysto.
+- [ ] **`BedmageWatch` widoczne w Django admin** z list_display + filter + search.
+- [ ] **`add_bedmage_watch` + `remove_bedmage_watch` + `check_bedmage_watches_for_character` działają w shell** (manual smoke).
+- [ ] **Settings `BEDMAGE_REGEN_MINUTES` + `BEDMAGE_NOTIFICATION_HANDLER`** dostępne, default values działają.
+- [ ] **Integration z `scrape_watched_characters`** — manual smoke pokazuje `LoggingHandler.notify` log entry po scrape postaci która ma BedmageWatch.
+- [ ] **GraphQL `myBedmages` query bez JWT** → error response (mirror M4-D22 auth pattern).
+- [ ] **GraphQL `addBedmageWatch` + `removeBedmageWatch` mutations** działają z JWT, error gdy bez auth.
+- [ ] **Wszystkie pre-commit + CI zielone** dla każdego PR-a.
+- [ ] **`coverage threshold = 70` zachowane**, lokalnie 100% dla `apps/bedmages/*.py` i `apps/notifications/*.py`.
+- [ ] **PROGRESS.md** rozszerzony o sekcję M5 z retro per Issue.
+- [ ] **Milestone M5 zamknięty** na GitHub.
+
+---
+
+## 9. Open questions / future
+
+**Otwarte (nie blokujące M5, do decyzji w M6+):**
+- **Per-watch custom interval** — `BedmageWatch.regen_minutes: PositiveIntegerField(null=True)` field z fallback do `settings.BEDMAGE_REGEN_MINUTES`. Useful gdy gracz ma postać z różnym regen rate (vocation differences, mage spell). M-future.
+- **Bedmage statistics** — query `myBedmageStats` zwraca `{watches_active: 5, total_notifications_sent: 47}`. M6+ z Discord bot w play.
+- **Watchdog "character no longer being scraped" alarm** — jeśli `Character.last_scraped_at < now - 1h`, BedmageWatch może być "uśpiony" (postać deleted, banned, etc). M6+ razem z notification infra.
+- **Rate limit `addBedmageWatch`** — user może spam'ować mutations. M5 nie limit'uje, M-future doda `django-ratelimit` jeśli abuse się pojawi.
+- **Bedmage history** — log każdej notyfikacji (`BedmageNotification` model: `watch`, `notified_at`, `delta_minutes`). Useful dla debug + statistics. M-future.
+- **Discord channel routing dla M6** — czy notyfikacja idzie na DM user'a, czy na konkretny channel jaki user wybrał? Decyzja w M6.
+
+**Z M5 pre-flight do potwierdzenia w D23:**
+- Nazwa katalogu `apps/notifications/` — singular vs plural? Convention w repo: `apps/characters/` (plural), `apps/accounts/` (plural), `apps/deaths/` (plural). Plural OK.
+- `BedmagesConfig.label = "bedmages"` lub `"bedmage"`? Konwencja: `characters` (plural), `accounts` (plural), `deaths` (plural). Plural.
+- `apps.notifications.apps.NotificationsConfig` z `label = "notifications"`.
+
+---
+
+## 10. Decision points dla user'a (review request)
+
+Przed start'em D23, **prosi review następujących decyzji** (Sekcja 4):
+
+1. **§4.1 Auto-create Character w `addBedmageWatch`** — propozycja: TAK (lazy fetch). OK?
+2. **§4.2 Hard vs soft delete dla `removeBedmageWatch`** — propozycja: HARD. OK?
+3. **§4.3 Notification handler abstraction w M5** — propozycja: TAK (`apps/notifications/` package). OK?
+4. **§4.4 Tracker fire trigger** — propozycja: w `scrape_watched_characters` post-success. OK?
+5. **§4.5 Tracker scope** — propozycja: scrape wszystkich Characters, filter dopiero w trackerze. OK?
+6. **§4.6 GraphQL mutations error handling** — propozycja: raise dla add-duplicate, idempotent dla remove. OK?
+7. **§4.7 FK on_delete dla `BedmageWatch.character` + `BedmageWatch.user`** — propozycja: CASCADE oba. OK?
+
+Plus open questions z §9 — czy któreś chcesz przesunąć do M5 (rozszerzenie scope) zamiast M-future?


### PR DESCRIPTION
M5 setup po zamknięciu M4. Obejmuje:

  ## Summary

  - **Design spec** (`docs/superpowers/specs/2026-05-08-m5-bedmage-tracker-design.md`, ~437 linii) — sekcje 1-9 mirror M4: cel, scope, architektura z flow diagram, **7 decyzji designowych zaakceptowanych przez developera
  2026-05-08** (auto-create Character, hard delete, notification handler abstraction, tracker fire trigger, scope, mutations error handling, FK CASCADE), 5 D-tasks split, integration points (M3 task, M2 GraphQL, future M6),
  test plan, DoD, open questions.
  - **Implementation plan** (`docs/superpowers/plans/2026-05-08-m5-implementation-plan.md`, ~330 linii) — pre-flight checklist, resolved decisions, risk + mitigation table, 5 task overview z timing, spec section refs.
  - **5 issue body files** (`.github/issue-bodies/m5-d23.md` — `m5-d27.md`) — gotowe do `gh issue create --body-file`. Każdy ~150-310 linii: header, cel, czego się nauczysz, AC z code snippets, sugerowane kroki, pułapki,
  testing plan, doc links, DoD.

  ## M5 zakres (świadomie wąski)

  - W: `apps/bedmages/` (model, services, GraphQL), `apps/notifications/` (handler abstraction + LoggingHandler default), tracker integration w `scrape_watched_characters`, `BEDMAGE_REGEN_MINUTES` +
  `BEDMAGE_NOTIFICATION_HANDLER` settings.
  - Poza: Discord bot (M6), real Discord notification handler (M6 swap), per-watch custom interval (M-future).

  ## Po merge

  - [ ] Stworzyć GitHub milestone "M5 — Bedmage tracker (backend)"
  - [ ] Utworzyć 5 issues przez `gh issue create --body-file .github/issue-bodies/m5-d23.md --title "[M5-D23] ..." --milestone "M5 — ..." --label phase-M5,app:bedmages,type:feat`
  - [ ] Zacząć D23 — `feat/<#>-bedmages-app-model` od fresh master

  ## Test plan

  Brak — czysta zmiana docs.