### PR TITLE
feat(discord): BedmageCog + /bedmage add/remove/list + bedmage wrapper services (M7-D33, #117)

### DIFF
--- a/discord_bot/bot.py
+++ b/discord_bot/bot.py
@@ -37,4 +37,7 @@ async def on_application_command_error(
 
 def setup_bot() -> discord.Bot:
     """Add cogs and return configured bot. D32: no cogs yet (D33+D34 add them)."""
+    from discord_bot.cogs.bedmages import BedmageCog
+
+    bot.add_cog(BedmageCog(bot))
     return bot

--- a/discord_bot/cogs/bedmages.py
+++ b/discord_bot/cogs/bedmages.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from asgiref.sync import sync_to_async
+import discord
+from discord.ext import commands
+
+from discord_bot.services import (
+    add_bedmage_for_discord_user,
+    list_bedmages_for_discord_user,
+    remove_bedmage_for_discord_user,
+)
+
+
+class BedmageCog(commands.Cog):
+    bedmage = discord.SlashCommandGroup("bedmage", "Manage your bedmage tracking list")
+
+    def __init__(self, bot: discord.Bot) -> None:
+        self.bot = bot
+
+    @bedmage.command(name="add", description="Add a character to your bedmage list")
+    async def add(
+        self,
+        ctx: discord.ApplicationContext,
+        character_name: discord.Option(str, "Tibiantis character name", max_length=64),
+    ) -> None:
+        watch, created = await sync_to_async(add_bedmage_for_discord_user)(
+            discord_id=ctx.author.id,
+            discord_username=ctx.author.name,
+            character_name=character_name,
+        )
+        msg = (
+            f"✅ Added `{character_name}` to your bedmage list."
+            if created
+            else f"ℹ️ `{character_name}` was already on your list."
+        )
+        await ctx.respond(msg, ephemeral=True)
+
+    @bedmage.command(
+        name="remove", description="Remove a character from your bedmage list"
+    )
+    async def remove(
+        self,
+        ctx: discord.ApplicationContext,
+        character_name: discord.Option(str, "Tibiantis character name", max_length=64),
+    ) -> None:
+        removed = await sync_to_async(remove_bedmage_for_discord_user)(
+            discord_id=ctx.author.id,
+            character_name=character_name,
+        )
+        msg = (
+            f"✅ Removed `{character_name}` from your list."
+            if removed
+            else f"ℹ️ `{character_name}` wasn't on your list."
+        )
+        await ctx.respond(msg, ephemeral=True)
+
+    @bedmage.command(name="list", description="Show your bedmage list")
+    async def list(self, ctx: discord.ApplicationContext) -> None:
+        watches = await sync_to_async(list_bedmages_for_discord_user)(ctx.author.id)
+        if not watches:
+            await ctx.respond(
+                "Your bedmage list is empty. Add with `/bedmage add <name>`.",
+                ephemeral=True,
+            )
+            return
+        names = ", ".join(f"`{w.character.name}`" for w in watches)
+        await ctx.respond(f"Your bedmages: {names}", ephemeral=True)

--- a/discord_bot/services.py
+++ b/discord_bot/services.py
@@ -7,6 +7,9 @@ from django.db import transaction
 from apps.accounts.models import User
 from discord_bot.models import DiscordChannel
 
+from apps.bedmages.models import BedmageWatch
+from apps.bedmages.services import add_bedmage_watch, remove_bedmage_watch
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,3 +59,41 @@ def set_death_threshold_for_guild(
         threshold,
     )
     return channel
+
+
+def add_bedmage_for_discord_user(
+    discord_id: int, discord_username: str, character_name: str
+) -> tuple[BedmageWatch, bool]:
+    """Auto-create User + delegate to apps.bedmages.services.add_bedmage_watch.
+
+    Returns (watch, created). created=False when watch already on user's list
+    (catches ValueError from apps service, idempotent ack).
+    """
+    user, _ = get_or_create_user_by_discord_id(discord_id, discord_username)
+    try:
+        watch = add_bedmage_watch(user, character_name)
+        return watch, True
+    except ValueError:
+        watch = BedmageWatch.objects.get(user=user, character__name=character_name)
+        return watch, False
+
+
+def remove_bedmage_for_discord_user(discord_id: int, character_name: str) -> bool:
+    """Auto-create User + delegate to apps.bedmages.services.remove_bedmage_watch.
+
+    Returns True if watch existed and was deleted, False otherwise.
+    Idempotent — never raises.
+    """
+    user, _ = get_or_create_user_by_discord_id(discord_id, discord_username="")
+    return remove_bedmage_watch(user, character_name)
+
+
+def list_bedmages_for_discord_user(discord_id: int) -> list[BedmageWatch]:
+    """Active bedmages for user. Empty list if user unknown (no auto-create on read)."""
+    try:
+        user = User.objects.get(discord_id=discord_id)
+    except User.DoesNotExist:
+        return []
+    return list(
+        BedmageWatch.objects.filter(user=user, active=True).select_related("character")
+    )

--- a/tests/unit/discord_bot/test_bedmage_cog.py
+++ b/tests/unit/discord_bot/test_bedmage_cog.py
@@ -1,0 +1,210 @@
+"""Tests for discord_bot.cogs.bedmages — slash command handlers.
+
+py-cord wraps `@bedmage.command(...)` decorators into `SlashCommand` objects
+with a `.callback` attribute holding the underlying coroutine. Tests invoke
+`cog.<name>.callback(cog, ctx, **kwargs)` to bypass Discord's slash option
+parsing — the parameter values are passed directly.
+
+Service functions are monkey-patched in the cog module's namespace so we
+test the cog wiring (response shape, ephemeral flag, message formatting)
+in isolation from M5 ORM and the auto-create logic exercised by
+test_services.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from discord_bot.cogs.bedmages import BedmageCog
+
+
+# === /bedmage add ===
+
+
+@pytest.mark.asyncio
+async def test_bedmage_add_command_responds_with_added_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path — created=True → ✅ confirmation + ephemeral.
+
+    Locks the response shape: emoji prefix, character name in backticks,
+    ephemeral=True (user-private data per §3.7).
+    """
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.author.name = "alice"
+    mock_ctx.respond = AsyncMock()
+
+    fake_watch = MagicMock()
+    monkeypatch.setattr(
+        "discord_bot.cogs.bedmages.add_bedmage_for_discord_user",
+        lambda **kw: (fake_watch, True),
+    )
+
+    cog = BedmageCog(bot=MagicMock())
+    await cog.add.callback(cog, mock_ctx, character_name="Yhral")
+
+    mock_ctx.respond.assert_awaited_once()
+    args, kwargs = mock_ctx.respond.call_args
+    assert "✅" in args[0]
+    assert "`Yhral`" in args[0]
+    assert "Added" in args[0]
+    assert kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_bedmage_add_command_responds_with_already_on_list_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Duplicate add — created=False → ℹ️ info, NOT an error.
+
+    §3.2 idempotent UX: wrapper translates M5 `ValueError` into `(existing, False)`
+    so the user sees a friendly "already on list" message instead of a traceback.
+    """
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.author.name = "alice"
+    mock_ctx.respond = AsyncMock()
+
+    fake_watch = MagicMock()
+    monkeypatch.setattr(
+        "discord_bot.cogs.bedmages.add_bedmage_for_discord_user",
+        lambda **kw: (fake_watch, False),
+    )
+
+    cog = BedmageCog(bot=MagicMock())
+    await cog.add.callback(cog, mock_ctx, character_name="Yhral")
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "ℹ️" in args[0]
+    assert "already on your list" in args[0]
+    assert kwargs["ephemeral"] is True
+
+
+# === /bedmage remove ===
+
+
+@pytest.mark.asyncio
+async def test_bedmage_remove_command_responds_with_removed_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Service returned True → ✅ removal confirmation."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.bedmages.remove_bedmage_for_discord_user",
+        lambda **kw: True,
+    )
+
+    cog = BedmageCog(bot=MagicMock())
+    await cog.remove.callback(cog, mock_ctx, character_name="Yhral")
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "✅" in args[0]
+    assert "Removed" in args[0]
+    assert "`Yhral`" in args[0]
+    assert kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_bedmage_remove_command_responds_with_not_on_list_when_no_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Service returned False → ℹ️ info, idempotent ack."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.bedmages.remove_bedmage_for_discord_user",
+        lambda **kw: False,
+    )
+
+    cog = BedmageCog(bot=MagicMock())
+    await cog.remove.callback(cog, mock_ctx, character_name="Unknown")
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "ℹ️" in args[0]
+    assert "wasn't on your list" in args[0]
+    assert kwargs["ephemeral"] is True
+
+
+# === /bedmage list ===
+
+
+@pytest.mark.asyncio
+async def test_bedmage_list_command_responds_with_empty_hint_when_no_bedmages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty list — hint pointing user to the `/bedmage add` command.
+
+    Provides discoverability: a new user running `/bedmage list` first sees
+    how to populate it, not just a silent empty response.
+    """
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.bedmages.list_bedmages_for_discord_user",
+        lambda *args, **kw: [],
+    )
+
+    cog = BedmageCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "empty" in args[0].lower()
+    assert "/bedmage add" in args[0]
+    assert kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_bedmage_list_command_responds_with_populated_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Populated list — character names joined with commas, each in backticks.
+
+    Backtick formatting is significant: Discord renders backticks as inline
+    monospace, visually separating character names from prose. Locks the
+    contract against accidental string-join refactors.
+    """
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.respond = AsyncMock()
+
+    watch1 = MagicMock()
+    watch1.character.name = "Yhral"
+    watch2 = MagicMock()
+    watch2.character.name = "Nidrak"
+    monkeypatch.setattr(
+        "discord_bot.cogs.bedmages.list_bedmages_for_discord_user",
+        lambda *args, **kw: [watch1, watch2],
+    )
+
+    cog = BedmageCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "Your bedmages:" in args[0]
+    assert "`Yhral`" in args[0]
+    assert "`Nidrak`" in args[0]
+    assert kwargs["ephemeral"] is True
+
+
+# === Cog registration ===
+
+
+def test_bedmage_cog_has_slash_command_group_at_class_level() -> None:
+    """Pułapka A — `SlashCommandGroup` MUST live on the class, not in __init__.
+
+    py-cord introspects class body when `bot.add_cog(...)` runs; groups
+    defined inside `__init__` are invisible to the registration walk.
+    """
+    assert isinstance(BedmageCog.bedmage, discord.SlashCommandGroup)
+    assert BedmageCog.bedmage.name == "bedmage"

--- a/tests/unit/discord_bot/test_services.py
+++ b/tests/unit/discord_bot/test_services.py
@@ -1,13 +1,17 @@
-"""Tests for discord_bot.services — user auto-create + threshold upsert."""
+"""Tests for discord_bot.services — user auto-create + threshold upsert + bedmage wrappers."""
 
 from __future__ import annotations
 
 import pytest
 
 from apps.accounts.models import User
+from apps.bedmages.models import BedmageWatch
 from discord_bot.models import DiscordChannel
 from discord_bot.services import (
+    add_bedmage_for_discord_user,
     get_or_create_user_by_discord_id,
+    list_bedmages_for_discord_user,
+    remove_bedmage_for_discord_user,
     set_death_threshold_for_guild,
 )
 
@@ -122,3 +126,152 @@ def test_set_death_threshold_updates_channel_id_when_changed() -> None:
 
     assert updated.channel_id == 200
     assert DiscordChannel.objects.filter(guild_id=42).count() == 1
+
+
+# === add_bedmage_for_discord_user (D33) ===
+
+
+@pytest.mark.django_db
+def test_add_bedmage_for_discord_user_creates_watch_on_first_call() -> None:
+    """First `/bedmage add` for a Discord user materializes User + BedmageWatch.
+
+    Auto-create User via the D31 service, then delegate to M5
+    `add_bedmage_watch` — Character is also lazily created (M5 contract).
+    """
+    watch, created = add_bedmage_for_discord_user(
+        discord_id=42, discord_username="alice", character_name="Yhral"
+    )
+
+    assert created is True
+    assert watch.pk is not None
+    assert watch.active is True
+    assert watch.character.name == "Yhral"
+    assert User.objects.filter(discord_id="42", pk=watch.user_id).exists()
+
+
+@pytest.mark.django_db
+def test_add_bedmage_for_discord_user_returns_existing_on_duplicate() -> None:
+    """Idempotent UX (§3.2): second add for same (user, character) → (existing, False).
+
+    Wrapper catches M5's `ValueError` and re-fetches the row instead of
+    surfacing the error to Discord — "already on list" is informational, not
+    a failure from the user's perspective.
+    """
+    first, first_created = add_bedmage_for_discord_user(
+        discord_id=42, discord_username="alice", character_name="Yhral"
+    )
+    second, second_created = add_bedmage_for_discord_user(
+        discord_id=42, discord_username="alice", character_name="Yhral"
+    )
+
+    assert first_created is True
+    assert second_created is False
+    assert second.pk == first.pk
+    assert (
+        BedmageWatch.objects.filter(user=first.user, character=first.character).count()
+        == 1
+    )
+
+
+# === remove_bedmage_for_discord_user (D33) ===
+
+
+@pytest.mark.django_db
+def test_remove_bedmage_for_discord_user_returns_true_on_match() -> None:
+    """Happy path — watch exists and is hard-deleted; service returns True."""
+    add_bedmage_for_discord_user(
+        discord_id=42, discord_username="alice", character_name="Yhral"
+    )
+
+    removed = remove_bedmage_for_discord_user(discord_id=42, character_name="Yhral")
+
+    assert removed is True
+    assert (
+        BedmageWatch.objects.filter(
+            user__discord_id="42", character__name="Yhral"
+        ).count()
+        == 0
+    )
+
+
+@pytest.mark.django_db
+def test_remove_bedmage_for_discord_user_returns_false_when_not_on_list() -> None:
+    """No-match case — idempotent (§3.2): never raises, returns False.
+
+    Covers two scenarios in one assertion: unknown user (auto-created) AND
+    unknown character. Both paths return False without crashing.
+    """
+    removed = remove_bedmage_for_discord_user(
+        discord_id=42, character_name="NeverAdded"
+    )
+
+    assert removed is False
+
+
+@pytest.mark.django_db
+def test_remove_bedmage_for_discord_user_auto_creates_user_when_unknown() -> None:
+    """Pułapka G — symmetric with `add`: removing for an unknown Discord user
+    auto-creates the User row (idempotent + symmetric behavior with `add`).
+
+    Defensive against UX inconsistency: `/bedmage remove` from a brand-new
+    user shouldn't behave differently from `/bedmage add` followed by remove.
+    """
+    assert User.objects.filter(discord_id="999").count() == 0
+
+    remove_bedmage_for_discord_user(discord_id=999, character_name="Anything")
+
+    assert User.objects.filter(discord_id="999").count() == 1
+
+
+# === list_bedmages_for_discord_user (D33) ===
+
+
+@pytest.mark.django_db
+def test_list_bedmages_for_discord_user_returns_empty_for_unknown_user() -> None:
+    """Pułapka H — read-only: unknown Discord ID returns [], does NOT auto-create.
+
+    Defense against unnecessary DB writes on idle `/bedmage list` calls.
+    """
+    watches = list_bedmages_for_discord_user(discord_id=99999)
+
+    assert watches == []
+    assert User.objects.filter(discord_id="99999").count() == 0
+
+
+@pytest.mark.django_db
+def test_list_bedmages_for_discord_user_returns_active_watches() -> None:
+    """Returns all active bedmages for the user, with Character preloaded.
+
+    `select_related("character")` guards against N+1 in the cog handler when
+    it formats `w.character.name` for each watch.
+    """
+    add_bedmage_for_discord_user(
+        discord_id=42, discord_username="alice", character_name="Yhral"
+    )
+    add_bedmage_for_discord_user(
+        discord_id=42, discord_username="alice", character_name="Nidrak"
+    )
+
+    watches = list_bedmages_for_discord_user(discord_id=42)
+
+    assert len(watches) == 2
+    assert {w.character.name for w in watches} == {"Yhral", "Nidrak"}
+
+
+@pytest.mark.django_db
+def test_list_bedmages_for_discord_user_excludes_inactive() -> None:
+    """`active=True` filter — soft-deactivated watches are not surfaced.
+
+    M5 `remove_bedmage_watch` is hard-delete so this path is currently dead
+    code, but the filter is a contract guarantee for future soft-delete
+    refactors (§3.2 wrapper isolation from M5 internals).
+    """
+    watch, _ = add_bedmage_for_discord_user(
+        discord_id=42, discord_username="alice", character_name="Yhral"
+    )
+    watch.active = False
+    watch.save(update_fields=["active"])
+
+    watches = list_bedmages_for_discord_user(discord_id=42)
+
+    assert watches == []


### PR DESCRIPTION
## Summary

Third PR for M7. Delivers the **first user-facing slash commands** — `/bedmage add`, `/bedmage remove`, `/bedmage list` work end-to-end in a dev guild after merge. Adds 3 wrapper services that adapt Discord context (`int discord_id`) onto the M5 service layer (`User` instance), plus the cog wiring and `setup_bot()` registration.

**Closes #117**

### What's in

- **`discord_bot/services.py`** extended with 3 wrappers (`add_bedmage_for_discord_user`, `remove_bedmage_for_discord_user`, `list_bedmages_for_discord_user`):
  - All three reuse the D31 `get_or_create_user_by_discord_id` auto-create. `list_*` is **read-only** — no auto-create on idle list calls (pułapka H).
  - `add_*` catches `ValueError` from M5 `add_bedmage_watch` and translates duplicate-active into `(existing, False)` (§3.2 idempotent UX). M5 service stays untouched.
  - `list_*` uses `select_related("character")` + `list(...)` materialization to guard against N+1 and `SynchronousOnlyOperation` in the async cog handler.
- **`discord_bot/cogs/__init__.py`** (empty marker) + **`discord_bot/cogs/bedmages.py`** with `BedmageCog`:
  - `SlashCommandGroup("bedmage", ...)` declared as **class attribute** (pułapka A — py-cord introspects class body at `add_cog` time).
  - 3 commands (`add`, `remove`, `list`) using `discord.Option(str, ..., max_length=64)` annotation (matches `Character.name max_length=64`).
  - All responses `ephemeral=True` (user-private data per §3.7). Idempotent acks (✅ created vs ℹ️ already-on-list / removed vs not-on-list).
  - `sync_to_async(service_fn)(...)` double-call pattern at every ORM boundary (M2-D11 precedent).
- **`discord_bot/bot.py setup_bot()`** extends with lazy `from discord_bot.cogs.bedmages import BedmageCog; bot.add_cog(BedmageCog(bot))` before return. Lazy import sidesteps any future circular between bot ↔ cog modules.
- **15 new tests** (cumulative 32 across `discord_bot/`):
  - 7 service tests in `test_services.py` (happy path + duplicate + idempotent remove + auto-create symmetry + active filter)
  - 7 cog handler tests in `test_bedmage_cog.py` using the `.callback` bypass + monkey-patched services
  - 1 cog registration assertion (`SlashCommandGroup` at class level — pułapka A regression guard)

### Out of scope

- `DeathsCog` + `/deaths threshold` → **D34**
- M7 closure + retro → **D35**

### Design notes / fixes during review

- **`watch.user.discord_id` in-memory state** — Django `CharField.get_prep_value()` auto-coerces `int → str` on save, but the in-memory User returned by `get_or_create(discord_id=42, ...)` retains `discord_id=42` (int) until `refresh_from_db()`. Service tests query DB level (`User.objects.filter(discord_id="42")`) instead of asserting in-memory state — accurate to the storage contract without depending on Django's CharField round-trip timing.
- **`# type: ignore[valid-type]` was a stale-cache false flag** — Initial mypy run reported `Invalid type comment or annotation` on the `discord.Option(...)` parameter annotations. After `pre-commit clean` mypy no longer emits the error (likely cache from before py-cord 2.7.2 stubs landed). Final code has no `# type: ignore` — clean strict pass.

## Test plan

- [x] `poetry run pytest tests/unit/discord_bot/ -v` — **32/32 passed**
- [x] Coverage `discord_bot/*` = **100%** (cumulative, all 13 files)
- [x] `poetry run mypy discord_bot/ apps/` — clean (68 source files, after `pre-commit clean`)
- [x] `poetry run ruff check discord_bot/ tests/unit/discord_bot/` — clean
- [x] **M5 regression:** `tests/integration/test_m5_bedmages_e2e.py` — 1/1 passed (wrappers don't break M5 contract)
- [x] Pre-commit on commit — all hooks green
- [ ] CI green (lint + test) on PR
- [ ] Manual smoke (DoD-recommended) in dev guild: `/bedmage list` → empty hint, `/bedmage add yhral` → ✅ added, `/bedmage add yhral` → ℹ️ already on list, `/bedmage list` → `\`Yhral\``, `/bedmage remove yhral` → ✅ removed, `/bedmage remove yhral` → ℹ️ wasn't on list.