### PR TITLE
feat(bedmages): GraphQL queries + mutations + e2e (M5-D27, #98)

### DIFF
--- a/apps/bedmages/schema.py
+++ b/apps/bedmages/schema.py
@@ -1,0 +1,68 @@
+from typing import cast
+
+import strawberry
+import strawberry_django
+from strawberry import auto
+
+from apps.bedmages.models import BedmageWatch
+from apps.bedmages.services import (
+    add_bedmage_watch,
+    remove_bedmage_watch,
+)
+from apps.characters.schema import CharacterType
+
+
+@strawberry_django.type(BedmageWatch)
+class BedmageWatchType:
+    id: auto
+    created_at: auto
+    last_notified_login: auto
+    active: auto
+    character: CharacterType
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    async def my_bedmages(self, info: strawberry.Info) -> list[BedmageWatchType]:
+        request = info.context.request
+        if not request.user.is_authenticated:
+            raise PermissionError("Authentication required")
+
+        qs = (
+            BedmageWatch.objects.filter(user=request.user)
+            .select_related("character")
+            .order_by("-created_at")
+        )
+        return cast("list[BedmageWatchType]", [w async for w in qs])
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    async def add_bedmage_watch(
+        self, info: strawberry.Info, character_name: str
+    ) -> BedmageWatchType:
+        request = info.context.request
+        if not request.user.is_authenticated:
+            raise PermissionError("Authentication required")
+
+        from asgiref.sync import sync_to_async
+
+        watch = await sync_to_async(add_bedmage_watch)(request.user, character_name)
+        return cast("BedmageWatchType", watch)
+
+    @strawberry.mutation
+    async def remove_bedmage_watch(
+        self, info: strawberry.Info, character_name: str
+    ) -> bool:
+        request = info.context.request
+        if not request.user.is_authenticated:
+            raise PermissionError("Authentication required")
+
+        from asgiref.sync import sync_to_async
+
+        deleted = await sync_to_async(remove_bedmage_watch)(
+            request.user, character_name
+        )
+        return deleted

--- a/config/schema.py
+++ b/config/schema.py
@@ -3,6 +3,11 @@ from strawberry.tools import merge_types
 from apps.accounts.schema import Query as AccountsQuery
 from apps.characters.schema import Query as CharactersQuery
 from apps.deaths.schema import Query as DeathsQuery
+from apps.bedmages.schema import Mutation as BedmagesMutation, Query as BedmagesQuery
 
-Query = merge_types("Query", (AccountsQuery, CharactersQuery, DeathsQuery))
-schema = strawberry.Schema(query=Query)
+
+Query = merge_types(
+    "Query", (AccountsQuery, CharactersQuery, DeathsQuery, BedmagesQuery)
+)
+Mutation = merge_types("Mutation", (BedmagesMutation,))
+schema = strawberry.Schema(query=Query, mutation=Mutation)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,11 @@ DJANGO_SETTINGS_MODULE = "config.settings.dev"
 python_files = ["test_*.py"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+[tool.coverage.run]
+omit = [
+    # TypedDict modules — fields are type hints, not executable at runtime.
+    # Coverage counts them as statements but they never execute, producing
+    # a false 0% reading. Exclude rather than fake-test type annotations.
+    "apps/*/types.py",
+]

--- a/tests/integration/test_m5_bedmages_e2e.py
+++ b/tests/integration/test_m5_bedmages_e2e.py
@@ -1,0 +1,75 @@
+"""E2E integration test for M5 — full chain: addBedmageWatch → tracker → handler.
+
+Spec M5 §5/D27: addBedmageWatch via service → force Character.last_login past
+threshold → invoke check_bedmage_watches_for_character → verify the configured
+notification handler was called once with the correct watch. Second invocation
+must be a no-op (idempotency invariant from CLAUDE.md §7).
+
+Mocks `LoggingHandler.notify` — the M5 default handler. Doesn't go through
+the GraphQL layer (the unit tests cover that boundary); this verifies the
+business-logic chain D24+D25 wires up end-to-end.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+from django.test import override_settings
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.bedmages.services import (
+    add_bedmage_watch,
+    check_bedmage_watches_for_character,
+)
+from apps.characters.models import Character
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(BEDMAGE_REGEN_MINUTES=100)
+@mock.patch("apps.notifications.handlers.LoggingHandler.notify")
+def test_e2e_add_bedmage_watch_then_check_fires_handler(
+    mock_notify: mock.MagicMock,
+) -> None:
+    """Full M5 chain — first check fires handler, second is idempotent no-op.
+
+    Step 1: addBedmageWatch creates watch + Character (lazy fetch §4.1).
+    Step 2: force Character.last_login = now - 120 min (>= REGEN_MINUTES).
+    Step 3: check_bedmage_watches_for_character → fired=1, handler.notify called
+            once with the watch, last_notified_login persisted on the row.
+    Step 4: re-run check immediately — fired=0, handler.notify NOT called again.
+            Asserts the idempotency invariant (last_notified_login ==
+            character.last_login → skip).
+    """
+    user = User.objects.create_user(
+        username="tester", email="t@example.com", password="ComplexPass!123"
+    )
+
+    watch = add_bedmage_watch(user, "Yhral")
+    assert watch.character.name == "Yhral"
+    assert watch.active is True
+    assert watch.last_notified_login is None
+
+    Character.objects.filter(name="Yhral").update(
+        last_login=timezone.now() - timedelta(minutes=120)
+    )
+    character = Character.objects.get(name="Yhral")
+
+    fired = check_bedmage_watches_for_character(character)
+
+    assert fired == 1
+    assert mock_notify.call_count == 1
+    notified_watch = mock_notify.call_args[0][0]
+    assert notified_watch.character.name == "Yhral"
+    assert notified_watch.user_id == user.pk
+
+    watch.refresh_from_db()
+    assert watch.last_notified_login == character.last_login
+
+    mock_notify.reset_mock()
+    fired_again = check_bedmage_watches_for_character(character)
+
+    assert fired_again == 0
+    assert mock_notify.call_count == 0

--- a/tests/unit/bedmages/test_graphql_bedmages.py
+++ b/tests/unit/bedmages/test_graphql_bedmages.py
@@ -1,0 +1,288 @@
+"""Tests for myBedmages query + addBedmageWatch / removeBedmageWatch mutations.
+
+Mirror of M4-D22 pattern (`tests/unit/deaths/test_graphql_recent_deaths.py`):
+JWT auth via `AccessToken.for_user`, AsyncClient against /graphql/, async
+resolvers exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from asgiref.sync import sync_to_async
+from django.test import AsyncClient
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.accounts.models import User
+from apps.bedmages.models import BedmageWatch
+from apps.characters.models import Character
+
+GRAPHQL_URL = "/graphql/"
+
+
+async def _post_query(
+    client: AsyncClient,
+    query: str,
+    bearer: str | None = None,
+) -> dict[str, object]:
+    headers = {"Authorization": f"Bearer {bearer}"} if bearer else {}
+    response = await client.post(
+        GRAPHQL_URL,
+        data=json.dumps({"query": query}),
+        content_type="application/json",
+        headers=headers,
+    )
+    assert response.status_code == 200, response.content
+    return response.json()
+
+
+async def _make_user_and_token(
+    username: str = "alice", email: str | None = None
+) -> tuple[User, str]:
+    user = await sync_to_async(User.objects.create_user)(
+        username=username,
+        email=email or f"{username}@example.com",
+        password="ComplexPass!123",
+    )
+    bearer = await sync_to_async(lambda: str(AccessToken.for_user(user)))()
+    return user, bearer
+
+
+# === myBedmages query ===
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_my_bedmages_filters_by_request_user() -> None:
+    """`myBedmages` returns ONLY the requesting user's watches.
+
+    Security invariant — must never leak other users' bedmage subscriptions
+    (would expose social graph + character names). Seeds 2 users with watches,
+    queries as user A, asserts B's watch is not returned.
+    """
+    user_a, bearer_a = await _make_user_and_token("alice")
+    user_b, _ = await _make_user_and_token("bob")
+
+    def _seed() -> None:
+        char1 = Character.objects.create(name="Yhral")
+        char2 = Character.objects.create(name="Tester")
+        char3 = Character.objects.create(name="OtherUserChar")
+        BedmageWatch.objects.create(user=user_a, character=char1)
+        BedmageWatch.objects.create(user=user_a, character=char2)
+        BedmageWatch.objects.create(user=user_b, character=char3)
+
+    await sync_to_async(_seed)()
+
+    payload = await _post_query(
+        AsyncClient(),
+        "{ myBedmages { id character { name } active } }",
+        bearer_a,
+    )
+
+    assert "errors" not in payload, payload
+    watches = payload["data"]["myBedmages"]
+    assert len(watches) == 2
+    names = sorted(w["character"]["name"] for w in watches)
+    assert names == ["Tester", "Yhral"]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_my_bedmages_requires_authentication() -> None:
+    """No JWT → resolver raises PermissionError → Strawberry surfaces as errors[]."""
+    payload = await _post_query(
+        AsyncClient(),
+        "{ myBedmages { id } }",
+        bearer=None,
+    )
+
+    assert "errors" in payload
+    error_msg = payload["errors"][0]["message"]
+    assert "Authentication" in error_msg or "auth" in error_msg.lower()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_my_bedmages_returns_empty_list_for_user_without_watches() -> None:
+    """User with 0 watches → empty list, NOT null and NOT error.
+
+    Distinguishes "no subscriptions" from "auth failed" for the client.
+    """
+    _, bearer = await _make_user_and_token("nobody")
+
+    payload = await _post_query(
+        AsyncClient(),
+        "{ myBedmages { id } }",
+        bearer,
+    )
+
+    assert "errors" not in payload, payload
+    assert payload["data"]["myBedmages"] == []
+
+
+# === addBedmageWatch mutation ===
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_add_bedmage_watch_creates_with_existing_character() -> None:
+    """Mutation creates BedmageWatch when Character already exists in DB."""
+    user, bearer = await _make_user_and_token("alice")
+    await sync_to_async(Character.objects.create)(name="Yhral")
+
+    mutation = """
+    mutation {
+        addBedmageWatch(characterName: "Yhral") {
+            id
+            active
+            character { name }
+        }
+    }
+    """
+
+    payload = await _post_query(AsyncClient(), mutation, bearer)
+
+    assert "errors" not in payload, payload
+    data = payload["data"]["addBedmageWatch"]
+    assert data["active"] is True
+    assert data["character"]["name"] == "Yhral"
+
+    count = await sync_to_async(BedmageWatch.objects.filter(user=user).count)()
+    assert count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_add_bedmage_watch_creates_character_lazily() -> None:
+    """§4.1 lazy fetch via GraphQL: Character is auto-created when missing.
+
+    Verifies the get_or_create path in add_bedmage_watch service surfaces
+    correctly through the Strawberry mutation — no separate "create character"
+    step required from the client.
+    """
+    _, bearer = await _make_user_and_token("alice")
+    pre_count = await sync_to_async(Character.objects.filter(name="NewChar").count)()
+    assert pre_count == 0
+
+    mutation = """
+    mutation {
+        addBedmageWatch(characterName: "NewChar") {
+            character { name }
+        }
+    }
+    """
+
+    payload = await _post_query(AsyncClient(), mutation, bearer)
+
+    assert "errors" not in payload, payload
+    assert payload["data"]["addBedmageWatch"]["character"]["name"] == "NewChar"
+
+    post_count = await sync_to_async(Character.objects.filter(name="NewChar").count)()
+    assert post_count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_add_bedmage_watch_raises_on_duplicate_active_watch() -> None:
+    """Second add for same (user, character) when already active → errors[]."""
+    user, bearer = await _make_user_and_token("alice")
+    char = await sync_to_async(Character.objects.create)(name="Yhral")
+    await sync_to_async(BedmageWatch.objects.create)(
+        user=user, character=char, active=True
+    )
+
+    mutation = """
+    mutation {
+        addBedmageWatch(characterName: "Yhral") { id }
+    }
+    """
+
+    payload = await _post_query(AsyncClient(), mutation, bearer)
+
+    assert "errors" in payload
+    assert "already exists" in payload["errors"][0]["message"]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_add_bedmage_watch_requires_authentication() -> None:
+    """No JWT → mutation refused via PermissionError."""
+    mutation = """
+    mutation {
+        addBedmageWatch(characterName: "Yhral") { id }
+    }
+    """
+
+    payload = await _post_query(AsyncClient(), mutation, bearer=None)
+
+    assert "errors" in payload
+    error_msg = payload["errors"][0]["message"]
+    assert "Authentication" in error_msg or "auth" in error_msg.lower()
+
+
+# === removeBedmageWatch mutation ===
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_remove_bedmage_watch_returns_true_when_existing() -> None:
+    """Existing watch → hard delete, return True, row gone from DB."""
+    user, bearer = await _make_user_and_token("alice")
+    char = await sync_to_async(Character.objects.create)(name="Yhral")
+    await sync_to_async(BedmageWatch.objects.create)(user=user, character=char)
+
+    mutation = """
+    mutation {
+        removeBedmageWatch(characterName: "Yhral")
+    }
+    """
+
+    payload = await _post_query(AsyncClient(), mutation, bearer)
+
+    assert "errors" not in payload, payload
+    assert payload["data"]["removeBedmageWatch"] is True
+
+    remaining = await sync_to_async(
+        BedmageWatch.objects.filter(user=user, character=char).count
+    )()
+    assert remaining == 0
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_remove_bedmage_watch_returns_false_when_not_found() -> None:
+    """§4.6 idempotency: missing watch returns False, NOT errors[].
+
+    Lets the UI safely retry/spam remove without surfacing auth-vs-state
+    ambiguity to the user.
+    """
+    _, bearer = await _make_user_and_token("alice")
+
+    mutation = """
+    mutation {
+        removeBedmageWatch(characterName: "Nonexistent")
+    }
+    """
+
+    payload = await _post_query(AsyncClient(), mutation, bearer)
+
+    assert "errors" not in payload, payload
+    assert payload["data"]["removeBedmageWatch"] is False
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_remove_bedmage_watch_requires_authentication() -> None:
+    """No JWT → mutation refused via PermissionError."""
+    mutation = """
+    mutation {
+        removeBedmageWatch(characterName: "Yhral")
+    }
+    """
+
+    payload = await _post_query(AsyncClient(), mutation, bearer=None)
+
+    assert "errors" in payload
+    error_msg = payload["errors"][0]["message"]
+    assert "Authentication" in error_msg or "auth" in error_msg.lower()

--- a/tests/unit/bedmages/test_models.py
+++ b/tests/unit/bedmages/test_models.py
@@ -1,0 +1,27 @@
+"""Tests for apps.bedmages.models — minimal coverage of __str__ formatting."""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.bedmages.models import BedmageWatch
+from apps.characters.models import Character
+from apps.accounts.models import User
+
+
+@pytest.mark.django_db
+def test_bedmage_watch_str_includes_username_and_character_name() -> None:
+    """`__str__` reads "<username> watching <character_name>".
+
+    Format is consumed by Django admin (list_display falls back to __str__ if a
+    field doesn't render) and by tests/services that log the watch instance.
+    Pinning the format prevents accidental changes from silently breaking the
+    admin row label.
+    """
+    user = User.objects.create_user(
+        username="alice", email="alice@example.com", password="ComplexPass!1"
+    )
+    character = Character.objects.create(name="Yhral")
+    watch = BedmageWatch.objects.create(user=user, character=character)
+
+    assert str(watch) == "alice watching Yhral"


### PR DESCRIPTION
## Summary

- New `apps/bedmages/schema.py` with `BedmageWatchType` (Strawberry-Django auto FK resolution), `Query.my_bedmages` (JWT-protected, user-scoped), and **first `Mutation` type in the project** — `addBedmageWatch` (lazy-fetch via service §4.1) + `removeBedmageWatch` (idempotent §4.6).
- `config/schema.py` extended with `merge_types("Mutation", (BedmagesMutation,))` + `mutation=Mutation` parameter on `strawberry.Schema(...)`. Without that parameter the mutations are silently invisible to clients (verified empirically during review).
- 10 unit tests covering query (3) + add mutation (4) + remove mutation (3), plus 1 E2E integration test wiring the full D24+D25+D26 chain (`add_bedmage_watch` → `check_bedmage_watches_for_character` → `LoggingHandler.notify`) with idempotency assertion.
- New `tests/unit/bedmages/test_models.py` for `__str__` coverage.
- `pyproject.toml` `[tool.coverage.run]` excludes `apps/*/types.py` (TypedDict modules — type hints, not executable; coverage tool counts them as 0% statements that never run).
- Cumulative `apps/bedmages/*` + `apps/notifications/*` coverage: **100%** (140/140 stmts, 28 tests passed). Exceeds DoD §8 ≥95% requirement.

## Decisions

- **`mutation=Mutation` parameter on `strawberry.Schema(...)`** — without it the schema SDL omits the entire `type Mutation { ... }` and clients get `"Cannot query field 'addBedmageWatch'"`. Easy miss because Query works fine without an analogous parameter (Strawberry has a Query default). Sanity check via `schema.as_str() | grep -i mutation` is now baseline for any future Mutation-introducing milestone.
- **`merge_types("Mutation", (BedmagesMutation,))`** — single-source tuple needs trailing comma (`(X,)`, not `(X)` which is redundant parens, not a tuple). Pułapka D from issue body.
- **`await sync_to_async(service)(...)` in mutations** — services are sync (Django ORM); Strawberry resolvers are async. The wrap converts at the boundary (M2-D11 precedent in `apps/accounts/schema.py:29`).
- **`.select_related("character")` in `my_bedmages` queryset** — eliminates `SynchronousOnlyOperation` when the resolver async-iterates and the client requests nested `character { ... }` fields. Async ORM lazy-loads FKs synchronously which crashes under `[w async for w in qs]`.
- **`cast("BedmageWatchType", ...)` with string forward reference** — Strawberry-Django returns model instances; mypy needs the explicit cast to recognize them as the type-decorated wrapper. Same pattern as M4-D22.
- **`removeBedmageWatch` returns `bool`, not raises** (§4.6) — lets the UI safely retry/spam without showing auth-vs-state ambiguity. Test `test_remove_bedmage_watch_returns_false_when_not_found` enforces.
- **`apps/*/types.py` excluded from coverage** — TypedDict definitions are type hints, not executable code. The coverage tool counts them as statements but never executes them, producing a misleading 0% reading. Standard exclusion rather than fake-test type annotations.

## Test plan

- [x] `poetry run pytest tests/unit/bedmages/ tests/unit/notifications/ tests/integration/test_m5_bedmages_e2e.py --cov=apps.bedmages --cov=apps.notifications` — **28 passed, 100% cumulative coverage** (140/140 stmts, 0 missed, post types.py exclude)
- [x] 10 unit tests covering: `myBedmages` user filtering / auth / empty list, `addBedmageWatch` existing+lazy character / duplicate / auth, `removeBedmageWatch` happy / idempotent / auth
- [x] E2E test `test_e2e_add_bedmage_watch_then_check_fires_handler` exercises full chain twice — first call fires handler once + persists `last_notified_login`; second call is no-op (idempotency invariant from CLAUDE.md §7 verified end-to-end)
- [x] SDL sanity: `from config.schema import schema; "type Mutation" in schema.as_str()` → `True`
- [x] Pre-commit zielony (ruff, ruff-format, mypy, gitleaks, conventional-pre-commit, mixed-line-ending auto-fix)
- [ ] CI lint + test zielone
- [ ] Smoke manual via GraphiQL (5 punktów AC) — login REST → JWT → mutation `addBedmageWatch` → query `myBedmages` → mutation `removeBedmageWatch` (true → false on retry) → unauthenticated query → errors[]

## Out of scope

- M5 closure — separate `docs/close-m5-tracker` PR will update `docs/PROGRESS.md` (M5 section: 🚧 IN PROGRESS → 🎉 COMPLETED), retro per D23-D27, milestone close via `gh api -X PATCH .../milestones/<#> -f state=closed`

Closes #98