### PR TITLE
feat(logs): MongoStatsExtension for Scrapy scrape_logs (M6-D29)

### DIFF
--- a/scrapers/tibiantis_scrapers/extensions.py
+++ b/scrapers/tibiantis_scrapers/extensions.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from django.conf import settings as django_settings
+from pymongo.errors import PyMongoError
+from scrapy import signals
+from scrapy.crawler import Crawler
+from scrapy.exceptions import NotConfigured
+from scrapy.spiders import Spider
+
+from logs_backend import get_collection
+
+logger = logging.getLogger(__name__)
+
+
+class MongoStatsExtension:
+    """Persist 1 document per `scrapy crawl <spider>` to scrape_logs (§3.2).
+
+    Wired via EXTENSIONS dict. Disabled cleanly via NotConfigured when
+    MONGO_URL is empty (dev mode without Mongo).
+    """
+
+    def __init__(self) -> None:
+        self.started_at: datetime | None = None
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> "MongoStatsExtension":
+        if not django_settings.MONGO_URL:
+            raise NotConfigured(
+                "MONGO_URL not configured — MongoStatsExtension disabled"
+            )
+
+        instance = cls()
+        crawler.signals.connect(instance.spider_opened, signal=signals.spider_opened)
+        crawler.signals.connect(instance.spider_closed, signal=signals.spider_closed)
+        return instance
+
+    def spider_opened(self, spider: Spider) -> None:
+        self.started_at = datetime.now(tz=timezone.utc)
+
+    def spider_closed(self, spider: Spider, reason: str) -> None:
+        finished_at = datetime.now(tz=timezone.utc)
+        stats: dict[str, Any] = spider.crawler.stats.get_stats()
+        error_count = stats.get("log_count/ERROR", 0)
+
+        doc = {
+            "spider_name": spider.name,
+            "started_at": self.started_at,
+            "finished_at": finished_at,
+            "duration_seconds": (
+                (finished_at - self.started_at).total_seconds()
+                if self.started_at
+                else 0.0
+            ),
+            "items_scraped": stats.get("item_scraped_count", 0),
+            "items_dropped": stats.get("item_dropped_count", 0),
+            "stats": stats,
+            "errors": [f"log_count/ERROR={error_count}"] if error_count > 0 else [],
+        }
+
+        try:
+            get_collection("scrape_logs").insert_one(doc)
+        except (PyMongoError, Exception) as e:
+            spider.logger.error("Mongo flush failed: %s", e, exc_info=True)

--- a/scrapers/tibiantis_scrapers/settings.py
+++ b/scrapers/tibiantis_scrapers/settings.py
@@ -19,3 +19,7 @@ ITEM_PIPELINES = {
 }
 
 TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
+
+EXTENSIONS = {
+    "scrapers.tibiantis_scrapers.extensions.MongoStatsExtension": 500,
+}

--- a/tests/unit/scrapers/test_mongo_stats_extension.py
+++ b/tests/unit/scrapers/test_mongo_stats_extension.py
@@ -1,0 +1,229 @@
+"""Tests for scrapers.tibiantis_scrapers.extensions.MongoStatsExtension.
+
+Real Mongo per spec §7.1 (CI mongo:7 service). Spider/Crawler are mocked
+because instantiating a real Scrapy crawl inside pytest brings up the
+Twisted reactor and is too heavy for unit scope (plan §Pułapka G).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pymongo.errors import ConnectionFailure
+from scrapy import signals
+from scrapy.exceptions import NotConfigured
+
+import logs_backend
+from logs_backend import get_collection, get_mongo_client
+from scrapers.tibiantis_scrapers.extensions import MongoStatsExtension
+
+if TYPE_CHECKING:
+    from django.conf import LazySettings
+
+
+# === Mongo isolation (mirrors tests/unit/logs_backend/conftest.py) ===
+
+
+@pytest.fixture(autouse=True)
+def mongo_isolation(settings: LazySettings) -> Iterator[None]:
+    """Force _test DB suffix, reset module singletons, drop collections."""
+    if not settings.MONGO_DB.endswith("_test"):
+        settings.MONGO_DB = f"{settings.MONGO_DB}_test"
+
+    logs_backend._client = None
+    logs_backend._initialized_collections.clear()
+
+    yield
+
+    if not settings.MONGO_URL:
+        return
+    db = get_mongo_client()[settings.MONGO_DB]
+    for name in db.list_collection_names():
+        db[name].drop()
+
+
+# === Spider / Crawler test doubles ===
+
+
+def _make_spider(
+    *,
+    name: str = "deaths",
+    stats: dict | None = None,
+) -> MagicMock:
+    spider = MagicMock()
+    spider.name = name
+    spider.crawler.stats.get_stats.return_value = stats or {
+        "item_scraped_count": 50,
+        "item_dropped_count": 0,
+        "log_count/INFO": 5,
+        "log_count/ERROR": 0,
+    }
+    return spider
+
+
+# === from_crawler ===
+
+
+def test_from_crawler_raises_not_configured_when_mongo_url_empty(
+    settings: LazySettings,
+) -> None:
+    """§3.4 — empty MONGO_URL must NotConfigured-disable cleanly, not break Scrapy."""
+    settings.MONGO_URL = ""
+    crawler = MagicMock()
+
+    with pytest.raises(NotConfigured):
+        MongoStatsExtension.from_crawler(crawler)
+
+
+def test_from_crawler_returns_instance_when_mongo_url_set(
+    settings: LazySettings,
+) -> None:
+    settings.MONGO_URL = "mongodb://localhost:27017"
+    crawler = MagicMock()
+
+    instance = MongoStatsExtension.from_crawler(crawler)
+
+    assert isinstance(instance, MongoStatsExtension)
+
+
+def test_from_crawler_subscribes_to_spider_opened_and_closed(
+    settings: LazySettings,
+) -> None:
+    """Extension must connect both lifecycle signals — otherwise no doc flushed."""
+    settings.MONGO_URL = "mongodb://localhost:27017"
+    crawler = MagicMock()
+
+    instance = MongoStatsExtension.from_crawler(crawler)
+
+    connected_signals = {
+        call.kwargs["signal"] for call in crawler.signals.connect.call_args_list
+    }
+    assert signals.spider_opened in connected_signals
+    assert signals.spider_closed in connected_signals
+    # And the handlers are the instance's bound methods
+    handlers = {call.args[0] for call in crawler.signals.connect.call_args_list}
+    assert instance.spider_opened in handlers
+    assert instance.spider_closed in handlers
+
+
+# === spider_opened ===
+
+
+def test_spider_opened_records_started_at_utc() -> None:
+    """started_at must be timezone-aware UTC — BSON requires tz-aware datetimes."""
+    extension = MongoStatsExtension()
+    spider = _make_spider()
+
+    extension.spider_opened(spider)
+
+    assert extension.started_at is not None
+    assert extension.started_at.tzinfo is not None
+    assert extension.started_at.utcoffset().total_seconds() == 0  # UTC
+
+
+# === spider_closed — happy path doc shape ===
+
+
+def test_spider_closed_flushes_doc_with_expected_fields() -> None:
+    """§4.2 schema — full lifecycle produces one doc with all required fields."""
+    extension = MongoStatsExtension()
+    spider = _make_spider(
+        name="deaths",
+        stats={
+            "item_scraped_count": 50,
+            "item_dropped_count": 2,
+            "log_count/INFO": 5,
+            "log_count/ERROR": 0,
+            "downloader/request_count": 1,
+        },
+    )
+
+    extension.spider_opened(spider)
+    extension.spider_closed(spider, reason="finished")
+
+    doc = get_collection("scrape_logs").find_one({"spider_name": "deaths"})
+    assert doc is not None
+    assert doc["spider_name"] == "deaths"
+    assert doc["started_at"] is not None
+    assert doc["finished_at"] is not None
+    assert doc["duration_seconds"] >= 0.0
+    assert doc["items_scraped"] == 50
+    assert doc["items_dropped"] == 2
+    assert isinstance(doc["stats"], dict)
+    assert doc["stats"]["downloader/request_count"] == 1
+    assert doc["errors"] == []
+
+
+def test_spider_closed_uses_zero_duration_when_opened_skipped() -> None:
+    """Defensive — if spider_opened never fired, duration must not crash on None subtraction."""
+    extension = MongoStatsExtension()
+    spider = _make_spider(name="orphan")
+
+    # Skip spider_opened — started_at stays None
+    extension.spider_closed(spider, reason="cancelled")
+
+    doc = get_collection("scrape_logs").find_one({"spider_name": "orphan"})
+    assert doc is not None
+    assert doc["duration_seconds"] == 0.0
+    assert doc["started_at"] is None
+
+
+# === errors field ===
+
+
+def test_spider_closed_populates_errors_when_log_count_error_nonzero() -> None:
+    """Plan §Pułapka G — errors marker when stats show ERROR-level logs."""
+    extension = MongoStatsExtension()
+    spider = _make_spider(
+        name="failing",
+        stats={
+            "item_scraped_count": 10,
+            "item_dropped_count": 0,
+            "log_count/ERROR": 3,
+        },
+    )
+
+    extension.spider_opened(spider)
+    extension.spider_closed(spider, reason="finished")
+
+    doc = get_collection("scrape_logs").find_one({"spider_name": "failing"})
+    assert doc is not None
+    assert doc["errors"] != []
+    assert any("log_count/ERROR=3" in entry for entry in doc["errors"])
+
+
+def test_spider_closed_leaves_errors_empty_when_no_error_logs() -> None:
+    """Sanity inverse of populates_errors — clean runs get empty errors list."""
+    extension = MongoStatsExtension()
+    spider = _make_spider(name="clean", stats={"log_count/ERROR": 0})
+
+    extension.spider_opened(spider)
+    extension.spider_closed(spider, reason="finished")
+
+    doc = get_collection("scrape_logs").find_one({"spider_name": "clean"})
+    assert doc is not None
+    assert doc["errors"] == []
+
+
+# === Mongo failure path ===
+
+
+def test_spider_closed_logs_error_on_mongo_failure_and_does_not_raise() -> None:
+    """§6.2 — Mongo down during spider_closed must NOT block the crawl shutdown."""
+    extension = MongoStatsExtension()
+    spider = _make_spider(name="unreachable_mongo")
+
+    extension.spider_opened(spider)
+    with patch(
+        "scrapers.tibiantis_scrapers.extensions.get_collection",
+        side_effect=ConnectionFailure("mongo unreachable"),
+    ):
+        # MUST NOT RAISE — spider close is on the crawl-shutdown hot path.
+        extension.spider_closed(spider, reason="finished")
+
+    spider.logger.error.assert_called_once()
+    args, kwargs = spider.logger.error.call_args
+    assert "Mongo flush failed" in args[0]
+    assert kwargs.get("exc_info") is True


### PR DESCRIPTION
## Summary

Closes #108.

- **`scrapers/tibiantis_scrapers/extensions.py`** new file: `MongoStatsExtension` subscribes to `spider_opened` (captures `started_at` UTC) and `spider_closed` (builds and inserts one document into `scrape_logs` per spec §4.2 schema). `from_crawler` raises `NotConfigured` when `MONGO_URL` is empty so Scrapy disables the extension cleanly in dev (§3.4). Lazy `get_collection()` call inside `spider_closed` keeps Scrapy startup independent of Mongo availability; PyMongo errors route to `spider.logger.error` and never propagate (§6.2 — shutdown hot path must not block).
- **`scrapers/tibiantis_scrapers/settings.py`**: registers the extension in Scrapy's `EXTENSIONS` dict at priority 500.
- **`errors` field**: empty list on clean runs; populated with `"log_count/ERROR=<n>"` marker when `crawler.stats` records ERROR-level logs (plan §Pułapka G — Scrapy stats don't carry per-message strings, so a count marker is the minimum viable signal).
- **Tests**: 9 unit tests in `tests/unit/scrapers/test_mongo_stats_extension.py` against real Mongo (CI `mongo:7` service per ci.yml). Spider/Crawler mocked because a real crawl brings up the Twisted reactor and is too heavy for unit scope. Coverage: `scrapers/tibiantis_scrapers/extensions.py` **100%**.

Commits intentionally split: `feat(logs)` → `test(logs)`.

## Test plan

- [ ] CI lint + test green
- [ ] `poetry run pytest tests/unit/scrapers/test_mongo_stats_extension.py --cov=scrapers.tibiantis_scrapers.extensions` → 9 passed, 100% coverage
- [ ] Local smoke with Mongo up: `docker compose -f docker-compose.dev.yml up -d mongo` then `poetry run scrapy crawl deaths` (or characters), check `docker exec tibiantis-scraper-mongo mongosh tibiantis_logs --quiet --eval "db.scrape_logs.findOne({},{spider_name:1,started_at:1,finished_at:1,items_scraped:1})"` returns the run
- [ ] Negative path: stop Mongo, repeat crawl → spider shuts down normally, `Mongo flush failed` line in spider logs, no `scrape_logs` doc
- [ ] `MONGO_URL=""` in `.env` → Scrapy startup logs `Disabled extension MongoStatsExtension (NotConfigured)`, crawl continues without `scrape_logs` writes

## Spec / plan refs

- Spec: `docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md` §3.2, §3.3 (Scrapy side), §3.4, §4.2, §6.2
- Plan: `docs/superpowers/plans/2026-05-08-m6-implementation-plan.md` Task #2