### PR TITLE
chore(pre-commit): block direct commits to master via no-commit-to-branch hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,8 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         args: [--fix=lf]
+      - id: no-commit-to-branch
+        args: [--branch, master]
 
   # Ruff (lint + format) — jedyny linter/formatter Pythona
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
## Summary

Adds the `no-commit-to-branch` hook from the existing `pre-commit-hooks` repo (`v5.0.0`, already pinned) to `.pre-commit-config.yaml`. Configured with `args: [--branch, master]` to block any direct `git commit` while `HEAD` is on `master`.

```yaml
- id: no-commit-to-branch
  args: [--branch, master]
```

## Why now

During the M5 session there were **two process incidents** where a feature commit landed on local `master` because the user forgot `git checkout -b feat/<#>-...` after cleanup of the previous branch. Recovery procedure:

```bash
git branch feat/<N>-<slug>      # save commit on a new branch
git reset --hard origin/master  # rollback master (destructive)
git checkout feat/<N>-<slug>
git push -u origin feat/<N>-<slug>
```

Each incident cost a `git reset --hard` (destructive — required user confirmation per system prompt rules) plus a separate push step. With the hook in place, `git commit` on master fails locally before any of this is needed:

```
don't commit to branch...................................................Failed
- hook id: no-commit-to-branch
- exit code: 1

----------------------------------------------------
You can't commit to branch master.
```

Forcing the dev to switch to a feature branch before the commit happens.

## Decisions

- **Reused `pre-commit-hooks` v5.0.0 instead of a `repo: local` shell hook** — the official hook is cross-platform (no `bash -c` dependency, works on Windows out of the box) and maintained by the pre-commit team. The repo is already pinned in this config (10 other hooks from it), so no new dependency is introduced.
- **`args: [--branch, master]` (single branch, not `master, main`)** — this repo's default branch is `master`. Adding `main` to the list would be defensive against a future rename, but right now it's noise. If we ever rename, the rename PR updates this arg.
- **No `stages:` override** — `no-commit-to-branch` defaults to `commit` stage, which is exactly what we want. The hook runs on `git commit`, not on `pre-commit run --all-files` against staged files (where it would produce noise on every CI run).
- **Hook auto-applies after merge** — `pre-commit install` writes a wrapper to `.git/hooks/pre-commit` that re-reads `.pre-commit-config.yaml` on every commit. Devs who already ran `poetry run pre-commit install` (per CLAUDE.md §12) get the new hook on the next `git pull` without re-installing. Devs who never installed it still need to (also covered by CLAUDE.md §12).

## Test plan

- [x] `poetry run pre-commit validate-config` — yaml syntax valid
- [x] `poetry run pre-commit run no-commit-to-branch --all-files` on a non-master branch — `Passed` (hook allows commits on feature branches)
- [x] Full `poetry run pre-commit run` after staging the config — all hooks green (mixed-line-ending auto-fix + the new hook explicitly Passed)
- [ ] CI lint zielony

## Out of scope

- Branch protection on the GitHub side (carry-over tech debt from M2/M3/M4) — that's a separate Settings change requiring admin access; the local hook is a defense-in-depth layer for the dev's local workflow, not a substitute for branch protection.
- Re-installing pre-commit on the dev machine — covered by CLAUDE.md §12 onboarding step (`poetry run pre-commit install`). One-time setup, not per-PR.

## Per CLAUDE.md §15.12

This PR contains **only** `.pre-commit-config.yaml` changes — no functional code mixed in.