### PR TITLE
feat(bedmages): integrate tracker in scrape_watched_characters task (M5-D26, #97)

### DIFF
--- a/apps/characters/tasks.py
+++ b/apps/characters/tasks.py
@@ -55,6 +55,19 @@ def scrape_watched_characters(self: Task) -> dict[str, int]:
         )
         if result.returncode == 0:
             scraped += 1
+            try:
+                character = Character.objects.get(name=name)
+                from apps.bedmages.services import (
+                    check_bedmage_watches_for_character,
+                )
+
+                check_bedmage_watches_for_character(character)
+            except Character.DoesNotExist:
+                logger.warning(
+                    "Character %s vanished mid-scrape, skipping bedmage check", name
+                )
+            except Exception:
+                logger.exception("bedmage check failed for character %s", name)
         else:
             failed += 1
             logger.warning(

--- a/tests/integration/test_celery_e2e.py
+++ b/tests/integration/test_celery_e2e.py
@@ -10,6 +10,7 @@ testów (post-M3). Tu chodzi o **logikę tasku**, nie o transport Celery.
 
 from __future__ import annotations
 
+import logging
 import subprocess
 import sys
 from datetime import timedelta
@@ -20,6 +21,22 @@ from django.utils import timezone
 
 from apps.characters.models import Character
 from apps.characters.tasks import scrape_watched_characters
+
+
+def _make_stale_character(name: str = "Yhral") -> Character:
+    """Create a Character whose last_scraped_at is stale enough to bypass the
+    freshness filter in `scrape_watched_characters`.
+
+    Forces `last_scraped_at = now - 2h` so the task's 30 min freshness threshold
+    treats it as eligible for scraping. Uses `.update()` to bypass `auto_now`
+    semantics on `last_scraped_at` (M3-D17 retro #5).
+    """
+    char = Character.objects.create(name=name)
+    Character.objects.filter(pk=char.pk).update(
+        last_scraped_at=timezone.now() - timedelta(hours=2)
+    )
+    char.refresh_from_db()
+    return char
 
 
 @pytest.mark.django_db(transaction=True)
@@ -66,3 +83,82 @@ def test_scrape_watched_characters_full_flow_mixed_freshness(
 
     tester_last_scraped_after = Character.objects.get(pk=tester.pk).last_scraped_at
     assert tester_last_scraped_after == tester_last_scraped_before
+
+
+# === D26 tracker integration tests ===
+
+
+@pytest.mark.django_db(transaction=True)
+@mock.patch("apps.bedmages.services.check_bedmage_watches_for_character")
+@mock.patch("apps.characters.tasks.subprocess.run")
+def test_scrape_watched_characters_invokes_bedmage_check_on_success(
+    mock_run: mock.MagicMock,
+    mock_check: mock.MagicMock,
+) -> None:
+    """Tracker called per scraped character (returncode=0).
+
+    Verifies the post-scrape integration hook from D26: every successful scrape
+    fires `check_bedmage_watches_for_character` with the corresponding Character.
+
+    Patch target is `apps.bedmages.services.*` (NOT `apps.characters.tasks.*`)
+    because `tasks.py` lazy-imports the function inside the loop — the patch
+    intercepts at the source module so the lazy import returns the MagicMock.
+    """
+    _make_stale_character("Yhral")
+    mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+
+    result = scrape_watched_characters.apply().get()
+
+    assert result == {"scraped": 1, "failed": 0, "skipped": 0}
+    mock_check.assert_called_once()
+    called_with = mock_check.call_args[0][0]
+    assert called_with.name == "Yhral"
+
+
+@pytest.mark.django_db(transaction=True)
+@mock.patch("apps.bedmages.services.check_bedmage_watches_for_character")
+@mock.patch("apps.characters.tasks.subprocess.run")
+def test_scrape_watched_characters_does_not_invoke_tracker_on_failure(
+    mock_run: mock.MagicMock,
+    mock_check: mock.MagicMock,
+) -> None:
+    """Failed scrape (returncode != 0) skips tracker — §4.5 invariant.
+
+    Tracker decisions must not fire on potentially stale `last_login` from a
+    failed scrape. Otherwise a "phantom bed-mage wake" notification could be
+    emitted while the character's actual state was never refreshed. Regression
+    guard for the design invariant from spec §4.5.
+    """
+    _make_stale_character("Yhral")
+    mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1)
+
+    scrape_watched_characters.apply().get()
+
+    mock_check.assert_not_called()
+
+
+@pytest.mark.django_db(transaction=True)
+@mock.patch("apps.bedmages.services.check_bedmage_watches_for_character")
+@mock.patch("apps.characters.tasks.subprocess.run")
+def test_scrape_watched_characters_logs_but_continues_on_tracker_exception(
+    mock_run: mock.MagicMock,
+    mock_check: mock.MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tracker exception caught and logged — scrape success metrics intact.
+
+    Defensive isolation: a bug in `apps.bedmages.services` must not bump the
+    `failed` counter (the scrape itself succeeded). Failure surfaces via
+    `logger.exception` for observability without polluting the Celery task
+    return value. Critical for production: tracker bugs would otherwise mask
+    real scrape problems in monitoring dashboards.
+    """
+    _make_stale_character("Yhral")
+    mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+    mock_check.side_effect = RuntimeError("simulated tracker failure")
+
+    with caplog.at_level(logging.ERROR, logger="apps.characters.tasks"):
+        result = scrape_watched_characters.apply().get()
+
+    assert result == {"scraped": 1, "failed": 0, "skipped": 0}
+    assert any("bedmage check failed" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary

- Wired `check_bedmage_watches_for_character` (D24 service) into `apps/characters/tasks.py:scrape_watched_characters` post-scrape hook — tracker fires only on `result.returncode == 0` (§4.5 invariant).
- **Defensive isolation**: lazy import + `try/except (Character.DoesNotExist, Exception)` ensures tracker bugs cannot bump the `failed` counter or crash the Celery task.
- 3 new integration tests in `tests/integration/test_celery_e2e.py` covering: tracker invoked on success, NOT invoked on failure (regression guard for §4.5), exception logged + scrape metrics intact. Plus `_make_stale_character` test helper extracted from M3-D17 inline pattern.
- Coverage: `apps/characters/tasks.py` 95% (37 stmts, 2 missed — both pre-existing M2 ping/M3 warning lines, all D26-added code 100% covered).

## Decisions

- **Lazy import inside `try` block, not module-top** (Pułapka A) — `from apps.bedmages.services import check_bedmage_watches_for_character` lives inside `scrape_watched_characters`. Top-level import would create a circular dependency the moment any reverse import path appears (`apps.bedmages.services → apps.characters.tasks`). `sys.modules` caches after first call so per-iteration cost is negligible.
- **Tracker fires ONLY in `if result.returncode == 0` branch** (§4.5 invariant) — failed scrape means `last_login` is potentially stale; tracker decisions on stale data would emit phantom "bed-mage wake" notifications. Test `test_scrape_watched_characters_does_not_invoke_tracker_on_failure` is the regression guard.
- **`Character.DoesNotExist` defensive catch** — handles the (unlikely) race where an admin deletes the character between `Character.objects.values_list` iteration and `Character.objects.get(name=name)`. Logged at WARNING, not crashed.
- **Broad `except Exception` with `logger.exception`** (Pułapka F) — tracker is "best effort" in M5; bugs in `apps.bedmages.services` (None pointer, DB connection) must not pollute `failed` counter. `logger.exception` carries traceback automatically — `logger.error` would lose it. M3 retro #61 lesson on single failure mode.
- **Mock target: `apps.bedmages.services.*`, NOT `apps.characters.tasks.*`** in tests — because the import is lazy, patching at the source module makes the lazy import return the MagicMock. Patching the target module fails (the symbol doesn't exist there until first call).

## Test plan

- [x] `poetry run pytest tests/integration/test_celery_e2e.py -v --cov=apps.characters.tasks` — **4 passed** (1 existing + 3 new), tasks.py 95% (D26 lines 100%)
- [x] `test_scrape_watched_characters_invokes_bedmage_check_on_success` — verifies handler called with correct Character instance
- [x] `test_scrape_watched_characters_does_not_invoke_tracker_on_failure` — §4.5 regression guard
- [x] `test_scrape_watched_characters_logs_but_continues_on_tracker_exception` — defensive isolation: `result == {"scraped": 1, "failed": 0, ...}` even when tracker raises
- [x] Existing `test_scrape_watched_characters_full_flow_mixed_freshness` (M3-D17) still passes — no regression
- [x] Pre-commit zielony (ruff, ruff-format, mypy, gitleaks, conventional-pre-commit, mixed-line-ending auto-fix)
- [ ] CI lint + test zielone
- [ ] Smoke manual end-to-end (D24+D25+D26 chain): `add_bedmage_watch` + force `last_login` past + `scrape_watched_characters.apply()` → expect `BEDMAGE: ...` log; second run → expect no log (idempotency)

## Out of scope

- GraphQL `myBedmages` query + `addBedmageWatch`/`removeBedmageWatch` mutations + e2e + M5 closure — D27 (#98)

Closes #97