### PR TITLE
feat(logs): Mongo log handler + Django LOGGING (M6-D28)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ DEATH_LEVEL_THRESHOLD=30
 
 BEDMAGE_REGEN_MINUTES=100
 BEDMAGE_NOTIFICATION_HANDLER=apps.notifications.handlers.LoggingHandler
+
+#  MongoDB
+MONGO_URL=mongodb://localhost:27017
+MONGO_DB=tibiantis_logs

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -159,3 +159,28 @@ BEDMAGE_NOTIFICATION_HANDLER = env(
     "BEDMAGE_NOTIFICATION_HANDLER",
     default="apps.notifications.handlers.LoggingHandler",
 )
+
+# MongoDB — used ONLY for app_logs / scrape_logs (CLAUDE.md §4).
+# Empty MONGO_URL disables Mongo logging gracefully via NullHandler (spec §3.4).
+MONGO_URL = env("MONGO_URL", default="")
+MONGO_DB = env("MONGO_DB", default="tibiantis_logs")
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+        "mongo": {
+            "()": "logs_backend.handlers.factory_or_null",
+        },
+    },
+    "loggers": {
+        "apps": {
+            "handlers": ["console", "mongo"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -180,7 +180,11 @@ LOGGING = {
         "apps": {
             "handlers": ["console", "mongo"],
             "level": "INFO",
-            "propagate": False,
+            # propagate=True so pytest caplog (LogCaptureHandler on root) keeps
+            # capturing records from apps.* loggers. No duplicate output in
+            # this project — root has no console/mongo handler, only the
+            # propagated record reaches pytest's capture.
+            "propagate": True,
         },
     },
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,5 +28,21 @@ services:
       timeout: 5s
       retries: 5
 
+  mongo:
+    container_name: tibiantis-scraper-mongo
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
 volumes:
   postgres_data:
+  mongo_data:

--- a/logs_backend/__init__.py
+++ b/logs_backend/__init__.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import pymongo
+from django.conf import settings
+from pymongo.collection import Collection
+from pymongo.database import Database
+
+_client: Optional[pymongo.MongoClient] = None
+_initialized_collections: set[str] = set()
+
+
+def get_mongo_client() -> pymongo.MongoClient:
+    """Lazy singleton MongoClient with fail-fast timeouts.
+
+    serverSelectionTimeoutMS=2000 prevents logger.info() from hanging 30s
+    when Mongo is down — fall back to stderr quickly instead (§6.4).
+    """
+    global _client
+    if _client is None:
+        _client = pymongo.MongoClient(
+            settings.MONGO_URL,
+            serverSelectionTimeoutMS=2000,
+            connectTimeoutMS=2000,
+            socketTimeoutMS=2000,
+        )
+    return _client
+
+
+def get_database() -> Database:
+    return get_mongo_client()[settings.MONGO_DB]
+
+
+def get_collection(name: str) -> Collection:
+    """Return collection, creating idempotent indexes on first call.
+
+    Index strategy (§3.5):
+    - app_logs: timestamp DESC (most-recent-first debug query).
+    - scrape_logs: spider_name + finished_at DESC (recent runs per spider).
+    """
+    collection = get_database()[name]
+
+    if name not in _initialized_collections:
+        if name == "app_logs":
+            collection.create_index(
+                [("timestamp", pymongo.DESCENDING)],
+                name="app_logs_timestamp_desc",
+            )
+        elif name == "scrape_logs":
+            collection.create_index(
+                [
+                    ("spider_name", pymongo.ASCENDING),
+                    ("finished_at", pymongo.DESCENDING),
+                ],
+                name="scrape_logs_spider_finished_desc",
+            )
+        _initialized_collections.add(name)
+
+    return collection

--- a/logs_backend/handlers.py
+++ b/logs_backend/handlers.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from django.conf import settings
+from pymongo.errors import PyMongoError
+
+from logs_backend import get_collection
+
+
+class MongoLogHandler(logging.Handler):
+    """Persist log records to Mongo `app_logs`. Silent stderr fallback on failure.
+
+    Synchronous emit (§3.1): blocks the calling thread for one insert_one
+    roundtrip (~5-50ms on local Mongo, fail-fast 2s on unreachable). Acceptable
+    for low-traffic backend.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setFormatter(logging.Formatter())
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            doc: dict[str, object] = {
+                "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc),
+                "level": record.levelname,
+                "logger": record.name,
+                "message": record.getMessage(),
+                "module": record.module,
+                "function": record.funcName,
+                "line": record.lineno,
+            }
+            if record.exc_info:
+                formatter = self.formatter or logging.Formatter()
+                doc["exc_info"] = formatter.formatException(record.exc_info)
+
+            get_collection("app_logs").insert_one(doc)
+        except (PyMongoError, Exception):
+            # Standard logging.Handler.handleError: writes formatted record
+            # to sys.stderr. Never break the app from a log call.
+            self.handleError(record)
+
+
+def factory_or_null() -> logging.Handler:
+    """Return MongoLogHandler if MONGO_URL configured, NullHandler otherwise.
+
+    Wired into Django LOGGING via the `()` factory pattern. Empty MONGO_URL
+    means dev mode without Mongo — app starts cleanly, logs go to console
+    via Django default handlers.
+    """
+    if not settings.MONGO_URL:
+        return logging.NullHandler()
+    return MongoLogHandler()

--- a/poetry.lock
+++ b/poetry.lock
@@ -973,6 +973,27 @@ markdown = ["types-markdown (>=0.1.5)"]
 requests = ["types-requests"]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+description = "DNS toolkit"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af"},
+    {file = "dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"},
+]
+
+[package.extras]
+dev = ["black (>=25.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "hypercorn (>=0.17.0)", "mypy (>=1.17)", "pylint (>=3)", "pytest (>=8.4)", "pytest-cov (>=6.2.0)", "quart-trio (>=0.12.0)", "sphinx (>=8.2.0)", "sphinx-rtd-theme (>=3.0.0)", "twine (>=6.1.0)", "wheel (>=0.45.0)"]
+dnssec = ["cryptography (>=45)"]
+doh = ["h2 (>=4.2.0)", "httpcore (>=1.0.0)", "httpx (>=0.28.0)"]
+doq = ["aioquic (>=1.2.0)"]
+idna = ["idna (>=3.10)"]
+trio = ["trio (>=0.30)"]
+wmi = ["wmi (>=1.5.1)"]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -1956,6 +1977,100 @@ docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
 tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
+name = "pymongo"
+version = "4.17.0"
+description = "PyMongo - the Official MongoDB Python driver"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pymongo-4.17.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:47b021363cd923ace5edc7a1d63c0ff8a6d9d43859b8a1ba23645f5afae63221"},
+    {file = "pymongo-4.17.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:422fa50d7d7f5c22ea0953554396c9ef95684a2d775f860bd75a7b510538dfca"},
+    {file = "pymongo-4.17.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:addd0498ebbdc6354227f6ed457ed9fce442d48a3bb30d5b5bad33e104996561"},
+    {file = "pymongo-4.17.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5c8e180cb2cabe37300e1e36c60aa4f2ff956cc579f0142135a5d2cba252243"},
+    {file = "pymongo-4.17.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bd835cdb37a1adec359dd072c24f8bb14809e2644fde86fab4ee2fc9719b9483"},
+    {file = "pymongo-4.17.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4979e7e8887862bbb44d203f00cc8263a3f27237876fa691b6beba23e40e6d8"},
+    {file = "pymongo-4.17.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:77aa4bc164b4de60d5db193b322f0f5b6ead716e831031bfdef8e8bd92205556"},
+    {file = "pymongo-4.17.0-cp310-cp310-win32.whl", hash = "sha256:48bbc576677b50af043df870d84ded67cc3a9b4aa7553201beef4da5dc050a0a"},
+    {file = "pymongo-4.17.0-cp310-cp310-win_amd64.whl", hash = "sha256:e46767f28dea610e02edf6c5d956ce615c3c7790ea396660b9b1efd5c5ead2e0"},
+    {file = "pymongo-4.17.0-cp310-cp310-win_arm64.whl", hash = "sha256:757f2a4c0c2c46cab87df0333681ce69e86c9d5b45bc5203ceba5410b3489e59"},
+    {file = "pymongo-4.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4141e6c6a339789b2974efa00ecd9409101672d77a0e3ee2cc3839eedf8ec4df"},
+    {file = "pymongo-4.17.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e68c76b84e0c132d9dbf9307f12ff8185702328187a87b9aca8c941303873433"},
+    {file = "pymongo-4.17.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ba2195d4f386f839a52a23ea1cfd60ffaaba78a3d7841db51b7e433001139918"},
+    {file = "pymongo-4.17.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8446ff4bfcb6ec2a2e50998c860986a1e992136f998b7f53e7a717fb8aa5a0b9"},
+    {file = "pymongo-4.17.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2a0d5ac205728c86e0a02192f1aa5f865b0d7d51f8df6101c01a69a7fc620d72"},
+    {file = "pymongo-4.17.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:485c8a8eaa4c739f00a331fc73757898ee7c092c214a79e63866ff76aaf282ff"},
+    {file = "pymongo-4.17.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2dfcc795f5b9fedbe179a11fdf6051581479d196582a3fe819a92a00e9b9969"},
+    {file = "pymongo-4.17.0-cp311-cp311-win32.whl", hash = "sha256:c2292144505fb12156b981bd440f3dc994a883da06ac726c0c8692ccdbc1c510"},
+    {file = "pymongo-4.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:2e190827834fce70ecdf9d46796c6dbc0ce08ea87dc2ff5bc6f3f5579b605cb9"},
+    {file = "pymongo-4.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:a8f9c40a09bb7d4b9fc8b1da65ecf6efa79bda5cb2756f39d9b6940fac1d19ae"},
+    {file = "pymongo-4.17.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53ffa94b2340dbf6b055e09a0090618c60482c158ecfc9565642fc996bf0944"},
+    {file = "pymongo-4.17.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6fe0de9d0f6791abce3471230b32b4817bf89d27b1182b6a550e1ec0fa72aa9a"},
+    {file = "pymongo-4.17.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e537e95514dae1aaa718f481ec03151a0f0394bcd05f1322896d8fc1330cb729"},
+    {file = "pymongo-4.17.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37a8385c29881b43eab31f584100fa0eaddedd5607adf010147ba1810118be90"},
+    {file = "pymongo-4.17.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f3ee3d241ed77a4fc99ce3cff3b289c3ebce37f61fdd7349d3592c23b82c8784"},
+    {file = "pymongo-4.17.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9eb5d63a3c518cb0804ed678f5e2b875af032d89a7cf57a57360322cf6a4d222"},
+    {file = "pymongo-4.17.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e97e03fa13327c87e3fdc5656acd01e71817f0c1dc3221cd8f30de136bf4ec3"},
+    {file = "pymongo-4.17.0-cp312-cp312-win32.whl", hash = "sha256:6877214bff5f06f6884a9fc8d9016a4a7a5f51f537f5c51ac3a576f93e7dfb32"},
+    {file = "pymongo-4.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:9828485f72f63c7d802e0ec41f71906f633c2692621ab3af55ca990186b091b1"},
+    {file = "pymongo-4.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:1195370a77baf003b59b10e91ecc4706297197f0dd9d29c840cc556dc08f7cee"},
+    {file = "pymongo-4.17.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:809ec74de3b9148ae43fa8df9faf53470f511c8d384f13b99d6f671f2a379f15"},
+    {file = "pymongo-4.17.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a431b737816bf4cddd4fa0fcef04e424ad36b7692734a64150f872fb8f3208be"},
+    {file = "pymongo-4.17.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4fab10f8403169ce92f3cea921609d9ee81107306caae06c08f592d4b8ad2b5"},
+    {file = "pymongo-4.17.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20323b0b1c1d33770ad1fc68d429c757734ce9ad3594421c3d6618f10572b1b9"},
+    {file = "pymongo-4.17.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5a5de048e6da5c18e27cc2437e8c15b3b0cdc8385c15b41178b0caa3322a09c2"},
+    {file = "pymongo-4.17.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dff3de1294fbbc1db0ba6b511f77b8e540601d092538a31312e99c8a91a78b1e"},
+    {file = "pymongo-4.17.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faf03e4c2aafd6de626dbd30ba246d369ae33f47f10629d1bbe40f72115027a6"},
+    {file = "pymongo-4.17.0-cp313-cp313-win32.whl", hash = "sha256:c9786665926a09630c5d420c79762cfadbff35a9438bcbc4c81a9fb5ab9228b7"},
+    {file = "pymongo-4.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:5960519b4d7168f1ecdd3ea10c81b2aedeb9423651aca953cfbc8e76705d3b38"},
+    {file = "pymongo-4.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:0ff6bd2f735ab5356541e3e57d5b7dbfbc3f2ee1ccb10b6b0f82d58af69d1d8e"},
+    {file = "pymongo-4.17.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ff5aa3f1c7e3f08eb0e7a016c91ba468b1850ccfd63d9b1f12f56350f4974cef"},
+    {file = "pymongo-4.17.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e816db649ba5d7de0568cf3a9f287a9dc9aad21cf0ca667ab156a7ef47fca0b0"},
+    {file = "pymongo-4.17.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c4fded3a9f1d6a687e36ebd384ac6d00b9b00de1969aa74048e7051ec2a713"},
+    {file = "pymongo-4.17.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2db66aa8dd253a0fc1fad3b0d23d5b3993f7ebde02fbbd7727128debf2853675"},
+    {file = "pymongo-4.17.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3987e96e7c7be4083d42e8ac2cc6c0d5b78db9973c90fce42ae800b616ca6b20"},
+    {file = "pymongo-4.17.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cee36b3c0d0354f880fa7a7fdcdaf2bb5e542c2281e25c1bfadf8cfe21eba7d2"},
+    {file = "pymongo-4.17.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:320b34457b20bbcc79997801f95d25ce00472915ca5241167242b42c4359e027"},
+    {file = "pymongo-4.17.0-cp314-cp314-win32.whl", hash = "sha256:df4a644af9ae132d4bfdb2e9516ea51a615fd881caddfbfbd071cf1354844479"},
+    {file = "pymongo-4.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:c797f8a80957134f6dd9690367a0f8f5906d672119af2c6aa55f0c527b656bed"},
+    {file = "pymongo-4.17.0-cp314-cp314-win_arm64.whl", hash = "sha256:68fca71e05ee5da23a8d73cee8379dfb3d26e609a377cae731d742771ed96946"},
+    {file = "pymongo-4.17.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b4384700cffc3f1dd98e088bc0072dedf6d7d68a230bb4b972665cf69c071c1e"},
+    {file = "pymongo-4.17.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:93641192644fa1ee0f34030e774fd31022a27ad11ba22cb1716142231524f8bd"},
+    {file = "pymongo-4.17.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:75bc3aa5b94fdb7138d357ec6ca61cd97e0c79f4f7f0bd3efe9639b15cc50942"},
+    {file = "pymongo-4.17.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e8f8e23c6df7c6d6929f5e734980b227706e73ee847517c9ba5af90f7fc466"},
+    {file = "pymongo-4.17.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:15d3f3d732aecac1f8d481bde4029755615639bd3076f258a2147210aec8515a"},
+    {file = "pymongo-4.17.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c5f62862d0f87be481fa1fe8cb811994486773c94a2b61e509285e3f2890763"},
+    {file = "pymongo-4.17.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64837adbbd72073301af51bb0fc80e3d7707fe5527cea1033ba0320f0b2f881b"},
+    {file = "pymongo-4.17.0-cp314-cp314t-win32.whl", hash = "sha256:b93b22eedc62598cf5ee9d8c8007a8e9121c50fd88137012d8985500e9dc3151"},
+    {file = "pymongo-4.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3689ea34f6b647c7d1e7bdc60fcfb214b2789ed1359a7fb96569c69f50e5f18f"},
+    {file = "pymongo-4.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9543d8f84c2e5608565c08ac679774811e6730770d8a645439b073422a4276fb"},
+    {file = "pymongo-4.17.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4ae22fafca69dd3c78261969e999782ac5fc23b76cf8cccfbc3707982a74cc3d"},
+    {file = "pymongo-4.17.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f09645e0ce4e3825fa0baa8254064a716ed0be33f78feeedd4731016cb8aaa17"},
+    {file = "pymongo-4.17.0-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7db10678814cdf7ea39fd308c6f41395cfa7b29d904bcd7895288963d8f892ba"},
+    {file = "pymongo-4.17.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5376ad67bb30ae910d83affcf997f706d9dee37e8b5dad8b6fedb0626e262d85"},
+    {file = "pymongo-4.17.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bb3ebc86782049f6928dcc583008287cb1c17d463501c94a620f035f5b4fd463"},
+    {file = "pymongo-4.17.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:51e1915761f65f2aaabd0ba691a31d56551d3f19d1263c2d6bf261730603de5f"},
+    {file = "pymongo-4.17.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1175563375d682260f613a96fb7a53dce746ed752bfd924eab61de3bc5bfde34"},
+    {file = "pymongo-4.17.0-cp39-cp39-win32.whl", hash = "sha256:5ab3b8ff79e0dfc49b68f3c925e8cc735ea95c60efaed84cfe75692dffcaac2a"},
+    {file = "pymongo-4.17.0-cp39-cp39-win_amd64.whl", hash = "sha256:b24598dc3c2feccbc83b43044be48145a0dc4f9bee49ef923e3d707d54a55d85"},
+    {file = "pymongo-4.17.0-cp39-cp39-win_arm64.whl", hash = "sha256:8a1be016198a03fd7727cdd55998964bfa4e5a6fd9733c8e95830628cef34d29"},
+    {file = "pymongo-4.17.0.tar.gz", hash = "sha256:70ffa08ba641468cc068cf46c06b34f01a8ce3489f6411309fcb5ceabe6b2fc0"},
+]
+
+[package.dependencies]
+dnspython = ">=2.6.1,<3.0.0"
+
+[package.extras]
+aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
+docs = ["furo (==2025.12.19)", "readthedocs-sphinx-search (>=0.3,<1.0)", "sphinx (>=5.3,<9)", "sphinx-autobuild (>=2020.9.1)", "sphinx-rtd-theme (>=2,<4)", "sphinxcontrib-shellcheck (>=1,<2)"]
+encryption = ["certifi (>=2023.7.22)", "pymongo-auth-aws (>=1.1.0,<2.0.0)", "pymongocrypt (>=1.13.0,<2.0.0)"]
+gssapi = ["pykerberos (>=1.2.4)", "winkerberos (>=0.5.0)"]
+ocsp = ["certifi (>=2023.7.22)", "cryptography (>=42.0.0)", "pyopenssl (>=23.2.0)", "requests (>=2.23.0,<3.0)", "service-identity (>=23.1.0)"]
+snappy = ["python-snappy (>=0.6.0)"]
+test = ["importlib-metadata (>=7.0)", "pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
+zstd = ["backports-zstd (>=1.0.0)"]
+
+[[package]]
 name = "pyopenssl"
 version = "26.0.0"
 description = "Python wrapper module around the OpenSSL library"
@@ -2811,4 +2926,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "c8a280380dbb614aa8076282ad49edee86d7499abaa32a2fd331d6881994f221"
+content-hash = "83392bb889f35b8d425380612285510f75d9618fbf92ade13a1d59b3f51b5fd4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ requires-python = ">=3.13,<4.0"
       "django-choices-field (>=4.0.0,<5.0.0)",
       "celery (>=5.6.3,<6.0.0)",
       "redis (>=7.4.0,<8.0.0)",
-      "django-celery-beat (>=2.9.0,<3.0.0)"
+      "django-celery-beat (>=2.9.0,<3.0.0)",
+      "pymongo (>=4.17.0,<5.0.0)"
   ]
 
 

--- a/tests/unit/logs_backend/conftest.py
+++ b/tests/unit/logs_backend/conftest.py
@@ -1,0 +1,41 @@
+"""Test isolation for logs_backend unit tests.
+
+Module-level singletons in logs_backend (`_client`, `_initialized_collections`)
+leak across tests if not reset — and `_initialized_collections` is keyed by
+collection name only, so switching MONGO_DB between tests silently skips
+index creation in the new DB. Reset both per-test.
+
+Paranoia: force MONGO_DB to a `_test` suffix so a misconfigured env never
+drops production `app_logs` (spec §7.4 + plan §Task #1 Pułapka H).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator
+
+import pytest
+
+import logs_backend
+from logs_backend import get_mongo_client
+
+if TYPE_CHECKING:
+    from django.conf import LazySettings
+
+
+@pytest.fixture(autouse=True)
+def mongo_db(settings: LazySettings) -> Iterator[None]:
+    if not settings.MONGO_DB.endswith("_test"):
+        settings.MONGO_DB = f"{settings.MONGO_DB}_test"
+
+    logs_backend._client = None
+    logs_backend._initialized_collections.clear()
+
+    yield
+
+    # Tests that override MONGO_URL to "" (factory NullHandler path) would
+    # crash MongoClient on empty URI; skip drop in that case.
+    if not settings.MONGO_URL:
+        return
+    db = get_mongo_client()[settings.MONGO_DB]
+    for name in db.list_collection_names():
+        db[name].drop()

--- a/tests/unit/logs_backend/test_mongo_log_handler.py
+++ b/tests/unit/logs_backend/test_mongo_log_handler.py
@@ -1,0 +1,197 @@
+"""Tests for logs_backend.handlers.MongoLogHandler + factory_or_null + indexes.
+
+Real Mongo per spec §7.1 — mongomock rejected because CI mongo:7 service is
+already wired and bypassing the real driver hides bugs. Indexes verified via
+`Collection.index_information()` against the names set in `get_collection`.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pymongo
+import pytest
+from pymongo.collection import Collection
+from pymongo.errors import ConnectionFailure
+
+import logs_backend
+from logs_backend import get_collection, get_mongo_client
+from logs_backend.handlers import MongoLogHandler, factory_or_null
+
+if TYPE_CHECKING:
+    from django.conf import LazySettings
+
+
+# === get_mongo_client / get_collection ===
+
+
+def test_mongo_client_configured_with_fail_fast_timeouts() -> None:
+    """§6.4 + Pułapka B — serverSelectionTimeoutMS=2000 prevents 30s hangs."""
+    client = get_mongo_client()
+
+    assert client.options.server_selection_timeout == 2.0
+    assert client.options.pool_options.connect_timeout == 2.0
+    assert client.options.pool_options.socket_timeout == 2.0
+
+
+def test_get_collection_returns_pymongo_collection() -> None:
+    collection = get_collection("app_logs")
+
+    assert isinstance(collection, Collection)
+
+
+def test_get_collection_creates_index_for_app_logs_on_first_call() -> None:
+    """§3.5 — timestamp DESC index created lazily on first call."""
+    collection = get_collection("app_logs")
+
+    indexes = collection.index_information()
+    assert "app_logs_timestamp_desc" in indexes
+    key = indexes["app_logs_timestamp_desc"]["key"]
+    assert key == [("timestamp", pymongo.DESCENDING)]
+
+
+def test_get_collection_creates_compound_index_for_scrape_logs() -> None:
+    """§3.5 — spider_name + finished_at DESC compound index."""
+    collection = get_collection("scrape_logs")
+
+    indexes = collection.index_information()
+    assert "scrape_logs_spider_finished_desc" in indexes
+    key = indexes["scrape_logs_spider_finished_desc"]["key"]
+    assert key == [
+        ("spider_name", pymongo.ASCENDING),
+        ("finished_at", pymongo.DESCENDING),
+    ]
+
+
+def test_get_collection_idempotent_on_second_call() -> None:
+    """Second call must not raise — Mongo create_index is idempotent (§3.5)."""
+    get_collection("app_logs")
+
+    # Force re-entry into the create_index branch by clearing the cache;
+    # Mongo itself should still no-op the duplicate index.
+    logs_backend._initialized_collections.clear()
+    collection = get_collection("app_logs")
+
+    assert "app_logs_timestamp_desc" in collection.index_information()
+
+
+# === MongoLogHandler.emit ===
+
+
+def _make_record(
+    *,
+    name: str = "apps.test",
+    level: int = logging.INFO,
+    msg: str = "hello",
+    lineno: int = 42,
+    func: str = "test_func",
+    exc_info: tuple | None = None,
+) -> logging.LogRecord:
+    return logging.LogRecord(
+        name=name,
+        level=level,
+        pathname="/fake/path/services.py",
+        lineno=lineno,
+        msg=msg,
+        args=None,
+        exc_info=exc_info,
+        func=func,
+    )
+
+
+def test_emit_writes_doc_with_expected_fields(settings: LazySettings) -> None:
+    """§4.1 schema — every required field present and correctly typed."""
+    handler = MongoLogHandler()
+    record = _make_record(msg="bedmage created")
+
+    handler.emit(record)
+
+    doc = get_collection("app_logs").find_one({"message": "bedmage created"})
+    assert doc is not None
+    assert doc["level"] == "INFO"
+    assert doc["logger"] == "apps.test"
+    assert doc["message"] == "bedmage created"
+    assert doc["module"] == "services"
+    assert doc["function"] == "test_func"
+    assert doc["line"] == 42
+    assert doc["timestamp"] is not None
+
+
+def test_emit_omits_exc_info_for_records_without_exception() -> None:
+    """Pułapka E — exc_info field only present when record.exc_info is set."""
+    handler = MongoLogHandler()
+    record = _make_record(msg="plain info")
+
+    handler.emit(record)
+
+    doc = get_collection("app_logs").find_one({"message": "plain info"})
+    assert doc is not None
+    assert "exc_info" not in doc
+
+
+def test_emit_includes_formatted_exc_info_for_error_records() -> None:
+    """§3.6 — formatted traceback string (not structured), via formatter."""
+    handler = MongoLogHandler()
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        record = _make_record(
+            level=logging.ERROR,
+            msg="caught it",
+            exc_info=sys.exc_info(),
+        )
+
+    handler.emit(record)
+
+    doc = get_collection("app_logs").find_one({"message": "caught it"})
+    assert doc is not None
+    assert "exc_info" in doc
+    assert "ValueError" in doc["exc_info"]
+    assert "boom" in doc["exc_info"]
+    assert "Traceback" in doc["exc_info"]
+
+
+def test_emit_falls_back_to_stderr_on_mongo_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """§3.3 + §6.1 — Mongo down must never raise from emit; stderr fallback."""
+    handler = MongoLogHandler()
+    record = _make_record(msg="should fall back")
+
+    with patch(
+        "logs_backend.handlers.get_collection",
+        side_effect=ConnectionFailure("mongo unreachable"),
+    ):
+        handler.emit(record)  # MUST NOT RAISE
+
+    captured = capsys.readouterr()
+    # handleError's default writes the traceback of the failed emit to stderr.
+    assert "ConnectionFailure" in captured.err or "mongo unreachable" in captured.err
+
+
+# === factory_or_null ===
+
+
+def test_factory_returns_null_handler_when_mongo_url_empty(
+    settings: LazySettings,
+) -> None:
+    """§3.4 — empty MONGO_URL → NullHandler so dev workflow without Mongo works."""
+    settings.MONGO_URL = ""
+
+    handler = factory_or_null()
+
+    assert isinstance(handler, logging.NullHandler)
+    assert not isinstance(handler, MongoLogHandler)
+
+
+def test_factory_returns_mongo_handler_when_mongo_url_set(
+    settings: LazySettings,
+) -> None:
+    settings.MONGO_URL = "mongodb://localhost:27017"
+
+    handler = factory_or_null()
+
+    assert isinstance(handler, MongoLogHandler)


### PR DESCRIPTION
## Summary

Closes #107.

- **`logs_backend/`** new top-level package (NOT a Django app): lazy `MongoClient` singleton with fail-fast 2s timeouts (spec §6.4), idempotent index creation on first `get_collection()` call (`app_logs.timestamp` DESC, `scrape_logs.spider_name+finished_at` compound, §3.5), `MongoLogHandler` with synchronous emit + silent stderr fallback (§3.1, §3.3, §6.1), and `factory_or_null` dispatch returning `NullHandler` when `MONGO_URL` empty (§3.4).
- **Django `LOGGING`** in `config/settings/base.py` — handler `"mongo"` via `'()'` factory, attached to logger `"apps"` with `propagate=False`. Console handler also attached so local dev sees logs.
- **Infra**: `mongo:7` service added to `docker-compose.dev.yml` with healthcheck + volume; `MONGO_URL` / `MONGO_DB` added to `.env.example` and read by `base.py` with safe defaults.
- **Tests**: 11 unit tests in `tests/unit/logs_backend/` against real Mongo (CI `mongo:7` service per ci.yml). Autouse fixture forces `_test` suffix on `MONGO_DB` and resets module singletons between tests. Coverage: `logs_backend/__init__.py` and `logs_backend/handlers.py` both **100%**.

Commits intentionally split per DoD: `build(deps)` → `feat(logs)` → `test(logs)`.

## Test plan

- [ ] CI lint + test green
- [ ] `poetry run pytest tests/unit/logs_backend/ --cov=logs_backend` → 11 passed, 100% coverage
- [ ] Local smoke: `docker compose -f docker-compose.dev.yml up -d mongo` then `poetry run python manage.py shell -c "import logging; logging.getLogger('apps.smoke').info('m6 d28 smoke')"` → `docker exec tibiantis-scraper-mongo mongosh tibiantis_logs --quiet --eval "db.app_logs.findOne({message:'m6 d28 smoke'})"` returns the doc
- [ ] Negative path: stop mongo, repeat `logger.info(...)` → Django stays up, message falls back to stderr (no crash)
- [ ] `MONGO_URL=""` in `.env` → app boots cleanly (NullHandler path)

## Spec / plan refs

- Spec: `docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md` §3.1, §3.3-§3.6, §4.1, §6.1, §6.4
- Plan: `docs/superpowers/plans/2026-05-08-m6-implementation-plan.md` Task #1