### PR TITLE
docs(m6): add Mongo logging design spec + implementation plan + issue bodies

### DIFF
--- a/.github/issue-bodies/m6-d28.md
+++ b/.github/issue-bodies/m6-d28.md
@@ -1,0 +1,263 @@
+**Milestone:** M6 — Mongo logging
+**Czas:** 2-3h
+**Branch:** `feat/<this-issue-#>-mongo-log-handler`
+**Type:** `feat`
+**Zależy od:** M5 closed + chore PR #105 (no-commit-to-branch hook) merged
+**Spec:** [`docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md`](../blob/master/docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md) §3.1, §3.3-§3.6, §4.1, §6.1, §6.4
+**Plan:** [`docs/superpowers/plans/2026-05-08-m6-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-08-m6-implementation-plan.md) Task #1
+
+---
+
+## 🎯 Cel
+
+Utworzyć `logs_backend/` jako top-level Python package (NIE Django app) z lazy MongoClient singleton, custom `MongoLogHandler` (sync emit, silent fallback do stderr) i `factory_or_null` dispatch'em. Skonfigurować Django `LOGGING` dict w `config/settings/base.py` żeby attached do logger `"apps"` (NIE root). Po D28: każdy `logger.info("...")` w `apps.*` zapisuje 1 dokument do `app_logs` collection.
+
+## 🧠 Czego się nauczysz
+
+- **`logging.Handler` API** — `__init__`, `emit(record)`, `format(record)`, `handleError(record)`. Default `handleError` impl writes to stderr — exact what we need for §3.3.
+- **`pymongo.MongoClient` config** — `serverSelectionTimeoutMS=2000` (fail-fast, §6.4) zamiast default 30s; lazy singleton wzorzec.
+- **Django `LOGGING` dict** (`logging.config.dictConfig` schema) — handler `"mongo"` przez `"()"` factory pattern (callable returning Handler instance). `propagate: False` na logger `"apps"` żeby NIE duplicate emit.
+- **`logging.NullHandler`** — stdlib no-op, używamy gdy `MONGO_URL` empty.
+- **Idempotent `create_index`** — Mongo `create_index(keys, name=...)` jest no-op gdy index już istnieje. Lazy w `get_collection()`.
+
+## ✅ Acceptance criteria
+
+### Pakiet `logs_backend/`
+
+- [ ] `logs_backend/__init__.py`:
+  ```python
+  from __future__ import annotations
+
+  from typing import Optional
+
+  import pymongo
+  from django.conf import settings
+  from pymongo.collection import Collection
+  from pymongo.database import Database
+
+  _client: Optional[pymongo.MongoClient] = None
+  _initialized_collections: set[str] = set()
+
+
+  def get_mongo_client() -> pymongo.MongoClient:
+      """Lazy singleton MongoClient with fail-fast timeouts.
+
+      serverSelectionTimeoutMS=2000 prevents logger.info() from hanging 30s
+      when Mongo is down — fall back to stderr quickly instead (§6.4).
+      """
+      global _client
+      if _client is None:
+          _client = pymongo.MongoClient(
+              settings.MONGO_URL,
+              serverSelectionTimeoutMS=2000,
+              connectTimeoutMS=2000,
+              socketTimeoutMS=2000,
+          )
+      return _client
+
+
+  def get_database() -> Database:
+      return get_mongo_client()[settings.MONGO_DB]
+
+
+  def get_collection(name: str) -> Collection:
+      """Return collection, creating idempotent indexes on first call.
+
+      Index strategy (§3.5):
+      - app_logs: timestamp DESC (most-recent-first debug query).
+      - scrape_logs: spider_name + finished_at DESC (recent runs per spider).
+      """
+      collection = get_database()[name]
+
+      if name not in _initialized_collections:
+          if name == "app_logs":
+              collection.create_index(
+                  [("timestamp", pymongo.DESCENDING)],
+                  name="app_logs_timestamp_desc",
+              )
+          elif name == "scrape_logs":
+              collection.create_index(
+                  [("spider_name", pymongo.ASCENDING), ("finished_at", pymongo.DESCENDING)],
+                  name="scrape_logs_spider_finished_desc",
+              )
+          _initialized_collections.add(name)
+
+      return collection
+  ```
+
+- [ ] `logs_backend/handlers.py`:
+  ```python
+  from __future__ import annotations
+
+  import logging
+  from datetime import datetime, timezone
+
+  from django.conf import settings
+  from pymongo.errors import PyMongoError
+
+  from logs_backend import get_collection
+
+
+  class MongoLogHandler(logging.Handler):
+      """Persist log records to Mongo `app_logs`. Silent stderr fallback on failure.
+
+      Synchronous emit (§3.1): blocks the calling thread for one insert_one
+      roundtrip (~5-50ms on local Mongo, fail-fast 2s on unreachable). Acceptable
+      for low-traffic backend.
+      """
+
+      def __init__(self) -> None:
+          super().__init__()
+          self.collection = get_collection("app_logs")
+          if self.formatter is None:
+              self.setFormatter(logging.Formatter())
+
+      def emit(self, record: logging.LogRecord) -> None:
+          try:
+              doc = {
+                  "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc),
+                  "level": record.levelname,
+                  "logger": record.name,
+                  "message": record.getMessage(),
+                  "module": record.module,
+                  "function": record.funcName,
+                  "line": record.lineno,
+              }
+              if record.exc_info:
+                  doc["exc_info"] = self.formatter.formatException(record.exc_info)
+
+              self.collection.insert_one(doc)
+          except (PyMongoError, Exception):
+              # Standard logging.Handler.handleError: writes formatted record
+              # to sys.stderr. Never break the app from a log call.
+              self.handleError(record)
+
+
+  def factory_or_null() -> logging.Handler:
+      """Return MongoLogHandler if MONGO_URL configured, NullHandler otherwise.
+
+      Wired into Django LOGGING via the `()` factory pattern. Empty MONGO_URL
+      means dev mode without Mongo — app starts cleanly, logs go to console
+      via Django default handlers.
+      """
+      if not settings.MONGO_URL:
+          return logging.NullHandler()
+      return MongoLogHandler()
+  ```
+
+### Django LOGGING config
+
+- [ ] `config/settings/base.py` rozszerzone:
+  ```python
+  LOGGING = {
+      "version": 1,
+      "disable_existing_loggers": False,
+      "handlers": {
+          "console": {
+              "class": "logging.StreamHandler",
+          },
+          "mongo": {
+              "()": "logs_backend.handlers.factory_or_null",
+          },
+      },
+      "loggers": {
+          "apps": {
+              "handlers": ["console", "mongo"],
+              "level": "INFO",
+              "propagate": False,
+          },
+      },
+  }
+  ```
+- [ ] Sanity: `manage.py shell -c "import logging; logging.getLogger('apps.test').info('hello'); from logs_backend import get_collection; c = get_collection('app_logs'); print(c.count_documents({'message': 'hello'}))"` → `1` (lub więcej jeśli kilka razy uruchomione).
+
+### `pymongo` w Poetry
+
+- [ ] `poetry add pymongo` (jeśli nie ma jeszcze). Sprawdź `poetry show pymongo` przed dodaniem.
+- [ ] **Osobny commit** `build(deps): add pymongo for M6 logging` jeśli nowy package.
+
+### Unit testy
+
+- [ ] `tests/unit/logs_backend/__init__.py` (pusty).
+- [ ] `tests/unit/logs_backend/conftest.py` z fixture `mongo_db`:
+  ```python
+  from __future__ import annotations
+
+  import pytest
+  from django.conf import settings as django_settings
+
+  from logs_backend import get_mongo_client
+
+
+  @pytest.fixture
+  def mongo_db():
+      """Yield clean test DB. Drops all collections in teardown."""
+      assert "test" in django_settings.MONGO_DB.lower(), (
+          f"Refusing to clear non-test DB: {django_settings.MONGO_DB!r}"
+      )
+      client = get_mongo_client()
+      db = client[django_settings.MONGO_DB]
+      yield db
+      for collection_name in db.list_collection_names():
+          db[collection_name].drop()
+  ```
+
+- [ ] `tests/unit/logs_backend/test_mongo_log_handler.py` z 8-10 testami (lista w §🧪 Testing plan).
+
+## 📋 Sugerowane kroki
+
+1. `git checkout master && git pull && git checkout -b feat/<#>-mongo-log-handler` ← **PRZED kodowaniem** (no-commit-to-branch hook).
+2. `poetry show pymongo` — jeśli brak: `poetry add pymongo` + osobny commit `build(deps): add pymongo`.
+3. Utwórz `logs_backend/__init__.py` per AC.
+4. Utwórz `logs_backend/handlers.py` per AC.
+5. Dodaj `LOGGING` dict w `config/settings/base.py`.
+6. Smoke: `manage.py shell -c "..."` (sanity z AC).
+7. Utwórz `tests/unit/logs_backend/__init__.py` + `conftest.py` + `test_mongo_log_handler.py`.
+8. `poetry run pytest tests/unit/logs_backend/ -v --cov=logs_backend` → 100%.
+9. Pre-commit + commit + push + PR.
+
+## ⚠️ Pułapki do uwagi
+
+- **A — `logs_backend/` to NIE Django app** — top-level package. NIE dodawaj do `LOCAL_APPS` w `base.py` ani do `INSTALLED_APPS` w `stubs.py`. Brak `apps.py`/`models.py`/migrations. Importowane przez `"()"` factory dispatch w LOGGING dict.
+- **B — `serverSelectionTimeoutMS=2000`** w MongoClient config — bez tego default 30s = `logger.info()` w widoku gdy Mongo down wisi pół minuty. Test `test_emit_returns_quickly_on_mongo_unreachable` enforce'uje przez `time.monotonic()` measurement <2s.
+- **C — `propagate: False`** na logger `"apps"` w LOGGING dict — bez tego logi z `apps.*` lecą przez `["console", "mongo"]` ORAZ przez root logger handlers (Django default) → duplicate output.
+- **D — Lazy singleton thread safety** — pierwszy call między 2 wątkami może utworzyć 2 instancje. **YAGNI:** brak `threading.Lock` — `pymongo.MongoClient` is thread-safe internally, double-init to cosmetic micro-leak.
+- **E — `formatException` z None record.exc_info** — `record.exc_info` jest `None` dla zwykłych INFO/WARNING. Conditional dorzucenie `exc_info` field tylko gdy set: `if record.exc_info: doc["exc_info"] = self.formatter.formatException(record.exc_info)`. Bez tego TypeError przy formatException(None).
+- **F — `MongoLogHandler.__init__` musi mieć formatter** — Django LOGGING dispatch może nie podać explicit. Default `logging.Formatter()` w `__init__` żeby `self.format(record)` (używane przez fallback `handleError`) działało.
+- **G — Test database isolation** — fixture `mongo_db` z drop-on-teardown. `assert "test" in MONGO_DB.lower()` paranoja przed czyszczeniem prod.
+- **H — `MONGO_DB` w testach `tibiantis_logs_test`** — CI ma osobne env var w `ci.yml`. Lokalnie pytest może override. Sanity: assert w fixture.
+
+## 🧪 Testing plan
+
+`tests/unit/logs_backend/test_mongo_log_handler.py`:
+
+1. `test_get_collection_returns_pymongo_collection` — sanity wrap, `assert isinstance(get_collection("app_logs"), Collection)`.
+2. `test_get_collection_creates_index_on_first_call` — pierwsze `get_collection("app_logs")`, assert `"app_logs_timestamp_desc"` w `index_information()`.
+3. `test_get_collection_idempotent_index_creation` — drugi call NIE rzuca.
+4. `test_emit_writes_doc_with_expected_fields` — emit `INFO` record z logger `apps.test`, assert `mongo_db.app_logs.count_documents({}) == 1`, doc ma `level`, `logger`, `message`, `module`, `function`, `line`, `timestamp` (datetime UTC).
+5. `test_emit_includes_exc_info_for_error_records` — `try: raise ValueError("boom") except: logger.exception("failed")`, assert `doc["exc_info"]` zawiera "ValueError" + "boom".
+6. `test_emit_omits_exc_info_for_records_without_exception` — zwykły `logger.info("hi")`, assert `"exc_info" not in doc`.
+7. `test_emit_falls_back_to_stderr_on_mongo_failure` — mock `collection.insert_one` raises `ConnectionFailure`, assert NOT raised; capsys.readouterr().err contains formatted record string.
+8. `test_emit_returns_quickly_on_mongo_unreachable` — patch `MONGO_URL=mongodb://localhost:1` (closed port), build handler, `start = time.monotonic(); handler.emit(record); assert time.monotonic() - start < 3.0`.
+9. `test_factory_returns_null_handler_when_mongo_url_empty` — `@override_settings(MONGO_URL="")`, `factory_or_null()` zwraca `NullHandler` instance.
+10. `test_factory_returns_mongo_handler_when_mongo_url_set` — default settings, factory zwraca `MongoLogHandler`.
+11. `test_django_logging_routes_apps_logger_to_mongo` — `logging.getLogger("apps.test").info("hello world")`, assert collection ma doc z `message="hello world"`.
+
+**Coverage cel:** `logs_backend/__init__.py` 100%, `logs_backend/handlers.py` 100%.
+
+## 🔗 Dokumentacja pomocnicza
+
+- Python `logging.Handler`: https://docs.python.org/3/library/logging.html#logging.Handler
+- `logging.config.dictConfig` schema: https://docs.python.org/3/library/logging.config.html#dictionary-schema-details
+- `pymongo.MongoClient`: https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html
+- `pymongo.Collection.create_index`: https://pymongo.readthedocs.io/en/stable/api/pymongo/collection.html#pymongo.collection.Collection.create_index
+- Django LOGGING dict: https://docs.djangoproject.com/en/6.0/topics/logging/
+
+## 📦 Definition of Done
+
+- [ ] AC spełnione (`logs_backend/`, `MongoLogHandler`, factory, Django LOGGING).
+- [ ] PR zmergowany squash (`feat(logs): add MongoLogHandler + Django LOGGING integration (M6-D28, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] `logs_backend/*.py` 100% coverage.
+- [ ] `pymongo` w `pyproject.toml` (osobny `build(deps)` commit jeśli był brakujący).
+- [ ] Issue zamknięty.

--- a/.github/issue-bodies/m6-d29.md
+++ b/.github/issue-bodies/m6-d29.md
@@ -1,0 +1,164 @@
+**Milestone:** M6 — Mongo logging
+**Czas:** 2-3h
+**Branch:** `feat/<this-issue-#>-mongo-stats-extension`
+**Type:** `feat`
+**Zależy od:** D28 merged
+**Spec:** [`docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md`](../blob/master/docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md) §3.2, §3.3, §3.4, §4.2, §6.2
+**Plan:** [`docs/superpowers/plans/2026-05-08-m6-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-08-m6-implementation-plan.md) Task #2
+
+---
+
+## 🎯 Cel
+
+Utworzyć `scrapers/tibiantis_scrapers/extensions.py` z `MongoStatsExtension` rejestrowanym przez `EXTENSIONS` dict w `scrapers/tibiantis_scrapers/settings.py`. Extension subscribe na Scrapy `signals.spider_opened` (zapisuje `started_at`) + `signals.spider_closed` (buduje doc z `crawler.stats`, `insert_one` do `scrape_logs`). Disabled mode przez `NotConfigured` raise gdy `MONGO_URL` empty. Po D29: każdy `scrapy crawl <spider>` lub Celery scrape task zapisuje 1 doc do `scrape_logs`.
+
+## 🧠 Czego się nauczysz
+
+- **Scrapy Extensions API** — `from_crawler(cls, crawler) -> instance` factory pattern. Returns instance lub raise `scrapy.exceptions.NotConfigured` żeby Scrapy disable cleanly. Subscribe na signals przez `crawler.signals.connect(handler, signal=signals.spider_opened)`.
+- **Scrapy signals** — `spider_opened(spider)` + `spider_closed(spider, reason)`. `reason` ∈ `{"finished", "shutdown", "cancelled", "failed"}`.
+- **`crawler.stats` API** — `crawler.stats.get_stats() -> dict` (raw stats dict). `get_value(key, default)` dla pojedynczych counters.
+- **Scrapy Settings vs Django settings** — Scrapy ma własny `Settings` object z `tibiantis_scrapers/settings.py`. M1-D8 already wired `django.setup()` w `scrapers/.../settings.py` więc `from django.conf import settings as django_settings` działa.
+
+## ✅ Acceptance criteria
+
+### Extension
+
+- [ ] `scrapers/tibiantis_scrapers/extensions.py`:
+  ```python
+  from __future__ import annotations
+
+  import logging
+  from datetime import datetime, timezone
+  from typing import Any
+
+  from django.conf import settings as django_settings
+  from pymongo.errors import PyMongoError
+  from scrapy import signals
+  from scrapy.crawler import Crawler
+  from scrapy.exceptions import NotConfigured
+  from scrapy.spiders import Spider
+
+  from logs_backend import get_collection
+
+  logger = logging.getLogger(__name__)
+
+
+  class MongoStatsExtension:
+      """Persist 1 document per `scrapy crawl <spider>` to scrape_logs (§3.2).
+
+      Wired via EXTENSIONS dict. Disabled cleanly via NotConfigured when
+      MONGO_URL is empty (dev mode without Mongo).
+      """
+
+      def __init__(self) -> None:
+          self.collection = get_collection("scrape_logs")
+          self.started_at: datetime | None = None
+
+      @classmethod
+      def from_crawler(cls, crawler: Crawler) -> "MongoStatsExtension":
+          if not django_settings.MONGO_URL:
+              raise NotConfigured("MONGO_URL not configured — MongoStatsExtension disabled")
+
+          instance = cls()
+          crawler.signals.connect(instance.spider_opened, signal=signals.spider_opened)
+          crawler.signals.connect(instance.spider_closed, signal=signals.spider_closed)
+          return instance
+
+      def spider_opened(self, spider: Spider) -> None:
+          self.started_at = datetime.now(tz=timezone.utc)
+
+      def spider_closed(self, spider: Spider, reason: str) -> None:
+          finished_at = datetime.now(tz=timezone.utc)
+          stats: dict[str, Any] = spider.crawler.stats.get_stats()
+
+          doc = {
+              "spider_name": spider.name,
+              "started_at": self.started_at,
+              "finished_at": finished_at,
+              "duration_seconds": (
+                  (finished_at - self.started_at).total_seconds()
+                  if self.started_at
+                  else 0.0
+              ),
+              "items_scraped": stats.get("item_scraped_count", 0),
+              "items_dropped": stats.get("item_dropped_count", 0),
+              "stats": stats,
+              "errors": [],  # M6 minimal — populated only when stats track explicit errors
+          }
+
+          try:
+              self.collection.insert_one(doc)
+          except (PyMongoError, Exception) as e:
+              # §6.2: don't block spider close on observability layer
+              spider.logger.error("Mongo flush failed: %s", e, exc_info=True)
+  ```
+
+### Scrapy settings
+
+- [ ] `scrapers/tibiantis_scrapers/settings.py` rozszerzone:
+  ```python
+  EXTENSIONS = {
+      "scrapers.tibiantis_scrapers.extensions.MongoStatsExtension": 500,
+  }
+  ```
+  (Lub merge z istniejącym `EXTENSIONS` jeśli pojawi się — sprawdź przed dorzuceniem.)
+
+### Smoke
+
+- [ ] `poetry run scrapy crawl deaths` z localnym Mongo running → 1 doc w `scrape_logs` z `spider_name="deaths"`, `items_scraped >= 0`, `started_at < finished_at`.
+- [ ] `MONGO_URL=""` env override + `scrapy crawl deaths` → log "Disabled extension MongoStatsExtension (NotConfigured)" + crawl normalnie kończy bez Mongo flush.
+
+### Unit testy
+
+- [ ] `tests/unit/scrapers/test_mongo_stats_extension.py` z 5-7 testami (lista w §🧪 Testing plan).
+
+## 📋 Sugerowane kroki
+
+1. `git checkout master && git pull && git checkout -b feat/<#>-mongo-stats-extension`.
+2. Utwórz `scrapers/tibiantis_scrapers/extensions.py` per AC.
+3. Dorzuć `EXTENSIONS` do `scrapers/tibiantis_scrapers/settings.py`.
+4. Smoke `scrapy crawl deaths` (sanity z AC).
+5. Smoke z `MONGO_URL=""` (sanity NotConfigured path).
+6. Utwórz `tests/unit/scrapers/test_mongo_stats_extension.py` z 5-7 testami.
+7. `poetry run pytest tests/unit/scrapers/test_mongo_stats_extension.py -v --cov=scrapers.tibiantis_scrapers.extensions` → 100%.
+8. Pre-commit + commit + push + PR.
+
+## ⚠️ Pułapki do uwagi
+
+- **A — `from_crawler` raise `NotConfigured`** (`scrapy.exceptions`) gdy `MONGO_URL` empty — Scrapy traktuje jako clean disable, log "Disabled extension X". Bez raise: extension się rejestruje ale fail przy pierwszym signal call.
+- **B — Scrapy Settings vs Django settings** — Scrapy ma własny `Settings` object (`tibiantis_scrapers/settings.py`). Sprawdź `scrapers/tibiantis_scrapers/settings.py:1-10` czy `django.setup()` is called (M1-D8 wired). Wtedy `from django.conf import settings as django_settings` w `extensions.py` działa. Inaczej `django_settings.MONGO_URL` rzuca `AppRegistryNotReady`.
+- **C — Lazy import `get_collection`** — w aktualnym designie top-level import OK (`logs_backend → pymongo`, brak circular). NIE potrzebne lazy import unless circular pojawi się w przyszłości.
+- **D — `started_at` jako instance attribute** — Scrapy single-threaded per crawl (Twisted reactor), więc `self.started_at` is safe. Multi-spider concurrent crawl byłoby anti-pattern (M1-D8 retro #8).
+- **E — `crawler.stats.get_stats()` z non-JSON types** — niektóre stats (np. `start_time`, `finish_time`) to `datetime`, ale BSON akceptuje `datetime` natywnie. Smoke unit test sprawdzi że `insert_one(doc)` NIE rzuca dla typowego stats dict. Jeśli pojawi się exotic type (np. `Path`, `Decimal`), defensive helper `_clean_stats(stats)` konwertujący do BSON-safe types — dorzuć dopiero gdy test ujawni problem.
+- **F — Index `scrape_logs.spider_name + finished_at`** — tworzony przez D28 `get_collection("scrape_logs")` (idempotent, no-op gdy już istnieje). D29 tylko używa.
+- **G — Test setup z mock'ami** — Scrapy testing patterns: `from scrapy.utils.test import get_crawler` daje real Crawler, ale wymaga `Spider` class. Prościej: `MagicMock(spec=Crawler)` z `.stats.get_stats.return_value = {...}`. Dla testu signal subscribe użyj `mock_crawler.signals.connect.assert_any_call(...)`.
+
+## 🧪 Testing plan
+
+`tests/unit/scrapers/test_mongo_stats_extension.py`:
+
+1. `test_from_crawler_raises_not_configured_when_mongo_url_empty` — `@override_settings(MONGO_URL="")`, `MongoStatsExtension.from_crawler(MagicMock())` → `pytest.raises(NotConfigured)`.
+2. `test_from_crawler_returns_instance_when_mongo_url_set` — happy path, returns `MongoStatsExtension`.
+3. `test_from_crawler_subscribes_to_spider_opened_and_closed` — assert `mock_crawler.signals.connect` called z `signals.spider_opened` and `signals.spider_closed`.
+4. `test_spider_opened_records_started_at` — `extension.spider_opened(mock_spider)`, assert `extension.started_at` is `datetime` w UTC, `< datetime.now()`.
+5. `test_spider_closed_flushes_doc_with_expected_fields` — full lifecycle (open + close), assert `mongo_db.scrape_logs.count_documents({}) == 1`, doc ma `spider_name`, `started_at`, `finished_at`, `duration_seconds >= 0`, `items_scraped`, `items_dropped`, `stats` (dict), `errors` (list).
+6. `test_spider_closed_logs_error_on_mongo_failure` — mock `insert_one` raises `ConnectionFailure`, assert `mock_spider.logger.error.assert_called_once_with("Mongo flush failed: %s", ...)`, assert NOT raised.
+7. `test_spider_closed_includes_raw_crawler_stats` — mock `crawler.stats.get_stats()` returns `{"downloader/request_count": 5, "log_count/INFO": 10}`, assert `doc["stats"]["downloader/request_count"] == 5`.
+
+**Coverage cel:** `scrapers/tibiantis_scrapers/extensions.py` 100%.
+
+## 🔗 Dokumentacja pomocnicza
+
+- Scrapy Extensions: https://docs.scrapy.org/en/latest/topics/extensions.html
+- Scrapy signals: https://docs.scrapy.org/en/latest/topics/signals.html
+- `scrapy.exceptions.NotConfigured`: https://docs.scrapy.org/en/latest/topics/api.html#scrapy.exceptions.NotConfigured
+- M1-D8 retro #8 (Twisted reactor + Scrapy + Django setup): `PROGRESS.md` line ~80
+- M5-D26 `crawler.stats` precedens (read-only access): `apps/characters/tasks.py`
+
+## 📦 Definition of Done
+
+- [ ] AC spełnione (`MongoStatsExtension`, EXTENSIONS dict, signals, error handling).
+- [ ] PR zmergowany squash (`feat(logs): add MongoStatsExtension for Scrapy scrape_logs (M6-D29, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] `scrapers/tibiantis_scrapers/extensions.py` 100% coverage.
+- [ ] Issue zamknięty.

--- a/.github/issue-bodies/m6-d30.md
+++ b/.github/issue-bodies/m6-d30.md
@@ -1,0 +1,188 @@
+**Milestone:** M6 — Mongo logging
+**Czas:** 2h
+**Branch:** `feat/<this-issue-#>-m6-e2e` + `docs/close-m6-mongo-logging` (M5-D27 pattern: 2 PR-y w 1 issue)
+**Type:** `feat` (e2e) + `docs` (closure)
+**Zależy od:** D29 merged
+**Spec:** [`docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md`](../blob/master/docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md) §7 (testing), §8 (DoD M6)
+**Plan:** [`docs/superpowers/plans/2026-05-08-m6-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-08-m6-implementation-plan.md) Task #3
+
+---
+
+## 🎯 Cel
+
+E2E integration test pokrywający pełny chain: Django `apps.*` logger → MongoLogHandler → `app_logs`; **plus** mocked subprocess crawler → Scrapy signals → MongoStatsExtension → `scrape_logs`. Walidacja że oba paths współdzielą Mongo connection i piszą poprawnie do różnych collections. Plus M6 closure — `PROGRESS.md` rozszerzone o sekcję M6 z retro per Issue, milestone closed via `gh api`.
+
+D30 ma **2 PR-y w 1 issue** (M5-D27 pattern):
+1. **Feature PR** (`feat/<#>-m6-e2e`) — `tests/integration/test_m6_logging_e2e.py` + ewentualne minor fixy odkryte przez E2E.
+2. **Closure PR** (`docs/close-m6-mongo-logging` od **fresh master** po feature merge) — `PROGRESS.md` retro + milestone close.
+
+## 🧠 Czego się nauczysz
+
+- **E2E test patterns** — full-chain bez bypass. Real Mongo, real Django LOGGING dispatch, real Scrapy Extension. Mock tylko external (subprocess).
+- **Django LOGGING reload w testach** — jeśli E2E nie widzi mongo handler attached, sprawdź `logging.config.dictConfig(settings.LOGGING)` w `conftest.py` fixture (analog M3-D17 Celery worker config reload).
+- **`gh api -X PATCH` REST API direct** — `gh milestone close` nie istnieje w gh CLI; raw REST: `gh api -X PATCH repos/:owner/:repo/milestones/<#> -f state=closed` (M5-D27 precedens).
+- **Closure PR od fresh master** (M1-D8 lekcja) — `git checkout master && git pull && git checkout -b docs/close-m6-mongo-logging`. NIE od feature brancha.
+
+## ✅ Acceptance criteria
+
+### Feature PR (`feat/<#>-m6-e2e`)
+
+#### Required AC — Django logger e2e (2 testy)
+
+- [ ] `tests/integration/test_m6_logging_e2e.py`:
+  ```python
+  """E2E integration test for M6 — Django logger → MongoLogHandler → app_logs."""
+
+  from __future__ import annotations
+
+  import logging
+
+  import pytest
+  from django.conf import settings as django_settings
+
+  from logs_backend import get_mongo_client
+
+
+  @pytest.fixture
+  def mongo_clean():
+      """Drop both M6 collections before/after test (paranoid against leakage)."""
+      assert "test" in django_settings.MONGO_DB.lower()
+      client = get_mongo_client()
+      db = client[django_settings.MONGO_DB]
+      for name in ("app_logs", "scrape_logs"):
+          db[name].drop()
+      yield db
+      for name in ("app_logs", "scrape_logs"):
+          db[name].drop()
+
+
+  @pytest.mark.django_db(transaction=True)
+  def test_e2e_django_logger_persists_to_app_logs(mongo_clean) -> None:
+      """logger.info() in apps.* writes 1 doc to app_logs via configured LOGGING."""
+      logging.getLogger("apps.test").info("hello e2e")
+
+      docs = list(mongo_clean.app_logs.find({"message": "hello e2e"}))
+      assert len(docs) == 1
+      assert docs[0]["level"] == "INFO"
+      assert docs[0]["logger"] == "apps.test"
+
+
+  @pytest.mark.django_db(transaction=True)
+  def test_e2e_django_logger_with_exception_persists_traceback(mongo_clean) -> None:
+      """logger.exception() persists formatted exc_info string (§3.6)."""
+      try:
+          raise ValueError("boom")
+      except ValueError:
+          logging.getLogger("apps.test").exception("operation failed")
+
+      doc = mongo_clean.app_logs.find_one({"message": "operation failed"})
+      assert doc is not None
+      assert "ValueError" in doc["exc_info"]
+      assert "boom" in doc["exc_info"]
+  ```
+
+#### Optional AC — Scrapy extension e2e (1 test, opcjonalne — Twisted reactor experiment)
+
+E2E test dla `MongoStatsExtension` jest **trudny** ze względu na Twisted reactor isolation w pytest. Trzy approaches do rozważenia, każdy z trade-offs:
+
+1. **`subprocess.run("scrapy", "crawl", "deaths", ...)`** — real subprocess, real CrawlerProcess, real extension flush. Slower (subprocess startup ~2s), ale verifies wholezvyklink. Dorzuć timeout + capture stderr dla diagnostyki.
+
+2. **`scrapy.utils.test.get_crawler` + `Spider.start_requests()=[]`** — in-process Crawler z extension'em rejestrowanym, ale spider zwraca puste requesty → extension flush'uje empty doc (`items_scraped=0`, `started_at`/`finished_at` set). Verifies extension wiring, NIE real crawl. Niedeterminizm: Twisted reactor reuse między testami może crashować.
+
+3. **Skip extension e2e** — D29 unit testy już pokrywają extension flow z mockiem. M6 closure dokumentuje że Scrapy e2e jest "manual smoke" (admin uruchamia `scrapy crawl deaths` z localnym Mongo i sprawdza `scrape_logs.count_documents` w mongoshell). Pragmatyczne dla M6 minimum viable.
+
+**Rekomendacja:** Opcja 3 (skip extension e2e w D30) — D29 unit covers, M6 manual smoke wystarczy dla §8 DoD "scrapy crawl <spider> zapisuje doc do scrape_logs". Jeśli chcesz pokryć w PR — wybierz opcję 1 (subprocess), unikaj opcji 2 (Twisted hell).
+
+- [ ] **Wszystkie M6 testy** (D28 + D29 + D30 e2e) zielone:
+  ```bash
+  poetry run pytest \
+      tests/unit/logs_backend/ \
+      tests/unit/scrapers/test_mongo_stats_extension.py \
+      tests/integration/test_m6_logging_e2e.py \
+      --cov=logs_backend \
+      --cov=scrapers.tibiantis_scrapers.extensions \
+      --cov-report=term
+  ```
+- [ ] Cumulative coverage `logs_backend/*` + `scrapers/.../extensions.py` ≥ 95%.
+
+### Closure PR (`docs/close-m6-mongo-logging`)
+
+- [ ] `PROGRESS.md` rozszerzone o:
+  - `## 🎉 Milestone M6 — Mongo logging COMPLETED (2026-MM-DD)` header z krótkim opisem.
+  - `### Ukończone (M6)` — lista 3 issues + PR linki + squash hashes (analog M5 §"Ukończone (M5)").
+  - `### Notatki z retro M6 (dopisywane progresywnie)` — per Issue D28-D30.
+  - `### Definition of Done M6` (ze spec'a §8) — wszystkie [x] poza ostatnim ("milestone closed" — TODO post-merge).
+  - `### Podsumowanie M6` (data range, dni vs budżet, najwartościowsze lekcje).
+  - `### Tech debt z M6` (carry-over do M7+).
+- [ ] **Po merge closure PR'a:** `gh api -X PATCH repos/bgozlinski/tibiantis-scraper/milestones/6 -f state=closed`.
+- [ ] **Sanity:** `gh issue list --milestone "M6 — Mongo logging" --state open` → empty.
+
+## 📋 Sugerowane kroki
+
+### Feature PR
+
+1. `git checkout master && git pull && git checkout -b feat/<#>-m6-e2e`.
+2. Utwórz `tests/integration/test_m6_logging_e2e.py` z 4 testami per AC.
+3. `poetry run pytest tests/integration/test_m6_logging_e2e.py -v` → 4 passed.
+4. Pełen suite z coverage (komenda z AC) → cumulative ≥ 95%.
+5. Pre-commit + commit + push + PR.
+
+### Closure PR (po merge feature)
+
+6. `git checkout master && git pull` ← FRESH master (M1-D8 lekcja).
+7. `git checkout -b docs/close-m6-mongo-logging`.
+8. Edytuj `PROGRESS.md` per AC.
+9. Pre-commit + commit + push + PR.
+10. Po merge: `gh api -X PATCH repos/bgozlinski/tibiantis-scraper/milestones/6 -f state=closed`.
+11. Sanity: `gh issue list --milestone "M6 — Mongo logging" --state open` → empty.
+
+## ⚠️ Pułapki do uwagi
+
+- **A — `LOGGING` dict reload w testach** — jeśli `logging.getLogger("apps.test").info(...)` w teście NIE pisze do Mongo, sprawdź czy Django zaaplikował `LOGGING` config (Django bootstrap robi `dictConfig(settings.LOGGING)` automatycznie, ale `@override_settings(LOGGING=...)` może wymagać explicit reload). Dla domyślnego `LOGGING` dict reload niepotrzebny.
+- **B — Test isolation** — fixture `mongo_clean` drop'uje OBA collections (`app_logs` + `scrape_logs`) before AND after. Bez "before drop" — collateral z poprzednich test session zostawia docs.
+- **C — Closure branch od fresh master** (M1-D8 lekcja, repeat z M5-D27) — `git checkout master && git pull && git checkout -b docs/close-m6-mongo-logging`. NIE od `feat/<#>-m6-e2e`. Inaczej closure PR zawiera duplikat squash D30 jako "no-op" commit (M1-D8 PR #26 problem).
+- **D — `gh api PATCH milestone`** — wymaga `repo` scope w token'ie. `gh auth status` sanity. Plus correct milestone number — sprawdź przed wywołaniem: `gh api repos/bgozlinski/tibiantis-scraper/milestones --jq '.[] | select(.title|startswith("M6")) | .number'` → `6`.
+- **E — Milestone exact title match** — `gh issue list --milestone "M6 — Mongo logging"` wymaga dokładnego tytułu (z em-dashem `—`, NIE zwykłym myślnikiem `-`). Sanity przed call'em. (Sprawdziłem 2026-05-08, milestone #6 ma tytuł "M6 — Mongo logging".)
+- **F — Process pre-commit hook (PR #105)** — branch creation BEFORE coding (no-commit-to-branch hook blokuje commits na master). Krok 1 i 7 explicit `git checkout -b ...`.
+
+## 🧪 Testing plan
+
+E2E tests w `tests/integration/test_m6_logging_e2e.py` (4 testy per AC).
+
+Plus uruchom **wszystkie** M6 testy (D28 + D29 + D30 e2e):
+
+```bash
+poetry run pytest \
+    tests/unit/logs_backend/ \
+    tests/unit/scrapers/test_mongo_stats_extension.py \
+    tests/integration/test_m6_logging_e2e.py \
+    --cov=logs_backend \
+    --cov=scrapers.tibiantis_scrapers.extensions \
+    --cov-report=term
+```
+
+**Coverage cel:** Cumulative `logs_backend/*` + `scrapers/.../extensions.py` ≥ 95%.
+
+## 🔗 Dokumentacja pomocnicza
+
+- M5-D27 closure pattern: PR #103 (feature) + PR #104 (closure) + `gh api PATCH milestone`
+- M4-D22 e2e test (Scrapy + fixture HTML): `tests/integration/test_m4_deaths_e2e.py`
+- M3-D17 e2e test (Celery + scrape task): `tests/integration/test_celery_e2e.py`
+- `gh api` REST: https://docs.github.com/en/rest/issues/milestones?apiVersion=2022-11-28#update-a-milestone
+
+## 📦 Definition of Done
+
+### Feature PR
+- [ ] Required AC spełnione (Django logger e2e — 2 testy passing).
+- [ ] Optional Scrapy extension e2e — wybór per implementation (rekomendowane: skip).
+- [ ] **Feature PR** zmergowany squash (`feat(logs): M6 e2e integration test (M6-D30, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] Cumulative `logs_backend/*` + `scrapers/.../extensions.py` ≥ 95% coverage (D28 + D29 unit testy już dostarczają większości; D30 e2e dorzuca tylko Django logger path).
+- [ ] Manual smoke (jeśli skip Scrapy e2e): `scrapy crawl deaths` lokalnie z Mongo running → 1 doc w `scrape_logs` (sprawdzone via mongoshell lub `manage.py shell -c`). Wzmianka w PR description.
+
+### Closure PR
+- [ ] **Closure PR** zmergowany squash (`docs(progress): close M6 — Mongo logging COMPLETED + retro D28-D30`).
+- [ ] CI lint zielony.
+- [ ] PROGRESS.md sekcja M6 dorzucona (header + Ukończone + Notatki retro + DoD + Podsumowanie + Tech debt).
+- [ ] Milestone M6 zamknięty na GitHub via `gh api -X PATCH .../milestones/6 -f state=closed`.
+- [ ] Wszystkie M6 issues CLOSED (`gh issue list --milestone "M6 — Mongo logging" --state open` → empty).

--- a/docs/superpowers/plans/2026-05-08-m6-implementation-plan.md
+++ b/docs/superpowers/plans/2026-05-08-m6-implementation-plan.md
@@ -1,0 +1,302 @@
+# M6 — Mongo logging — Implementation plan
+
+**Data:** 2026-05-08
+**Spec:** [`docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md`](../specs/2026-05-08-m6-mongo-logging-design.md)
+**Status:** READY (spec accepted, decyzje §3.1-3.6 zaakceptowane przez developera 2026-05-08).
+
+---
+
+## Źródła
+
+- **CLAUDE.md** §3 (struktura `logs_backend/` planowana), §4 (Mongo dwie kolekcje: `app_logs` + `scrape_logs`, **bez** Djongo/MongoEngine), §10 (`MONGO_URL`, `MONGO_DB` env vars), §13.1 (CI mongo:7 service).
+- **Design spec M6** — kluczowy dokument referencyjny. Każdy issue body linkuje do spec'a §X.
+- **Precedensy z M0-M5:**
+  - M3-D17 retro #5 — `auto_now_add` workaround (`update()` bypass). Niepotrzebne dla M6 (Mongo schemaless), ale wzorzec znany.
+  - M4-D19/D20 — Scrapy spider/pipeline + `crawler.stats` API. D29 buduje na tym (signals zamiast pipeline'u, ale same `crawler` interface).
+  - M4-D22 — async/sync boundary w Strawberry resolvers (`sync_to_async`). Niepotrzebne dla M6 (logging emit jest sync, NIE async resolver), ale wzorzec dyscypliny "boundary conversion".
+  - M5-D25 — pierwszy package `apps/notifications/` jako Protocol-based abstraction. M6 robi analogiczny `logs_backend/` ale **NIE Django app** (top-level package, nie `apps/`).
+
+---
+
+## Pre-flight checklist (przed startem D28)
+
+- [ ] **`logs_backend/` nie istnieje** — sprawdzone 2026-05-08, fresh creation.
+- [ ] **`scrapers/tibiantis_scrapers/extensions.py` nie istnieje** — sprawdzone 2026-05-08, fresh creation.
+- [ ] **`MONGO_URL` + `MONGO_DB` env vars w `.env.example`** — istnieją od M0 (CLAUDE.md §10), aktualnie nieużywane przez kod (placeholder do M6).
+- [ ] **CI ma `mongo:7` service** — `ci.yml` ma `mongo` service container, ports 27017:27017, env `MONGO_URL=mongodb://localhost:27017` + `MONGO_DB=tibiantis_logs_test` (CLAUDE.md §13.1). Smoke confirmed: M5 testy nie używają Mongo, ale service jest already up — D28 unit testy mogą polegać na nim od pierwszego strzału.
+- [ ] **`pymongo` w `pyproject.toml`** — sprawdź przed D28. Jeśli brak — `poetry add pymongo` w D28 (osobny commit `build(deps): add pymongo`).
+- [ ] **Django LOGGING dict aktualnie nie skonfigurowany** — sprawdzone 2026-05-08, `config/settings/base.py` nie ma `LOGGING = {...}`. D28 dorzuca cały blok.
+- [ ] **`scrapers/tibiantis_scrapers/settings.py` aktualnie nie ma `EXTENSIONS = {...}`** — sprawdzone 2026-05-08, fresh addition w D29.
+- [ ] **PROCESS gotcha: pre-commit `no-commit-to-branch` hook** (PR #105, merged 2026-05-08) — blokuje commits na master. **Każdy D-task wymaga `git checkout -b feat/<#>-...` PRZED kodowaniem**, inaczej hook zabije commit. Zaakceptowane carry-over z M5 (D26+D27 incidenty).
+
+---
+
+## Otwarte pytania (rozstrzygnięte 2026-05-08, spec §3)
+
+Wszystkie 6 decyzji designowych ze spec'a §3 zaakceptowane bez modyfikacji:
+
+1. ✅ **§3.1** Synchronous emit (blocking insert) — NIE async/queued.
+2. ✅ **§3.2** Per-spider-run granularity dla `scrape_logs` — NIE per-request.
+3. ✅ **§3.3** Silent fallback do stderr przy Mongo failure (Django) / `spider.logger.error` (Scrapy).
+4. ✅ **§3.4** NullHandler gdy `MONGO_URL` empty (Django) / NotConfigured (Scrapy).
+5. ✅ **§3.5** Indexes na obu kolekcjach (idempotent `create_index`).
+6. ✅ **§3.6** Formatted `exc_info` string (NIE structured array).
+
+**Open questions z §9** (do M-future, NIE w M6 scope):
+- TTL retention (auto-cleanup starych logów).
+- GraphQL admin query do `scrape_logs`.
+- Per-request `scrape_logs` (downloader middleware).
+- Async/queued emit.
+- Structured `exc_info`.
+- Aggregation pipelines / Grafana dashboards.
+- Django middleware enrichment (request user/path/method w `app_logs`).
+- Mongo healthcheck w `docker-compose.dev.yml`.
+
+---
+
+## Risk + mitigation
+
+| Ryzyko | Prawdopodobieństwo | Impact | Mitigation |
+|---|---|---|---|
+| **Mongo down podczas Django emit** | Średnie (lokalny dev bez `docker-compose up mongo`) | App `logger.info` zacząłby 500'ki | §6.1 silent fallback: `try/except → handleError` (stdlib pattern). Test `test_emit_falls_back_to_stderr_on_mongo_failure` enforce'uje. |
+| **Mongo down podczas spider_closed** | Niskie (Beat schedule, prod mongo zawsze up) | Spider close blocked → Celery task hangs | §6.2 try/except → `spider.logger.error`, NO raise. Test `test_spider_closed_logs_error_on_mongo_failure`. |
+| **`pymongo.MongoClient` blocks 30s na server selection gdy Mongo down** | Wysokie (default timeout) | `logger.info` w view'ie wisi 30s przed fallback'iem | §6.4 `serverSelectionTimeoutMS=2000` w `get_mongo_client()` — fail-fast 2s. |
+| **Index creation race** (multiple workers wywołujące `get_collection` jednocześnie) | Niskie (lazy singleton w jednym procesie) | `create_index` zwraca już-istniejący name, idempotent | Mongo `create_index` jest idempotent. Plus singleton MongoClient = jedno wywołanie per proces, nie N. |
+| **`MONGO_URL` empty w prod** (deploy bug) | Niskie (CI checks env vars) | Logi nie idą do Mongo, silent | §3.4 NullHandler — app działa, console handler dalej działa. Smoke check po deploy: `manage.py shell -c "from logs_backend import get_mongo_client; print(get_mongo_client())"` (None vs MongoClient). |
+| **Logger `apps` filter pomija system logs** (Django/3rd-party) | Świadome | Brak logów z Django ORM/migrations w Mongo | Zamierzone (§3.4 reasoning) — `app_logs` to **business** observability, nie infra. Inne handlery (Django default) dalej obsługują system logs. |
+| **CI Mongo service dostępny ale `MONGO_DB=tibiantis_logs_test` shared między testami** | Średnie | Test isolation problem (race między concurrent test runs) | Pytest fixture `mongo_db` z `db.collection.drop()` w teardown (autouse=False, explicit per test). M3-D17 race lesson. |
+
+---
+
+## Task overview
+
+| # | ID | Tytuł | Czas | Zależy od | Branch |
+|---|---|---|---|---|---|
+| 1 | M6-D28 | `logs_backend/` package + `MongoLogHandler` + factory + Django LOGGING integration | 2-3h | M5 closed + chore PR #105 (no-commit-to-branch hook) merged | `feat/<#>-mongo-log-handler` |
+| 2 | M6-D29 | `MongoStatsExtension` + Scrapy signals + `scrape_logs` doc | 2-3h | D28 merged | `feat/<#>-mongo-stats-extension` |
+| 3 | M6-D30 | E2E smoke (live spider mocked + real Mongo) + M6 closure (PROGRESS.md retro + milestone close) | 2h | D29 merged | `feat/<#>-m6-e2e` + `docs/close-m6-mongo-logging` |
+
+**Total:** ~7-8h, ~2 dni roboczych. Mniejszy niż M5 (5 D-tasków, 13-15h) bo M6 jest węższy: tylko logging infrastructure, brak business logic, brak GraphQL, brak Celery tasks.
+
+---
+
+## Task #1 — [M6-D28] `logs_backend/` package + `MongoLogHandler` + factory + Django LOGGING
+
+### 🎯 Cel
+
+Utworzyć `logs_backend/` jako top-level Python package (NIE Django app) z lazy MongoClient singleton, custom `MongoLogHandler` (sync emit, silent fallback do stderr) i `factory_or_null` dispatch'em. Skonfigurować Django `LOGGING` dict w `config/settings/base.py` żeby attached do logger `"apps"` (NIE root). Po D28: każdy `logger.info("...")` w `apps.*` zapisuje 1 dokument do `app_logs` collection.
+
+### 🧠 Czego się nauczysz
+
+- **`logging.Handler` API** — `__init__`, `emit(record)`, `format(record)`, `handleError(record)`. `emit` jest hot path — wywoływany dla każdego `logger.info(...)` call. `handleError` to default fallback path stdlib (default impl writes to stderr, dokładnie czego potrzebujemy dla §3.3).
+- **`pymongo.MongoClient` config** — `serverSelectionTimeoutMS=2000` (fail-fast, §6.4), default `maxPoolSize=100` wystarczy dla low-traffic backendu, `connectTimeoutMS`/`socketTimeoutMS=2000` zaspojnione. Lazy singleton wzorzec: `MongoClient` instancja tworzona przy pierwszym `get_mongo_client()` call, cache na module level (`_client: MongoClient | None`).
+- **Django `LOGGING` dict** (`logging.config.dictConfig` schema) — handler `"mongo"` przez `"()"` factory pattern (callable returning Handler instance). `loggers` config attaches `"apps"` logger do handler `"mongo"` z `"propagate": False` żeby NIE emit'ować dwukrotnie (raz przez `apps` handler, drugi przez root). PEP-8 naming: `LOGGING` (uppercase, Django convention).
+- **`logging.NullHandler`** — stdlib no-op handler. `emit()` is no-op. Używamy go jako fallback gdy `MONGO_URL` empty — app działa, logi idą do default Django console handler ale NIE do Mongo.
+- **Idempotent `create_index`** — Mongo `collection.create_index(keys, name=...)` jest idempotent (no-op gdy index z tym name'em już istnieje). Wywoływane w `get_collection(name)` na pierwszy call, lazy.
+
+### ✅ Acceptance criteria
+
+(Pełne AC w issue body — `.github/issue-bodies/m6-d28.md`.)
+
+**Kluczowe punkty:**
+- `logs_backend/__init__.py` z `get_mongo_client()` (lazy singleton, `serverSelectionTimeoutMS=2000`) + `get_collection(name)` (z idempotent `create_index` dla `app_logs.timestamp` desc i `scrape_logs.spider_name+finished_at` compound).
+- `logs_backend/handlers.py` z `MongoLogHandler(logging.Handler)` (sync `insert_one`, fallback przez `self.handleError(record)`) + `factory_or_null()` (zwraca `MongoLogHandler` lub `NullHandler` w zależności od `settings.MONGO_URL`).
+- `config/settings/base.py` z `LOGGING` dict — handler `"mongo"` przez `"()"` factory + logger `"apps"` z `"handlers": ["mongo"]`, `"level": "INFO"`, `"propagate": False`.
+- Plus istniejący Django default console logging dla root logger (Django auto-config) — zostaje, NIE override.
+- 6-7 unit testów (handler emit, exc_info formatting, Mongo fail fallback, NullHandler dispatch, index creation idempotency).
+
+### ⚠️ Pułapki do uwagi
+
+- **A — `logs_backend/` to NIE Django app** — top-level package. NIE dodawaj do `LOCAL_APPS` w `base.py` ani do `INSTALLED_APPS` w `stubs.py`. Plus brak `apps.py` / `models.py` / migrations. Pakiet importowany przez Django LOGGING dispatch (`'()': 'logs_backend.handlers.factory_or_null'`).
+- **B — `serverSelectionTimeoutMS=2000`** w `MongoClient` config — bez tego default 30s. Każdy `logger.info` w widoku gdy Mongo down wisi 30s zanim fallback do stderr. **Test:** mock `MongoClient.insert_one` raises `ConnectionFailure`, assert handler `emit` returnuje w <2s (np. `time.monotonic()` measurement).
+- **C — `propagate: False`** na logger `"apps"` w LOGGING dict — bez tego logi z `apps.*` szły by przez handler `"mongo"` ORAZ przez handlery root logger'a (np. Django console) → duplicate log entries.
+- **D — Lazy singleton thread safety** — `_client: MongoClient | None = None; if _client is None: _client = MongoClient(...)`. Race między pierwszymi 2 wątkami możliwa, ale `MongoClient` jest itself thread-safe i utworzenie 2 instancji to tylko micro-leak (one zwolniona przez GC). **Mitigacja:** brak — `pymongo` MongoClient internally pool'uje, double-init jest cosmetic. Premature optimization byłby `threading.Lock`. YAGNI.
+- **E — `formatException` z None record.exc_info** — `record.exc_info` jest `None` dla zwykłych logów (INFO/WARNING). `MongoLogHandler.emit()` musi conditionally dorzucić `exc_info` field tylko gdy `record.exc_info` is set (`if record.exc_info: doc["exc_info"] = self.formatter.formatException(record.exc_info)`). Bez tego `KeyError` lub `formatException(None)` exception.
+- **F — `MongoLogHandler.__init__` musi przyjąć optional `formatter`** — Django LOGGING dispatch może podać formatter explicit. Jeśli brak, użyj `logging.Formatter()` default (handler MUSI mieć formatter żeby `self.format(record)` działał — fallback do stderr używa formatted text).
+- **G — Test database isolation** — pytest fixture `mongo_db` (per spec §7.2) drop'uje wszystkie collections w teardown. Bez tego collateral między testami (jeden test zostawia 5 docs, drugi assert `count == 1`).
+- **H — `MONGO_DB` w testach `tibiantis_logs_test` (NIE prod `tibiantis_logs`)** — CI ma osobne env var (`ci.yml` line ~80). Lokalnie: `.env` dev mongo używa `MONGO_DB=tibiantis_logs` ale pytest może override przez `pytest-django` settings. Sanity: testy NIE flush'ują prod `app_logs` (paranoja: assert `db.name == "tibiantis_logs_test"` w fixture).
+
+### 🧪 Testing plan
+
+`tests/unit/logs_backend/__init__.py` (pusty) + `tests/unit/logs_backend/conftest.py` (fixture `mongo_db` z drop teardown) + `tests/unit/logs_backend/test_mongo_log_handler.py`:
+
+- `test_get_collection_returns_pymongo_collection` — sanity wrap.
+- `test_get_collection_creates_index_on_first_call` — pierwsze `get_collection("app_logs")` tworzy index na `timestamp`.
+- `test_get_collection_idempotent_index_creation` — drugi call NIE rzuca (Mongo create_index idempotent).
+- `test_emit_writes_doc_with_expected_fields` — emit `INFO` record z `apps.test`, assert collection ma 1 doc z fields: `timestamp` (ISODate), `level="INFO"`, `logger="apps.test"`, `message`, `module`, `function`, `line`.
+- `test_emit_includes_exc_info_for_error_records` — emit ERROR z `try: raise ValueError except: logger.exception(...)`, assert doc ma `exc_info` field z formatted traceback string ("Traceback..." in value).
+- `test_emit_omits_exc_info_for_records_without_exception` — emit zwykły `logger.info("hi")`, assert `"exc_info" not in doc`.
+- `test_emit_falls_back_to_stderr_on_mongo_failure` — mock `collection.insert_one` raises `ConnectionFailure`, assert `handler.emit(record)` NOT raised; capsys.readouterr().err zawiera formatted record string.
+- `test_emit_returns_quickly_on_mongo_unreachable` — mock MongoClient z `serverSelectionTimeoutMS=100`, point at `mongodb://localhost:1` (closed port), assert `emit()` returns w <2s. (Sanity test dla §6.4.)
+- `test_factory_returns_null_handler_when_mongo_url_empty` — `@override_settings(MONGO_URL="")`, `factory_or_null()` zwraca `logging.NullHandler` instance.
+- `test_factory_returns_mongo_handler_when_mongo_url_set` — default settings (MONGO_URL set w `.env`), `factory_or_null()` zwraca `MongoLogHandler`.
+- `test_django_logging_routes_apps_logger_to_mongo` — `import logging; logging.getLogger("apps.test").info("hello")`, assert collection.find_one(message="hello") exists. (Smoke że `LOGGING` config jest correct.)
+
+**Coverage cel:** `logs_backend/__init__.py` 100%, `logs_backend/handlers.py` 100%.
+
+### 📦 Definition of Done
+
+- [ ] AC spełnione (`logs_backend/`, `MongoLogHandler`, factory, Django LOGGING).
+- [ ] PR zmergowany squash (`feat(logs): add MongoLogHandler + Django LOGGING integration (M6-D28, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] `logs_backend/*.py` 100% coverage.
+- [ ] `pymongo` w `pyproject.toml` (osobny `build(deps)` commit jeśli brak).
+- [ ] Issue zamknięty.
+
+---
+
+## Task #2 — [M6-D29] `MongoStatsExtension` + Scrapy signals + `scrape_logs` doc
+
+### 🎯 Cel
+
+Utworzyć `scrapers/tibiantis_scrapers/extensions.py` z `MongoStatsExtension` rejestrowanym przez Scrapy `EXTENSIONS` dict w `scrapers/tibiantis_scrapers/settings.py`. Extension subscribuje na `signals.spider_opened` (zapisuje `started_at`) + `signals.spider_closed` (buduje doc z `crawler.stats`, `insert_one` do `scrape_logs`). Disabled mode przez `NotConfigured` raise gdy `MONGO_URL` empty. Po D29: każdy `scrapy crawl <spider>` lub `scrapy crawl deaths` przez Celery zapisuje 1 doc do `scrape_logs`.
+
+### 🧠 Czego się nauczysz
+
+- **Scrapy Extensions API** — `from_crawler(cls, crawler) -> instance` factory pattern (analogicznie do Scrapy `Pipeline`). Returns `cls(...)` lub raise `scrapy.exceptions.NotConfigured` żeby Scrapy disable extension cleanly. Plus subscribe na signals przez `crawler.signals.connect(self.handler, signal=signals.spider_opened)`.
+- **Scrapy signals** — `spider_opened(spider)` i `spider_closed(spider, reason)` (oba w `scrapy.signals`). `reason` może być `"finished"`, `"shutdown"`, `"cancelled"`, `"failed"` — wartościowe dla `scrape_logs.reason` field (post-M6 enhancement, ale dla M6 używamy tylko stats, nie reason).
+- **`crawler.stats` API** — `crawler.stats.get_stats() -> dict` zwraca raw stats dict (~30+ kluczy). `crawler.stats.get_value(key, default)` dla pojedynczego getter'a. Wszystkie counters (downloader/request_count, item_scraped_count, log_count/ERROR, etc.) są w `get_stats()`.
+- **`from logs_backend import get_collection`** — top-level import (NIE relative `from .` bo `scrapers/` to oddzielny Python tree). Współdzielenie singleton MongoClient z Django (oba procesy, gdy Scrapy uruchomione z subprocess, mają osobne MongoClient instances — to jest OK, każdy proces self-contained).
+
+### ✅ Acceptance criteria
+
+(Pełne AC w issue body — `.github/issue-bodies/m6-d29.md`.)
+
+**Kluczowe punkty:**
+- `scrapers/tibiantis_scrapers/extensions.py` z `MongoStatsExtension` (`__init__`, `from_crawler` z `NotConfigured` raise, `spider_opened` handler zapisuje `started_at`, `spider_closed` handler buduje doc + `insert_one`, defensive try/except → `spider.logger.error`).
+- `scrapers/tibiantis_scrapers/settings.py` rozszerzone o `EXTENSIONS = {"scrapers.tibiantis_scrapers.extensions.MongoStatsExtension": 500}`.
+- 5-6 unit testów (`from_crawler` NotConfigured path, `spider_opened` records timestamp, `spider_closed` flushes doc, error path on Mongo failure, doc shape matches schema §4.2).
+
+### ⚠️ Pułapki do uwagi
+
+- **A — `from_crawler` raise `NotConfigured`** (scrapy.exceptions) gdy `crawler.settings.get("MONGO_URL")` empty — Scrapy traktuje to jako clean disable, log "Disabled extension X (NotConfigured)". Bez raise: extension się rejestruje ale fail przy pierwszym signal.
+- **B — Scrapy `crawler.settings` to NIE Django `settings`** — Scrapy używa własnego `Settings` objektu (z `tibiantis_scrapers/settings.py`). Trzeba sprawdzić jak `MONGO_URL` przepuszczone — albo dorzucić `MONGO_URL = os.environ.get("MONGO_URL", "")` do `scrapers/tibiantis_scrapers/settings.py`, albo użyć Django `settings.MONGO_URL` (wymaga `django.setup()` na top of `extensions.py` — istnieje już dla pipeline'u przez M1-D8 scaffolding). Druga opcja lepsza — single source of truth. Sprawdź `scrapers/tibiantis_scrapers/settings.py:1-10` czy `django.setup()` is called.
+- **C — Lazy import `get_collection`** wewnątrz `spider_closed` handler — analogicznie do M5-D26 lazy import (cikular safety między `apps.bedmages.services` ↔ `apps.characters.tasks`). Tutaj cikular nie ma (Scrapy → logs_backend, logs_backend nie importuje Scrapy), więc top-level import OK. Wybór dla consistency: top-level import.
+- **D — `started_at` thread-local vs instance attribute** — Scrapy default uruchamia spider'y w jednym thread'zie per crawl (Twisted reactor single-threaded), więc instance attribute `self.started_at` is safe. Multi-spider concurrent crawls byłyby Twisted reactor anti-pattern (M1-D8 retro #8). YAGNI — instance attribute wystarczy.
+- **E — `crawler.stats.get_stats()` zawiera non-JSON-serializable types** — niektóre stats (np. `start_time`, `finish_time`) to `datetime` objects, ale Mongo BSON akceptuje `datetime` natywnie. `int`/`float`/`str` też BSON-native. Scrapy stats w 99% przypadków są clean. **Sanity:** test asercja, że `insert_one(doc)` NIE rzuca dla typowego crawl stats dict. Jeśli pojawi się exotic type (np. `Path`), defensive `_clean_stats(stats)` helper konwertujący do BSON-safe (str fallback). M6 pierwsze podejście: assume clean, dorzuć helper jeśli test ujawni problem.
+- **F — Index `scrape_logs.spider_name + finished_at`** — compound, descending na `finished_at`. Tworzony przez `get_collection("scrape_logs")` w D28 (już impl'd). D29 tylko używa, nie tworzy.
+- **G — Test setup wymaga `Spider` mock i `Crawler` mock** — zgodnie z Scrapy testing patterns: `from scrapy.utils.test import get_crawler`. Lub bezpośrednio mock'ować przez `MagicMock(spec=Crawler)` z `.stats.get_stats.return_value = {...}`. Druga opcja prostsza.
+
+### 🧪 Testing plan
+
+`tests/unit/scrapers/test_mongo_stats_extension.py`:
+
+- `test_from_crawler_raises_not_configured_when_mongo_url_empty` — `@override_settings(MONGO_URL="")` (lub Scrapy `Settings({"MONGO_URL": ""})` mock), `MongoStatsExtension.from_crawler(crawler)` → `NotConfigured`.
+- `test_from_crawler_returns_instance_when_mongo_url_set` — happy path, returns `MongoStatsExtension` instance.
+- `test_from_crawler_subscribes_to_spider_opened_and_closed` — assert `crawler.signals.connect` called with both signals.
+- `test_spider_opened_records_started_at` — call `extension.spider_opened(spider)`, assert `extension.started_at` is `datetime` w UTC.
+- `test_spider_closed_flushes_doc_with_expected_fields` — call full lifecycle (open + close), assert collection ma 1 doc z `spider_name`, `started_at`, `finished_at`, `duration_seconds` (>=0), `items_scraped`, `items_dropped`, `stats` (dict), `errors` (list).
+- `test_spider_closed_logs_error_on_mongo_failure` — mock `insert_one` raises `ConnectionFailure`, assert `spider.logger.error` called z "Mongo flush failed", assert NOT raised.
+- `test_spider_closed_populates_errors_when_log_count_error_nonzero` — Stats z `log_count/ERROR=2`, assert `doc["errors"]` is non-empty list (przy fakcie że stats nie zawierają string'owych errorów per-message — zostawić empty list jeśli stats nie tracking, dorzucić TODO dla M-future).
+
+**Coverage cel:** `scrapers/tibiantis_scrapers/extensions.py` 100%.
+
+### 📦 Definition of Done
+
+- [ ] AC spełnione (`MongoStatsExtension`, EXTENSIONS dict, signals, error handling).
+- [ ] PR zmergowany squash (`feat(logs): add MongoStatsExtension for Scrapy scrape_logs (M6-D29, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] `scrapers/tibiantis_scrapers/extensions.py` 100% coverage.
+- [ ] Issue zamknięty.
+
+---
+
+## Task #3 — [M6-D30] E2E smoke (live spider mocked + real Mongo) + M6 closure
+
+### 🎯 Cel
+
+E2E integration test pokrywający pełny chain: Django `apps.bedmages` logger → MongoLogHandler → `app_logs`; **plus** mocked subprocess crawler → Scrapy signals → MongoStatsExtension → `scrape_logs`. Walidacja że oba paths współdzielą Mongo connection i piszą poprawnie do różnych collections. Plus M6 closure — `PROGRESS.md` rozszerzone o sekcję M6 z retro per Issue, milestone closed via `gh api`.
+
+D30 ma **2 PR-y w 1 issue** (M5-D27 pattern):
+1. **Feature PR** — `tests/integration/test_m6_logging_e2e.py` + ewentualne minor fixy odkryte przez E2E.
+2. **Closure PR** — `PROGRESS.md` retro + milestone close.
+
+### 🧠 Czego się nauczysz
+
+- **E2E test patterns** — full-chain test bez bypass (real Mongo, real Django LOGGING dispatch, real Scrapy Extension). Mock tylko external services (subprocess Scrapy crawl jeśli używamy z Celery — analog M3-D17 + M4-D22 e2e). Plus pytest fixture rozszerzony żeby reset OBA `app_logs` i `scrape_logs`.
+- **Django LOGGING dict reload w testach** — `LOGGING` jest applied przy Django startup. Override przez `@override_settings(LOGGING=...)` może wymagać `logging.config.dictConfig(settings.LOGGING)` po override żeby zmiana wzięła. Lub: zostawić default LOGGING, dispatch przez logger explicit (`logging.getLogger("apps.test").info(...)`) który dispatchuje do mongo handler attached już przy bootstrap'ie.
+- **`gh api -X PATCH` REST API direct** — `gh milestone close` nie istnieje w gh CLI, używamy raw REST: `gh api -X PATCH repos/:owner/:repo/milestones/<#> -f state=closed`. M5-D27 precedens.
+- **Closure PR od fresh master** — `git checkout master && git pull && git checkout -b docs/close-m6-mongo-logging`. M1-D8 ops blunder (PR #26 duplicate) lekcja, pamiętana przez M5-D27.
+
+### ✅ Acceptance criteria
+
+(Pełne AC w issue body — `.github/issue-bodies/m6-d30.md`.)
+
+### Feature PR (`feat/<#>-m6-e2e`)
+
+**Required (2 testy — Django logger e2e):**
+- `tests/integration/test_m6_logging_e2e.py`:
+  - `test_e2e_django_logger_persists_to_app_logs` — `logging.getLogger("apps.test").info("hi")`, assert `app_logs` collection ma 1 doc z `message="hi"`, `level="INFO"`, `logger="apps.test"`.
+  - `test_e2e_django_logger_with_exception_persists_traceback` — `try: raise ValueError("boom") except: logging.getLogger("apps.test").exception("failed")`, assert doc ma `exc_info` z "ValueError" + "boom" (§3.6 formatted exc_info).
+
+**Optional (Scrapy extension e2e — Twisted reactor experiment):**
+- E2E dla `MongoStatsExtension` jest trudny ze względu na Twisted reactor isolation w pytest. Trzy approaches z trade-offs (subprocess vs `get_crawler` vs skip). **Rekomendacja:** skip — D29 unit testy pokrywają flow extension'a z mockiem; M6 closure dokumentuje "manual smoke" jako alternatywę (admin uruchamia `scrapy crawl deaths` lokalnie + sprawdza `scrape_logs.count_documents` w mongoshell). Pragmatyczne dla minimum viable scope. Pełna dyskusja opcji w issue body D30.
+
+### Closure PR (`docs/close-m6-mongo-logging`)
+
+**Kluczowe punkty:**
+- `PROGRESS.md` rozszerzone:
+  - Header sekcji M6: `## 🎉 Milestone M6 — Mongo logging COMPLETED (2026-MM-DD)`.
+  - `### Ukończone (M6)` — lista 3 issues + PR linki + squash hashes.
+  - `### Notatki z retro M6` — per Issue D28-D30.
+  - `### Definition of Done M6` (ze spec'a §8) — wszystkie [x].
+  - `### Podsumowanie M6` (data range, dni vs budżet, lekcje).
+  - `### Tech debt z M6` (do M7+ carry-over).
+- Milestone close: `gh api -X PATCH repos/bgozlinski/tibiantis-scraper/milestones/6 -f state=closed`.
+- Sanity: `gh issue list --milestone "M6 — Mongo logging" --state open` → empty.
+
+### ⚠️ Pułapki do uwagi
+
+- **A — `LOGGING` dict reload w testach** — jeśli E2E nie widzi Mongo handler attached, sprawdź czy Django zaaplikował config (`logging.config.dictConfig(settings.LOGGING)` w app startup lub `conftest.py` fixture). M5-D17 precedens dla Celery worker config reload.
+- **B — Test isolation** — pytest fixture `mongo_db` (z D28) drop'uje `app_logs` + `scrape_logs` w teardown. Bez tego E2E test #4 (`isolated`) failuje gdy poprzednie testy zostawiły docs w jednej z collections.
+- **C — Closure branch od fresh master** (M1-D8 lekcja) — `git checkout master && git pull && git checkout -b docs/close-m6-mongo-logging`. NIE od feature brancha D30. Inaczej: closure PR zawiera duplikat squash D30 jako "no-op" commit (M1-D8 PR #26 problem).
+- **D — `gh api PATCH milestone`** — wymaga uprawnień `repo` w token'ie, nie `public_repo`. Sanity przed call'em: `gh auth status` pokazuje permissions. Plus correct milestone number (`6` dla M6, sprawdź `gh api repos/.../milestones --jq '.[] | select(.title|contains("M6")) | .number'`).
+- **E — Milestone "M6 — Mongo logging"** — exact title match dla `gh issue list --milestone "..."`. Sprawdziłem 2026-05-08, milestone #6 ma tytuł "M6 — Mongo logging" (check przed zamknięciem aby nie missnąć).
+
+### 🧪 Testing plan
+
+E2E tests w `tests/integration/test_m6_logging_e2e.py` (4 testy per AC). Plus uruchom **wszystkie** testy z M6 (D28 + D29 + D30 e2e) + cumulative coverage check:
+
+```bash
+poetry run pytest tests/unit/logs_backend/ tests/unit/scrapers/test_mongo_stats_extension.py tests/integration/test_m6_logging_e2e.py --cov=logs_backend --cov=scrapers.tibiantis_scrapers.extensions --cov-report=term
+```
+
+**Coverage cel:** Cumulative `logs_backend/*` + `scrapers/tibiantis_scrapers/extensions.py` ≥ 95%.
+
+### 📦 Definition of Done
+
+#### Feature PR
+- [ ] AC spełnione (E2E test, all 4 cases passing).
+- [ ] **Feature PR** zmergowany squash (`feat(logs): M6 e2e integration test (M6-D30, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] Cumulative `logs_backend/*` + `scrapers/.../extensions.py` ≥ 95% coverage.
+
+#### Closure PR
+- [ ] **Closure PR** zmergowany squash (`docs(progress): close M6 — Mongo logging COMPLETED + retro D28-D30`).
+- [ ] CI lint zielony.
+- [ ] PROGRESS.md sekcja M6 dorzucona.
+- [ ] Milestone M6 zamknięty na GitHub via `gh api -X PATCH .../milestones/6 -f state=closed`.
+- [ ] Wszystkie M6 issues CLOSED (`gh issue list --milestone "M6 — Mongo logging" --state open` → empty).
+
+---
+
+## Spec section refs
+
+| Spec section | Realizowane przez |
+|---|---|
+| §2 architektura komponenty | All tasks |
+| §3.1 sync emit | D28 |
+| §3.2 per-spider-run granularity | D29 |
+| §3.3 silent fallback (Django) | D28 |
+| §3.3 silent fallback (Scrapy) | D29 |
+| §3.4 NullHandler / NotConfigured | D28 (Django) + D29 (Scrapy) |
+| §3.5 indeksy idempotent | D28 |
+| §3.6 formatted exc_info | D28 |
+| §4.1 app_logs schema | D28 |
+| §4.2 scrape_logs schema | D29 |
+| §5 D-task split | This document |
+| §6.1-6.3 error handling | D28 + D29 |
+| §6.4 connection timeout | D28 |
+| §7 testing strategy | D28 + D29 + D30 e2e |
+| §8 DoD M6 | M6 closure (D30 closure PR) |
+| §9 Open questions | M-future, NIE w M6 |

--- a/docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md
+++ b/docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md
@@ -1,0 +1,364 @@
+# M6 — Mongo logging — Design spec
+
+**Data:** 2026-05-08
+**Status:** ACCEPTED (decyzje §4.1-4.5 zaakceptowane przez developera 2026-05-08, brainstorming w sesji M6 brainstorm)
+**Plan:** [`docs/superpowers/plans/2026-05-08-m6-implementation-plan.md`](../plans/2026-05-08-m6-implementation-plan.md) (ten sam PR)
+**Milestone:** [#6 — Mongo logging](https://github.com/bgozlinski/tibiantis-scraper/milestone/6)
+
+---
+
+## §1 Cel + scope
+
+Wprowadzić MongoDB jako observability backend dla aplikacji Tibiantis Monitor. Dwie kolekcje:
+
+- **`app_logs`** — Python logging output z `apps.*` loggers (poziomy INFO+).
+- **`scrape_logs`** — historia uruchomień Scrapy spiderów (1 dokument per `scrapy crawl <spider>` invocation).
+
+Zgodnie z CLAUDE.md §4 — Mongo trzyma **wyłącznie logi**, nigdy dane domenowe. `pymongo` bezpośrednio (NIE Djongo, NIE MongoEngine).
+
+### W zakresie M6:
+- Custom `MongoLogHandler(logging.Handler)` w `logs_backend/`.
+- `MongoStatsExtension` jako Scrapy Extension hookujący `spider_opened` + `spider_closed` signals.
+- Indeksy na obu kolekcjach (idempotent `create_index` przy pierwszym `get_collection` call).
+- Disabled mode gdy `MONGO_URL` empty (`NullHandler` dla Django, `NotConfigured` dla Scrapy).
+- Silent fallback do stderr przy Mongo failure (logging never breaks the app).
+- Real Mongo w testach (CI service już skonfigurowany w `ci.yml`).
+
+### Poza zakresem M6 (do M-future):
+- TTL indexes / retention policy — unbounded growth, do adresowania post-traffic-data.
+- GraphQL query do `scrape_logs` (admin observability) — może być w M7+.
+- Per-request granularity dla `scrape_logs` (każdy URL fetch = 1 doc) — odrzucone na rzecz prostoty.
+- Async/queued emit — sync wystarczy dla low-traffic backendu.
+- Structured `exc_info` (file/line/type/msg array) — formatted string wystarczy dla debug.
+- Aggregation pipelines / dashboards.
+
+---
+
+## §2 Architektura
+
+### High-level diagram
+
+```
+┌──────────────────────┐                 ┌────────────────────┐
+│ Django (web/celery)  │                 │ Scrapy (spiders)   │
+│ logger.info(...)     │                 │ crawler signals    │
+└──────────┬───────────┘                 └─────────┬──────────┘
+           │                                       │
+           ▼                                       ▼
+┌──────────────────────┐                 ┌────────────────────┐
+│ MongoLogHandler      │                 │ MongoStatsExtension│
+│ (logs_backend/)      │                 │ (scrapers/.../     │
+│ - INFO+ from apps.*  │                 │  extensions.py)    │
+│ - sync insert_one    │                 │ - spider_opened    │
+│ - try/except → stderr│                 │ - spider_closed    │
+└──────────┬───────────┘                 └─────────┬──────────┘
+           │                                       │
+           └─────────────┬─────────────────────────┘
+                         ▼
+                ┌─────────────────┐
+                │ pymongo client  │
+                │ (lazy singleton │
+                │ w logs_backend) │
+                └────────┬────────┘
+                         ▼
+                ┌──────────────────┐
+                │ MongoDB          │
+                │ DB: tibiantis_   │
+                │     logs         │
+                │ ┌──────────────┐ │
+                │ │ app_logs     │ │
+                │ │ scrape_logs  │ │
+                │ └──────────────┘ │
+                └──────────────────┘
+```
+
+### Komponenty (5 plików, 1 modyfikacja)
+
+| # | Plik | Status | Zawartość |
+|---|---|---|---|
+| 1 | `logs_backend/__init__.py` | NEW | `get_mongo_client()` lazy singleton; `get_collection(name)` helper z idempotent `create_index` na pierwszy call. |
+| 2 | `logs_backend/handlers.py` | NEW | `MongoLogHandler(logging.Handler)` (`emit` + format dict + sync insert + try/except → stderr); `factory_or_null()` callable zwracające `NullHandler` gdy `MONGO_URL` empty. |
+| 3 | `scrapers/tibiantis_scrapers/extensions.py` | NEW | `MongoStatsExtension` (`from_crawler` raises `NotConfigured` gdy `MONGO_URL` empty; subscribe na `spider_opened` + `spider_closed`; flush 1 doc na zamknięcie). |
+| 4 | `config/settings/base.py` | MODIFY | Dodać `LOGGING` dict z handler `"mongo"` przez dotted path do `factory_or_null`, attached do logger `"apps"` (NIE root — eliminuje Django/3rd-party noise). |
+| 5 | `scrapers/tibiantis_scrapers/settings.py` | MODIFY | Dodać `EXTENSIONS = {"scrapers.tibiantis_scrapers.extensions.MongoStatsExtension": 500}`. |
+
+**Note:** `logs_backend/` to top-level Python package, NIE Django app — żadnej edycji `LOCAL_APPS` w `config/settings/base.py` ani `INSTALLED_APPS` w `config/settings/stubs.py`. Pakiet jest importowany przez Django LOGGING dispatch (`'()': 'logs_backend.handlers.factory_or_null'`) i Scrapy EXTENSIONS — żadna z tych dróg nie wymaga rejestracji w Django app registry.
+
+---
+
+## §3 Decyzje designowe (zaakceptowane 2026-05-08)
+
+### §3.1 Synchronous emit (blocking insert)
+**Wybór:** `MongoLogHandler.emit()` robi `collection.insert_one(...)` synchronously w call'ującym thread'zie.
+
+**Justyfikacja:** Low-traffic backend (deaths co 5 min, characters monitor, GraphQL queries z admin interface) — network roundtrip do Mongo (5-50ms na localhost) jest negligible. Async via background queue dorzuciłby threading complexity (queue overflow, daemon thread lifecycle, shutdown flush) bez aktualnego perf benefit. **YAGNI** — async może być M-future jeśli traffic wzrośnie.
+
+**Odrzucone alternatywy:**
+- Async background queue (Python `queue.Queue` + daemon thread) — over-engineering dla M6 traffic.
+- Sync teraz, async w follow-up — nie dorzucamy chore PR'a "na zapas", przyjdzie naturalnie z M-future signals.
+
+### §3.2 Per-spider-run granularity dla `scrape_logs`
+**Wybór:** 1 dokument per `scrapy crawl <spider>` invocation, flushed w `signals.spider_closed`.
+
+**Justyfikacja:** Low document volume (~6 docs/dzień: deaths co 5 min × 24h przy enabled Beat = 288, characters co 1h = 24; nawet przy oba enabled to <500 docs/dzień, manageable). Pasuje pod CLAUDE.md §4 "liczba pozyskanych rekordów" (cumulative metric per crawl). Per-request granularity (każdy URL = 1 doc) wymagałby Scrapy `DOWNLOADER_MIDDLEWARE` i wygenerowałby ~1500 docs/dzień bez wyraźnego debug benefit (failed URLs i tak są w `crawler.stats.downloader/exception_count`).
+
+**Odrzucone alternatywy:**
+- Per-request — zbyt duży volume, Scrapy `crawler.stats` już aggreguje to samo bez per-doc cost.
+- Hybrid (run header + nested per-request array) — Mongo doc size limit 16MB nie jest realnym blockerem, ale querying nested arrays jest awkward (`$elemMatch` + index na nested fields). YAGNI.
+
+### §3.3 Silent fallback do stderr przy Mongo failure
+**Wybór:** `MongoLogHandler.emit()` owija `insert_one` w `try/except (pymongo.errors.PyMongoError, Exception)` → na fail flush'uje record do `sys.stderr.write(self.format(record))`.
+
+**Justyfikacja:** Standard Python logging philosophy — `logging.Handler.handleError` default catches exceptions w emit i pisze do stderr. App nigdy nie crashuje od logu. Mongo down jest observability problem, NIE app blocker. Dla scrape extension: na fail `spider.logger.error("Mongo flush failed: %s", e)` zamiast stderr (bo Scrapy ma własny logger context).
+
+**Odrzucone alternatywy:**
+- Fail-fast (raise) — `logger.info` w widoku rzucałby 500 dla całego request flow gdy Mongo down. Niepraktyczne dla prod.
+- "Disable handler po pierwszym fail" — wymaga restart żeby logi wróciły, problemy z observability gdy Mongo wstanie ale handler dalej disabled.
+
+### §3.4 NullHandler gdy `MONGO_URL` empty
+**Wybór:** `logs_backend.handlers.factory_or_null()` zwraca `logging.NullHandler` gdy `settings.MONGO_URL` empty/missing, `MongoLogHandler(...)` gdy set. Scrapy: `MongoStatsExtension.from_crawler` raise `scrapy.exceptions.NotConfigured` przy empty `MONGO_URL` → Scrapy ciche disable extension.
+
+**Justyfikacja:** Lokalne dev workflow bez Docker / bez Mongo running — app powinien startować i pisać do console. `MONGO_URL` jako required env var byłoby invasive (każdy `manage.py runserver` smoke wymagałby Mongo up). Stderr/console handler dalej działa (Django `LOGGING` default).
+
+**Odrzucone alternatywy:**
+- `MONGO_URL` REQUIRED (`ImproperlyConfigured` jak brak) — invasive dla dev.
+- Default `mongodb://localhost:27017` — w prod gdzie env var jest missing app cicho zapisuje do nieistniejącego localhost'a → silent fallback do stderr od pierwszego logu, mylące dla operatora.
+
+### §3.5 Indeksy na obu kolekcjach
+**Wybór:** Tworzone przy pierwszym `get_collection(name)` call w `logs_backend/__init__.py` przez `collection.create_index(...)` (idempotent w Mongo — no-op gdy index już istnieje).
+
+**Indexes:**
+- `app_logs.timestamp` — descending (najnowsze pierwsze; debug query "ostatnie 100 logów").
+- `scrape_logs.spider_name + finished_at` — compound index (descending na `finished_at`); query "ostatnie 10 deaths runów".
+
+**Justyfikacja:** Bez indeksów full collection scan na każdy debug query. M-future moglibyśmy dorzucić TTL index dla retention; teraz priorytet na prosty debug experience.
+
+**Odrzucone:** Brak indeksów — przyszłe debug session'y (np. "czemu Yhral failowało wczoraj") wymagałyby `collection.find({"logger": "..."}).sort("timestamp", -1).limit(100)` na full scan.
+
+### §3.6 Formatted `exc_info` string (NIE structured)
+**Wybór:** `MongoLogHandler.emit()` formatuje `record.exc_info` przez `self.formatter.formatException(record.exc_info)` (standardowy `logging.Formatter` API) i zapisuje jako string field `exc_info`.
+
+**Justyfikacja:** Tradycyjny logging output, czytelny dla człowieka, jeden field zamiast N. M-future structured (file/line/type/msg array) jeśli pojawi się observability tool który tego wymaga (np. Sentry alternative).
+
+---
+
+## §4 Document schemas
+
+### §4.1 `app_logs`
+
+Jeden dokument per `logger.info(...)`/`.warning(...)`/`.error(...)`/`.critical(...)` call gdzie:
+- Logger name zaczyna się od `apps.` (filter w `LOGGING` dict — handler `"mongo"` attached do logger `"apps"`).
+- Level ≥ INFO.
+
+**Schema:**
+
+```json
+{
+  "_id": ObjectId,
+  "timestamp": ISODate,                     // datetime.fromtimestamp(record.created, UTC)
+  "level": "INFO",                          // record.levelname
+  "logger": "apps.bedmages.services",       // record.name
+  "message": "BedmageWatch created for ...",  // record.getMessage()
+  "module": "services",                     // record.module
+  "function": "add_bedmage_watch",          // record.funcName
+  "line": 23,                               // record.lineno
+  "exc_info": "Traceback (most recent call last):\n  ..."  // OPTIONAL — only when record.exc_info, formatted via formatter.formatException
+}
+```
+
+**Indexes:**
+- `{ timestamp: -1 }` — descending dla "ostatnie N logów" query pattern.
+
+### §4.2 `scrape_logs`
+
+Jeden dokument per spider crawl invocation, flushed w `signals.spider_closed` przez `MongoStatsExtension`.
+
+**Schema:**
+
+```json
+{
+  "_id": ObjectId,
+  "spider_name": "deaths",                  // crawler.spider.name
+  "started_at": ISODate,                    // captured w spider_opened
+  "finished_at": ISODate,                   // captured w spider_closed
+  "duration_seconds": 3.5,                  // (finished_at - started_at).total_seconds()
+  "items_scraped": 50,                      // crawler.stats.get_value("item_scraped_count", 0)
+  "items_dropped": 0,                       // crawler.stats.get_value("item_dropped_count", 0)
+  "stats": {                                // crawler.stats.get_stats() — raw dict, schemaless
+    "downloader/request_count": 1,
+    "downloader/response_status_count/200": 1,
+    "log_count/INFO": 5,
+    "log_count/ERROR": 0,
+    "scheduler/dequeued/memory": 1,
+    "elapsed_time_seconds": 3.5,
+    "...": "..."
+  },
+  "errors": [                               // populated only if log_count/ERROR > 0
+    "Failed to parse character page: ..."
+  ]
+}
+```
+
+**Indexes:**
+- `{ spider_name: 1, finished_at: -1 }` — compound; supports query "ostatnie 10 runów dla `deaths` spider'a".
+
+---
+
+## §5 D-task split
+
+| # | ID | Tytuł | Czas | Branch | Zależy od |
+|---|---|---|---|---|---|
+| 1 | M6-D28 | `logs_backend/` package + `MongoLogHandler` + factory + Django LOGGING integration + tests | 2-3h | `feat/<#>-mongo-log-handler` | M5 closed |
+| 2 | M6-D29 | `MongoStatsExtension` + Scrapy signals + `scrape_logs` doc + tests | 2-3h | `feat/<#>-mongo-stats-extension` | D28 |
+| 3 | M6-D30 | E2E smoke (live spider mocked subprocess + real Mongo) + M6 closure (PROGRESS.md retro + milestone close) | 2h | `feat/<#>-m6-e2e` + `docs/close-m6-mongo-logging` (M5-D27 pattern: 2 PR-y w 1 issue) | D29 |
+
+**Total:** ~7-8h, ~2 dni roboczych. Mniejsze niż M5 (5 D-tasków, ~13-15h) bo M6 jest wąsko zakresowy (logging only, no business logic).
+
+### Spec section refs do D-tasków (mapping)
+
+| Spec section | Realizowane przez |
+|---|---|
+| §3.1 sync emit | D28 |
+| §3.2 per-spider-run | D29 |
+| §3.3 silent fallback (Django side) | D28 |
+| §3.3 silent fallback (Scrapy side) | D29 |
+| §3.4 NullHandler / NotConfigured | D28 (Django) + D29 (Scrapy) |
+| §3.5 indeksy | D28 (`get_collection` z `create_index`) |
+| §3.6 formatted exc_info | D28 |
+| §4.1 app_logs schema | D28 |
+| §4.2 scrape_logs schema | D29 |
+| §6 error handling | D28 + D29 |
+| §7 testing | D28 + D29 + D30 e2e |
+
+---
+
+## §6 Error handling
+
+### §6.1 Mongo down podczas Django `logger.emit()`
+```python
+def emit(self, record: logging.LogRecord) -> None:
+    try:
+        doc = self._build_doc(record)
+        self.collection.insert_one(doc)
+    except (PyMongoError, Exception):  # broad on purpose — never break app
+        # Standard logging.Handler.handleError fallback semantics
+        self.handleError(record)  # default impl writes to sys.stderr
+```
+
+### §6.2 Mongo down podczas Scrapy `spider_closed`
+```python
+def spider_closed(self, spider: Spider, reason: str) -> None:
+    doc = self._build_doc(spider, reason)
+    try:
+        self.collection.insert_one(doc)
+    except (PyMongoError, Exception):
+        spider.logger.error("Mongo flush failed: %s", e, exc_info=True)
+        # Don't raise — spider close must not block on observability layer
+```
+
+### §6.3 `MONGO_URL` empty
+- **Django:** `factory_or_null()` zwraca `NullHandler` → `logger.info()` is no-op (relative do Mongo); console handler dalej działa.
+- **Scrapy:** `MongoStatsExtension.from_crawler` raise `scrapy.exceptions.NotConfigured` → Scrapy log "Extension X disabled (NotConfigured)" + crawl continues normalnie bez `scrape_logs` flush.
+
+### §6.4 Connection pool exhausted / slow
+`pymongo.MongoClient` ma default `maxPoolSize=100`, `serverSelectionTimeoutMS=30000`. Dla low-traffic backendu (M6) wystarczy default. Konfiguracja w `logs_backend/__init__.py:get_mongo_client()`:
+
+```python
+return MongoClient(
+    settings.MONGO_URL,
+    serverSelectionTimeoutMS=2000,  # FAST fail — log handler nie może wisieć 30s na każdy emit
+    connectTimeoutMS=2000,
+    socketTimeoutMS=2000,
+)
+```
+
+`serverSelectionTimeoutMS=2000` zamiast default 30s — gdy Mongo niedostępne, fail-fast 2s zamiast blokować emit thread na 30s. Po fail: silent fallback do stderr (§6.1).
+
+---
+
+## §7 Testing strategy
+
+### §7.1 Real Mongo (NIE mongomock)
+
+CI ma `mongo:7` service (już skonfigurowany w `ci.yml` per CLAUDE.md §13.1):
+- `MONGO_URL: mongodb://localhost:27017`
+- `MONGO_DB: tibiantis_logs_test`
+
+Lokalnie: `docker-compose.dev.yml` ma Mongo. `mongomock` library odrzucony — real Mongo szybkie (insert+drop ~10ms), CI service już skonfigurowany, bypass real driver bug surface.
+
+### §7.2 Pytest fixture
+
+```python
+# tests/unit/logs_backend/conftest.py (local scope — fixture nie potrzebny dla testów apps/*)
+import pytest
+from logs_backend import get_mongo_client
+
+@pytest.fixture
+def mongo_db():
+    """Yield clean test DB. Drops all collections in teardown."""
+    client = get_mongo_client()
+    db = client[settings.MONGO_DB]
+    yield db
+    for collection_name in db.list_collection_names():
+        db[collection_name].drop()
+```
+
+### §7.3 Test scenarios
+
+**`tests/unit/logs_backend/test_mongo_log_handler.py`:**
+- `test_emit_writes_doc_with_expected_fields` — emit `INFO` record, assert collection has 1 doc z poprawnymi fields.
+- `test_emit_includes_exc_info_for_error_records` — emit ERROR z `exc_info`, assert doc ma formatted traceback string.
+- `test_emit_falls_back_to_stderr_on_mongo_failure` — mock `MongoClient.insert_one` raises `ConnectionFailure`, assert NOT raised; check stderr capture (capsys).
+- `test_factory_returns_null_handler_when_mongo_url_empty` — `@override_settings(MONGO_URL="")`, factory zwraca `NullHandler`.
+- `test_factory_returns_mongo_handler_when_mongo_url_set` — factory zwraca `MongoLogHandler`.
+
+**`tests/unit/logs_backend/test_indexes.py`:**
+- `test_get_collection_creates_indexes_on_first_call` — pierwsze `get_collection("app_logs")` tworzy index na `timestamp`.
+- `test_get_collection_idempotent_index_creation` — drugi call NIE rzuca (Mongo `create_index` is idempotent).
+
+**`tests/unit/scrapers/test_mongo_stats_extension.py`:**
+- `test_extension_raises_not_configured_when_mongo_url_empty` — `MongoStatsExtension.from_crawler(crawler)` z empty `MONGO_URL` → `NotConfigured`.
+- `test_spider_opened_records_started_at` — call `spider_opened`, assert internal state ma `started_at` datetime.
+- `test_spider_closed_flushes_doc_with_stats` — call full lifecycle, assert collection ma 1 doc z `spider_name`, `started_at`, `finished_at`, `stats`.
+- `test_spider_closed_logs_error_on_mongo_failure` — mock `insert_one` raises, assert spider.logger.error called, no raise propagation.
+
+**`tests/integration/test_m6_logging_e2e.py`:**
+- `test_e2e_django_logger_persists_to_mongo` — `apps.bedmages` logger emits, assert doc w `app_logs`.
+- `test_e2e_spider_run_persists_to_scrape_logs` — full crawl (mocked subprocess + fixture spider), assert doc w `scrape_logs`.
+
+### §7.4 Coverage cel
+
+- `logs_backend/__init__.py` 100%
+- `logs_backend/handlers.py` 100%
+- `scrapers/tibiantis_scrapers/extensions.py` 100%
+- Cumulative `logs_backend/*.py` ≥ 95% (DoD).
+
+---
+
+## §8 Definition of Done M6
+
+- [ ] **3 PR merged, 3 Issues zamknięte** (D28-D30 + closure PR).
+- [ ] **`logs_backend/` package** (`__init__.py` + `handlers.py`) z lazy `MongoClient` singleton + `MongoLogHandler` + `factory_or_null`.
+- [ ] **`scrapers/tibiantis_scrapers/extensions.py`** z `MongoStatsExtension` rejestrowanym w `EXTENSIONS` dict.
+- [ ] **Django `LOGGING`** w `base.py` z handler `"mongo"` attached do logger `"apps"`.
+- [ ] **`MONGO_URL` empty** → app startuje normalnie (NullHandler dla Django, NotConfigured dla Scrapy).
+- [ ] **`MONGO_URL` set** + Mongo running → `logger.info(...)` w `apps.*` zapisuje doc do `app_logs`; `scrapy crawl <spider>` zapisuje doc do `scrape_logs`.
+- [ ] **Mongo down** → app NIE crashuje, fallback do stderr (Django) / `spider.logger.error` (Scrapy).
+- [ ] **Indexes** stworzone idempotentnie przy pierwszym `get_collection` call.
+- [ ] **Wszystkie pre-commit + CI zielone** dla każdego PR-a.
+- [ ] **Coverage cumulative `logs_backend/*` ≥ 95%** (cel 100%).
+- [ ] **PROGRESS.md** rozszerzony o sekcję M6 z retro per Issue.
+- [ ] **Milestone M6 zamknięty** na GitHub via `gh api -X PATCH .../milestones/6 -f state=closed`.
+
+---
+
+## §9 Open questions / future work (NIE w M6 scope)
+
+- **TTL retention** — `app_logs` 30 dni, `scrape_logs` 90 dni. Implementation: TTL index na `timestamp`/`finished_at`. Decyzja przy pierwszej observability sesji gdy Mongo storage rośnie.
+- **GraphQL admin query** dla `scrape_logs` — `recentScrapeRuns(spider: String, limit: Int)` JWT-protected, admin-only. Może być w M7+ (Discord bot dashboard).
+- **Per-request `scrape_logs`** — Scrapy `DOWNLOADER_MIDDLEWARE` z `process_response`/`process_exception`. Decyzja dopiero gdy per-spider-run okaże się niewystarczający dla debug session'a.
+- **Async/queued emit** — `queue.Queue` + daemon thread + batch insert. Decyzja przy pierwszym wzroście traffic'u (10x current).
+- **Structured `exc_info`** (file/line/type/msg array) — gdy podłączymy Sentry/alternative observability tool który zinterpretuje structured errors lepiej niż formatted string.
+- **Aggregation pipelines / dashboard** — Grafana/Metabase dashboardy nad `scrape_logs` (success rate per spider, daily volume). M-future po wdrożeniu Discord bot (stabilna baseline traffic'u).
+- **`logs_backend.middleware`** — Django middleware capturing request user/path/method dla `app_logs` enrichment. Kandydat na M7+ (tied do JWT/admin observability).
+- **Docker compose** — Mongo healthcheck w `docker-compose.dev.yml`. Carry-over do M9 (Dockeryzacja).


### PR DESCRIPTION
## Summary

Wprowadza pełny pakiet design'owy dla Milestone M6 (Mongo logging — backend), bez kodu produkcyjnego. Po merge tego PR'a tworzymy 3 GitHub issues z bodies w `.github/issue-bodies/m6-d28.md`/`d29.md`/`d30.md` i ruszamy z implementacją (D28→D29→D30).

**Pliki:**
- `docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md` — design spec (9 sekcji, ~360 linii)
- `docs/superpowers/plans/2026-05-08-m6-implementation-plan.md` — implementation plan (~300 linii)
- `.github/issue-bodies/m6-d28.md` — D28 logs_backend + MongoLogHandler + Django LOGGING (~265 linii)
- `.github/issue-bodies/m6-d29.md` — D29 MongoStatsExtension + Scrapy signals + scrape_logs (~165 linii)
- `.github/issue-bodies/m6-d30.md` — D30 e2e + M6 closure (~190 linii)

Razem ~5 plików, +917 linii (zero kodu produkcyjnego — sam design + procedural).

## Scope (zaakceptowane podczas brainstormingu)

Tylko CLAUDE.md §4 minimum viable:
- 2 kolekcje: `app_logs` (Python logging output z `apps.*`, INFO+) + `scrape_logs` (1 doc per `scrapy crawl <spider>` invocation)
- `pymongo` bezpośrednio (NIE Djongo/MongoEngine)
- Custom `MongoLogHandler` w `logs_backend/` (top-level package, NIE Django app)
- Scrapy `MongoStatsExtension` z `spider_opened`/`spider_closed` signals

**Poza zakresem M6:** TTL retention, GraphQL admin query, per-request granularity, async/queued emit, structured exc_info, aggregation pipelines.

## Decyzje designowe (spec §3, zaakceptowane)

1. **Synchronous emit** (blocking insert) — low-traffic backend, async byłby YAGNI.
2. **Per-spider-run granularity** dla `scrape_logs` — 1 doc per crawl, NIE per-request (~6 docs/dzień vs ~1500).
3. **Silent fallback do stderr** przy Mongo failure (`handleError` stdlib pattern) — logging never breaks the app.
4. **NullHandler** gdy `MONGO_URL` empty (Django) / `NotConfigured` (Scrapy) — dev mode bez Mongo.
5. **Indexes** na obu kolekcjach (idempotent `create_index` w `get_collection`) — `app_logs.timestamp` desc, `scrape_logs.spider_name + finished_at` compound.
6. **Formatted `exc_info`** string (NIE structured) — czytelne dla człowieka, M-future structured jeśli pojawi się Sentry/alternative.

## D-task split

| # | ID | Title | Czas | Zależy od |
|---|---|---|---|---|
| 1 | M6-D28 | `logs_backend/` + `MongoLogHandler` + factory + Django LOGGING | 2-3h | M5 closed + chore #105 |
| 2 | M6-D29 | `MongoStatsExtension` + Scrapy signals + `scrape_logs` | 2-3h | D28 |
| 3 | M6-D30 | E2E (Django logger e2e required, Scrapy e2e optional) + M6 closure | 2h | D29 |

Total ~7-8h, ~2 dni roboczych. Mniejszy niż M5 (5 D-tasków, 13-15h) — M6 jest węższy (logging only, brak business logic, brak GraphQL, brak Celery tasks).

## Self-review

Spec + plan + issue bodies przeszły self-review:
- **Placeholder scan:** Wykryłem 2 `...` placeholdery w D30 issue body (testy Scrapy extension e2e), naprawione przez podział na "required Django logger e2e" + "optional Scrapy extension e2e (Twisted reactor experiment)".
- **Spec coverage:** Każdy spec section §1-§9 ma mapping do D-task'a w plan.md "Spec section refs" table.
- **Type consistency:** `MongoLogHandler`, `MongoStatsExtension`, `factory_or_null`, `get_collection`, `get_mongo_client` — nazwy zgodne między spec, plan, i issue bodies.

## Post-merge action

Po merge utworzymy 3 GitHub issues w milestone #6 z bodies:

```powershell
foreach ($d in 28, 29, 30) {
  gh issue create `
    --milestone "M6 — Mongo logging" `
    --label "phase-M6,app:logs,type:feat" `
    --title "[M6-D$d] <tytuł z body>" `
    --body-file ".github/issue-bodies/m6-d$d.md"
}
```

(Lub manualnie przez gh UI — wybór per workflow.)

## Per CLAUDE.md §15.12

This PR contains **only** docs (spec + plan + issue bodies) — no functional code mixed in. Pre-commit hooks pass for markdown-only diff (mixed-line-ending auto-fix, no-commit-to-branch passing on `docs/m6-mongo-logging`).