### PR TITLE
test(logs): M6 e2e — Django logger → app_logs (M6-D30)

### DIFF
--- a/tests/integration/test_m6_logging_e2e.py
+++ b/tests/integration/test_m6_logging_e2e.py
@@ -1,0 +1,96 @@
+"""E2E integration test for M6 — Django logger → MongoLogHandler → app_logs.
+
+Full chain without bypass: invokes the configured Django LOGGING dispatch
+(factory_or_null → MongoLogHandler → real Mongo), then reads the document
+back via pymongo. Confirms the production wiring works end-to-end.
+
+Scrapy MongoStatsExtension e2e is intentionally skipped (plan §Task #3
+Optional AC, recommendation: opcja 3) — D29 unit tests cover the extension
+flow, and a real `scrapy crawl` subprocess inside pytest brings up the
+Twisted reactor with reactor-reuse hazards. Manual smoke covers it:
+`scrapy crawl deaths` locally + `db.scrape_logs.count_documents({})`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Iterator
+
+import pytest
+
+import logs_backend
+from logs_backend import get_mongo_client
+from logs_backend.handlers import MongoLogHandler
+
+if TYPE_CHECKING:
+    from django.conf import LazySettings
+    from pymongo.database import Database
+
+
+@pytest.fixture
+def mongo_clean(settings: LazySettings) -> Iterator[Database]:
+    """Force _test DB suffix, reset module singletons, drop M6 collections."""
+    if not settings.MONGO_DB.endswith("_test"):
+        settings.MONGO_DB = f"{settings.MONGO_DB}_test"
+    # Paranoia — never let a misconfigured env wipe production app_logs.
+    assert "test" in settings.MONGO_DB.lower()
+
+    logs_backend._client = None
+    logs_backend._initialized_collections.clear()
+
+    db = get_mongo_client()[settings.MONGO_DB]
+    for name in ("app_logs", "scrape_logs"):
+        db[name].drop()
+
+    yield db
+
+    for name in ("app_logs", "scrape_logs"):
+        db[name].drop()
+
+
+def _apps_logger_has_mongo_handler() -> bool:
+    """LOGGING dict applied at Django startup must have wired MongoLogHandler.
+
+    If MONGO_URL was empty at startup, factory_or_null returned NullHandler
+    and these e2e tests cannot assert anything meaningful — fail loudly.
+    """
+    apps_logger = logging.getLogger("apps")
+    return any(isinstance(h, MongoLogHandler) for h in apps_logger.handlers)
+
+
+def test_e2e_django_logger_persists_to_app_logs(mongo_clean: Database) -> None:
+    """logger.info() in apps.* writes 1 doc to app_logs via the configured LOGGING."""
+    assert _apps_logger_has_mongo_handler(), (
+        "MongoLogHandler not attached to 'apps' logger — MONGO_URL was probably "
+        "empty at Django startup. Set MONGO_URL in .env / CI env to run this test."
+    )
+
+    logging.getLogger("apps.test").info("hello e2e")
+
+    docs = list(mongo_clean.app_logs.find({"message": "hello e2e"}))
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc["level"] == "INFO"
+    assert doc["logger"] == "apps.test"
+    assert doc["message"] == "hello e2e"
+    assert doc["timestamp"] is not None
+
+
+def test_e2e_django_logger_with_exception_persists_traceback(
+    mongo_clean: Database,
+) -> None:
+    """logger.exception() persists formatted exc_info string (§3.6)."""
+    assert _apps_logger_has_mongo_handler()
+
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        logging.getLogger("apps.test").exception("operation failed")
+
+    doc = mongo_clean.app_logs.find_one({"message": "operation failed"})
+    assert doc is not None
+    assert doc["level"] == "ERROR"
+    assert "exc_info" in doc
+    assert "ValueError" in doc["exc_info"]
+    assert "boom" in doc["exc_info"]
+    assert "Traceback" in doc["exc_info"]


### PR DESCRIPTION
## Summary

First of two PRs for #109 (M5-D27 pattern: feature PR + closure PR). This is the **feature PR** — the **closure PR** with PROGRESS.md retro + milestone close will follow off fresh master after merge.

- **`tests/integration/test_m6_logging_e2e.py`** new file: 2 e2e tests through the production Django LOGGING wiring. Real Mongo (CI mongo:7), real factory dispatch, real MongoLogHandler emit — no bypass.
  - `test_e2e_django_logger_persists_to_app_logs` — plain `logger.info()` in `apps.*` → 1 doc in `app_logs` with expected fields
  - `test_e2e_django_logger_with_exception_persists_traceback` — `logger.exception()` → formatted traceback string in `exc_info` field per §3.6
- **Scrapy `MongoStatsExtension` e2e intentionally skipped** per plan §Task #3 Optional AC, recommendation opcja 3. D29 unit tests already cover the extension flow with full lifecycle; a real `scrapy crawl` subprocess inside pytest brings up the Twisted reactor with reactor-reuse hazards. Manual smoke (`scrapy crawl deaths` + `db.scrape_logs.count_documents({})`) covers DoD §8.
- **Fixture `mongo_clean`** forces `_test` suffix on `MONGO_DB`, asserts the suffix defensively, resets module singletons (`_client`, `_initialized_collections`), and drops both M6 collections before/after.

## Coverage

Cumulative across M6 production files: **100%**

| File | Cover |
|---|---|
| `logs_backend/__init__.py` | 100% |
| `logs_backend/handlers.py` | 100% |
| `scrapers/tibiantis_scrapers/extensions.py` | 100% |

DoD §7.4 cumulative ≥95% — easily cleared.

## Test plan

- [ ] CI lint + test green
- [ ] `poetry run pytest tests/unit/logs_backend/ tests/unit/scrapers/test_mongo_stats_extension.py tests/integration/test_m6_logging_e2e.py --cov=logs_backend --cov=scrapers.tibiantis_scrapers.extensions` → 22 passed, cumulative 100%
- [ ] Local Mongo manual smoke (`scrapy crawl deaths`) → `scrape_logs` collection has 1 doc with `spider_name=deaths`, populated `stats` dict, non-null `started_at`/`finished_at`

## Spec / plan refs

- Spec: `docs/superpowers/specs/2026-05-08-m6-mongo-logging-design.md` §7 (testing), §8 (DoD)
- Plan: `docs/superpowers/plans/2026-05-08-m6-implementation-plan.md` Task #3 (feature PR scope)

## Next

Closure PR (`docs/close-m6-mongo-logging`) — opened separately from fresh master after this merges. Includes PROGRESS.md M6 retro + `gh api -X PATCH milestones/6 state=closed`.