### PR TITLE
fix(discord): remove future annotations from cogs (py-cord runtime introspection)

### DIFF
--- a/discord_bot/cogs/bedmages.py
+++ b/discord_bot/cogs/bedmages.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
-
+# NOTE: NO `from __future__ import annotations` here — py-cord introspects
+# parameter annotations at slash command invocation time and requires them
+# as runtime objects, not PEP 563 strings.
 from asgiref.sync import sync_to_async
 import discord
 from discord.ext import commands

--- a/discord_bot/cogs/deaths.py
+++ b/discord_bot/cogs/deaths.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
-
+# NOTE: NO `from __future__ import annotations` here — py-cord introspects
+# parameter annotations at slash command invocation time and requires them
+# as runtime objects, not PEP 563 strings.
 from asgiref.sync import sync_to_async
 import discord
 from discord.ext import commands


### PR DESCRIPTION
## Summary

Hotfix on D33+D34 — both cog modules had `from __future__ import annotations` at the top, which makes parameter annotations PEP 563 strings at runtime. py-cord introspects those annotations **at slash command invocation time** (when Discord sends an Interaction) and calls `issubclass(annotation, ...)`. Strings aren't classes → `TypeError: issubclass() arg 1 must be a class`, surfaced as the generic "Something went wrong" via D32's global error handler.

Caught during manual smoke after the D33 merge — `/bedmage add yhral` reproduced the error reliably.

### What's in

- **`discord_bot/cogs/bedmages.py`** — removed `from __future__ import annotations` (was line 1). Added a 3-line `# NOTE:` comment explaining why future annotations are unsafe in py-cord cogs (the **why** future readers/me need).
- **`discord_bot/cogs/deaths.py`** — same fix.

### Why this is safe

Python 3.13 supports the runtime types our cogs use without future annotations:
- Builtin generic subscripts (`tuple[X, Y]`, `list[X]`) work natively since 3.9
- PEP 604 union syntax (`X | None`) works at runtime since 3.10
- All annotations in both cogs reference runtime classes (`discord.ApplicationContext`, `discord.Bot`, `int`, `str`, `discord.Option(...)`) — no forward references that would need stringification

### Why tests didn't catch it

Cog tests use `cog.<command>.callback(cog, ctx, **kwargs)` to bypass py-cord's slash option parsing — they invoke the underlying coroutine directly with parameter values. The `issubclass(annotation, ...)` path lives in py-cord's command-registration / interaction-dispatch layer, which the test pattern never exercises.

**Documenting as M7 retro lesson** (D35): cog tests via `.callback` bypass don't cover the py-cord option-parsing pipeline. Future cog work should either keep future annotations OFF (matches this fix) or be verified via manual smoke in a dev guild before merge.

## Test plan

- [x] `poetry run pytest tests/unit/discord_bot/ -q` — **38/38 passed** (no regression)
- [x] Manual smoke in dev guild: `/bedmage add yhral` → ✅ "Added `yhral`..." (was crashing pre-fix)
- [ ] CI green (lint + test) on PR
- [ ] Spot-check other 3 commands after merge: `/bedmage remove`, `/bedmage list`, `/deaths threshold`