### PR TITLE
feat(discord): DeathsCog + /deaths threshold + admin perm check (M7-D34, #118)

### DIFF
--- a/discord_bot/bot.py
+++ b/discord_bot/bot.py
@@ -36,8 +36,11 @@ async def on_application_command_error(
 
 
 def setup_bot() -> discord.Bot:
-    """Add cogs and return configured bot. D32: no cogs yet (D33+D34 add them)."""
+    """Register cogs and return configured bot."""
+
     from discord_bot.cogs.bedmages import BedmageCog
+    from discord_bot.cogs.deaths import DeathsCog
 
     bot.add_cog(BedmageCog(bot))
+    bot.add_cog(DeathsCog(bot))
     return bot

--- a/discord_bot/cogs/deaths.py
+++ b/discord_bot/cogs/deaths.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from asgiref.sync import sync_to_async
+import discord
+from discord.ext import commands
+
+from discord_bot.services import set_death_threshold_for_guild
+
+
+class DeathsCog(commands.Cog):
+    deaths = discord.SlashCommandGroup("deaths", "Death monitor configuration")
+
+    def __init__(self, bot: discord.Bot) -> None:
+        self.bot = bot
+
+    @deaths.command(
+        name="threshold",
+        description="Set death notification level threshold (server admin only)",
+    )
+    async def threshold(
+        self,
+        ctx: discord.ApplicationContext,
+        level: discord.Option(
+            int, "Minimum level to notify", min_value=1, max_value=999
+        ),
+    ) -> None:
+        if ctx.guild is None:
+            await ctx.respond(
+                "❌ This command must be used in a server.", ephemeral=True
+            )
+            return
+
+        # Narrow types — post DM-check guarantees:
+        assert isinstance(ctx.author, discord.Member)
+        assert ctx.channel_id is not None
+
+        if not ctx.author.guild_permissions.administrator:
+            await ctx.respond(
+                "❌ Only server admins can change the death threshold.",
+                ephemeral=True,
+            )
+            return
+
+        await sync_to_async(set_death_threshold_for_guild)(
+            guild_id=ctx.guild.id,
+            channel_id=ctx.channel_id,
+            threshold=level,
+        )
+        # Public ack — other admins see the change
+        await ctx.respond(f"🪦 Death notification threshold set to level **{level}**.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,10 @@ ignore_missing_imports = true
 module = ["discord", "discord.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["discord_bot.cogs.*"]
+disable_error_code = ["valid-type"]
+
 [tool.django-stubs]
 django_settings_module = "config.settings.stubs"
 

--- a/tests/unit/discord_bot/test_deaths_cog.py
+++ b/tests/unit/discord_bot/test_deaths_cog.py
@@ -1,0 +1,190 @@
+"""Tests for discord_bot.cogs.deaths — /deaths threshold guarded by perms.
+
+Two-layer guard (order matters): DM rejection BEFORE admin check.
+`ctx.author.guild_permissions` is a `Member`-only attribute — in a DM
+`ctx.author` is `discord.User` and accessing `guild_permissions` raises
+`AttributeError`. The DM check short-circuits before the admin path runs.
+
+Mixed-visibility responses (§3.5 design):
+- Rejection (DM, non-admin) → `ephemeral=True` (private feedback to caller)
+- Success ack → public (audit trail; other admins see who changed threshold)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from discord_bot.cogs.deaths import DeathsCog
+
+
+# === Guard layer ===
+
+
+@pytest.mark.asyncio
+async def test_deaths_threshold_rejects_dm_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pułapka A — DM check MUST come before admin check.
+
+    In a DM `ctx.guild is None` and `ctx.author.guild_permissions` would
+    `AttributeError`. The DM branch short-circuits with a clear message
+    instead of leaking the generic error-handler response from D32.
+    """
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.guild = None
+    mock_ctx.respond = AsyncMock()
+
+    spy_service = MagicMock()
+    monkeypatch.setattr(
+        "discord_bot.cogs.deaths.set_death_threshold_for_guild", spy_service
+    )
+
+    cog = DeathsCog(bot=MagicMock())
+    await cog.threshold.callback(cog, mock_ctx, level=50)
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "❌" in args[0]
+    assert "must be used in a server" in args[0]
+    assert kwargs["ephemeral"] is True
+    spy_service.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_deaths_threshold_rejects_non_admin_caller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """§3.5 — only Discord Server Admins can change threshold.
+
+    Permission decided server-side (Discord `Member.guild_permissions`), not
+    via Django `User.is_superuser` — avoids pre-linking friction and matches
+    standard Discord bot conventions.
+    """
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.guild = MagicMock()
+    mock_ctx.channel_id = 666
+    mock_ctx.author = MagicMock(spec=discord.Member)
+    mock_ctx.author.guild_permissions.administrator = False
+    mock_ctx.respond = AsyncMock()
+
+    spy_service = MagicMock()
+    monkeypatch.setattr(
+        "discord_bot.cogs.deaths.set_death_threshold_for_guild", spy_service
+    )
+
+    cog = DeathsCog(bot=MagicMock())
+    await cog.threshold.callback(cog, mock_ctx, level=50)
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "❌" in args[0]
+    assert "Only server admins" in args[0]
+    assert kwargs["ephemeral"] is True
+    spy_service.assert_not_called()
+
+
+# === Success path ===
+
+
+@pytest.mark.asyncio
+async def test_deaths_threshold_persists_value_on_admin_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Admin path delegates to the D31 service with (guild_id, channel_id, level).
+
+    `channel_id` from `ctx.channel_id` is captured so M8 can use it as the
+    default outbound destination for death announcements — admin moves
+    threshold-setting to a new channel → that channel becomes the target.
+    """
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 555
+    mock_ctx.channel_id = 666
+    mock_ctx.author = MagicMock(spec=discord.Member)
+    mock_ctx.author.guild_permissions.administrator = True
+    mock_ctx.respond = AsyncMock()
+
+    spy_service = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        "discord_bot.cogs.deaths.set_death_threshold_for_guild", spy_service
+    )
+
+    cog = DeathsCog(bot=MagicMock())
+    await cog.threshold.callback(cog, mock_ctx, level=50)
+
+    spy_service.assert_called_once_with(guild_id=555, channel_id=666, threshold=50)
+
+
+@pytest.mark.asyncio
+async def test_deaths_threshold_responds_with_public_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """§3.5 design — success ack is PUBLIC, not ephemeral.
+
+    Other admins on the server see who changed the threshold (audit trail).
+    Locks the contract against accidental `ephemeral=True` addition during
+    refactor — would silently break the visibility intent.
+    """
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 555
+    mock_ctx.channel_id = 666
+    mock_ctx.author = MagicMock(spec=discord.Member)
+    mock_ctx.author.guild_permissions.administrator = True
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deaths.set_death_threshold_for_guild",
+        lambda **kw: MagicMock(),
+    )
+
+    cog = DeathsCog(bot=MagicMock())
+    await cog.threshold.callback(cog, mock_ctx, level=50)
+
+    _, kwargs = mock_ctx.respond.call_args
+    assert kwargs.get("ephemeral", False) is False
+
+
+@pytest.mark.asyncio
+async def test_deaths_threshold_message_format_includes_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Success message embeds the level value with bold markdown.
+
+    Locks the response shape: 🪦 emoji + "level **N**" formatting. Discord
+    renders `**X**` as bold; pinning this guards against accidental
+    formatting drift during message-string refactors.
+    """
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 555
+    mock_ctx.channel_id = 666
+    mock_ctx.author = MagicMock(spec=discord.Member)
+    mock_ctx.author.guild_permissions.administrator = True
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deaths.set_death_threshold_for_guild",
+        lambda **kw: MagicMock(),
+    )
+
+    cog = DeathsCog(bot=MagicMock())
+    await cog.threshold.callback(cog, mock_ctx, level=42)
+
+    args, _ = mock_ctx.respond.call_args
+    assert "🪦" in args[0]
+    assert "level **42**" in args[0]
+
+
+# === Cog registration ===
+
+
+def test_deaths_cog_has_slash_command_group_at_class_level() -> None:
+    """Pułapka A (M7 cog idiom) — `SlashCommandGroup` MUST live on the class.
+
+    py-cord introspects class body at `bot.add_cog(...)` time; groups
+    declared inside `__init__` are invisible to the registration walk.
+    """
+    assert isinstance(DeathsCog.deaths, discord.SlashCommandGroup)
+    assert DeathsCog.deaths.name == "deaths"


### PR DESCRIPTION
## Summary

Fourth PR for M7. Closes the slash-command surface: admin-gated `/deaths threshold <level>` writes per-guild `DiscordChannel.death_level_threshold` via the D31 `set_death_threshold_for_guild` service. After merge, all 4 commands from CLAUDE.md §8 are live; D35 will wrap M7 with closure + retro.

**Closes #118**

### What's in

- **`discord_bot/cogs/deaths.py`** — `DeathsCog` with one `SlashCommandGroup("deaths", ...)` and one command `/deaths threshold <level>`:
  - **Guard order (pułapka A):** DM check (`ctx.guild is None`) BEFORE admin check. `ctx.author.guild_permissions` is `Member`-only and would `AttributeError` in DM.
  - **Type narrowing for mypy strict** — post DM-check: `assert isinstance(ctx.author, discord.Member)` + `assert ctx.channel_id is not None`. py-cord types `ctx.author: Member | User` and `ctx.channel_id: int | None`; the asserts both document the post-condition and unblock strict checking.
  - **Mixed visibility (§3.5):** rejection responses `ephemeral=True` (private feedback), success ack is **public** (audit trail — other admins see who set the threshold).
  - **Discord-side validation:** `discord.Option(int, ..., min_value=1, max_value=999)` — Discord client enforces range before the call reaches the bot.
- **`discord_bot/bot.py setup_bot()`** — second `bot.add_cog(DeathsCog(bot))` alongside the D33 `BedmageCog` registration. Lazy imports keep the cog/bot module boundary clean.
- **`pyproject.toml`** — preventive `[[tool.mypy.overrides]]` for `discord_bot.cogs.*` with `disable_error_code = ["valid-type"]`. Covers the `discord.Option(...)` annotation pattern across all current and future cogs. Narrower than relaxing `valid-type` globally; doesn't touch `union-attr` / `arg-type` (those are caught by the narrowing asserts above).
- **6 unit tests** in `tests/unit/discord_bot/test_deaths_cog.py`:
  - DM rejection (early return, service not called)
  - Non-admin rejection (post-DM, service not called)
  - Admin success — service called with `(guild_id, channel_id, threshold)`
  - Public ack (no `ephemeral=True` on success)
  - Message format (`🪦` emoji + `level **N**` bold)
  - Cog registration sanity (`SlashCommandGroup` at class level)

### Out of scope (D35)

- M7 closure PR (PROGRESS.md retro + milestone close) → **D35**

### Design notes / fixes during review

- **Narrowing asserts after DM check** — initial implementation tripped two mypy strict errors (`union-attr` on `ctx.author.guild_permissions` and `arg-type` on `ctx.channel_id`). py-cord's union types are conservative; the DM check guarantees a guild context at runtime but mypy can't infer the correlation. Two `assert` lines document the invariant and unblock strict checking, with negligible runtime cost.
- **Test mocking for the `Member` assert** — admin/non-admin tests had to upgrade `mock_ctx.author` from a plain `MagicMock` to `MagicMock(spec=discord.Member)` so `isinstance(ctx.author, discord.Member)` succeeds inside the cog under test. DM-rejection test untouched (short-circuits before the assert).

## Test plan

- [x] `poetry run pytest tests/unit/discord_bot/ -v` — **38/38 passed** (cumulative D31-D34)
- [x] Coverage `discord_bot/*` = **100%** (14 source files, all-line)
- [x] `poetry run mypy discord_bot/ apps/` — clean (69 source files)
- [x] `poetry run ruff check discord_bot/ tests/unit/discord_bot/` — clean
- [x] Pre-commit on commit — all hooks green
- [ ] CI green (lint + test) on PR
- [ ] Manual smoke (DoD-recommended) in dev guild as admin: `/deaths threshold 50` → 🪦 public ack + Django admin `DiscordChannel` row shows `death_level_threshold=50`. As non-admin: `/deaths threshold 50` → ❌ ephemeral "Only server admins". In DM with bot: `/deaths threshold 50` → ❌ "must be used in a server" (if globally synced).