### PR TITLE
test(discord): M7 e2e bot wiring sanity + idempotent setup_bot (M7-D35, #119)

### DIFF
--- a/discord_bot/bot.py
+++ b/discord_bot/bot.py
@@ -36,11 +36,14 @@ async def on_application_command_error(
 
 
 def setup_bot() -> discord.Bot:
-    """Register cogs and return configured bot."""
-
+    """Register cogs and return configured bot. Idempotent — safe to call
+    multiple times (tests share the module-level bot singleton)."""
     from discord_bot.cogs.bedmages import BedmageCog
     from discord_bot.cogs.deaths import DeathsCog
 
-    bot.add_cog(BedmageCog(bot))
-    bot.add_cog(DeathsCog(bot))
+    if "BedmageCog" not in bot.cogs:
+        bot.add_cog(BedmageCog(bot))
+    if "DeathsCog" not in bot.cogs:
+        bot.add_cog(DeathsCog(bot))
+
     return bot

--- a/tests/integration/test_m7_bot_e2e.py
+++ b/tests/integration/test_m7_bot_e2e.py
@@ -1,0 +1,42 @@
+"""E2E sanity for M7 — setup_bot wires all 4 slash commands.
+
+Pure in-memory check: `setup_bot()` runs cog registration; we walk each
+registered cog's command tree and assert the 4 commands from CLAUDE.md §8
+are present. No Discord gateway connection, no `bot.run()`.
+
+Catches the regression class that unit tests miss: cog `.callback` tests
+bypass py-cord's command-registration machinery entirely. If someone removes
+`bot.add_cog(...)` in `setup_bot`, all unit tests stay green and only this
+e2e fails. PR #124 (`fix(discord): remove future annotations from cogs`) is
+the canonical example of a bug at this layer — runtime introspection of
+slash command parameter types was broken under PEP 563.
+
+We walk `bot.cogs[...].walk_commands()` instead of
+`bot.walk_application_commands()`: nested commands inside a
+`SlashCommandGroup` (e.g. `/bedmage add` lives under the `bedmage` group)
+are stored on the cog and only flushed to the bot's top-level command list
+at Discord gateway sync time, which this in-memory test deliberately skips.
+"""
+
+from __future__ import annotations
+
+from discord_bot.bot import setup_bot
+
+
+def test_setup_bot_registers_all_four_slash_commands() -> None:
+    """All 4 commands per spec §1 are registered after `setup_bot()`.
+
+    `Cog.walk_commands()` descends into `SlashCommandGroup` children, so the
+    qualified names use the `<group> <command>` form.
+    """
+    bot = setup_bot()
+
+    names: set[str] = set()
+    for cog in bot.cogs.values():
+        for command in cog.walk_commands():
+            names.add(command.qualified_name)
+
+    assert "bedmage add" in names
+    assert "bedmage remove" in names
+    assert "bedmage list" in names
+    assert "deaths threshold" in names


### PR DESCRIPTION
## Summary

Feature PR for M7-D35 (first of two — closure PR follows from fresh master). Adds an in-memory e2e test that asserts `setup_bot()` registers all 4 slash commands per CLAUDE.md §8 (`bedmage add/remove/list` + `deaths threshold`). Closes the test-coverage gap that PR #124's hotfix exposed: cog `.callback` unit tests bypass py-cord's command-registration pipeline entirely, so regressions there land green.

Also makes `setup_bot()` idempotent — needed so the new e2e and the existing D32 `test_setup_bot_returns_a_discord_bot_instance` can coexist in one pytest session (both share the module-level `bot` singleton; second `add_cog` would otherwise raise `discord.errors.ClientException: Cog 'BedmageCog' already loaded`).

**Part of #119** (closure PR will close the issue.)

### What's in

- **`tests/integration/test_m7_bot_e2e.py`** — single test walking `bot.cogs[...].walk_commands()` to collect qualified command names and asserting the 4 expected ones are present. We deliberately walk per-cog rather than via `bot.walk_application_commands()` because `SlashCommandGroup`-nested commands stay attached to the cog until Discord gateway sync — which this test skips by design.
- **`discord_bot/bot.py setup_bot()`** — guarded `bot.add_cog(...)` calls (`if "BedmageCog" not in bot.cogs:`). Production behavior unchanged (called once from `run_discord_bot.py`); the idempotency only matters for tests that share the singleton. Also refreshed the now-stale `"D32: no cogs yet"` docstring.

### Design notes

- **Why this layer of test matters** — pure-unit cog tests use `cog.<command>.callback(cog, ctx, ...)` to bypass slash option parsing. That misses bugs in py-cord's registration machinery itself (PR #124 was exactly that — `from __future__ import annotations` broke runtime introspection of `Option(...)` annotations, all unit tests stayed green, only manual smoke caught it). This e2e gives us a CI-level signal for that whole layer at near-zero runtime cost (~0.5s, no network).
- **No Discord gateway connection** — `bot.run()` is never called. Just `setup_bot()` followed by introspection.

## Test plan

- [x] `poetry run pytest tests/unit/discord_bot/ tests/integration/test_m7_bot_e2e.py -v` — **39/39 passed** (including the new e2e; idempotent setup_bot lets it coexist with D32's setup_bot smoke)
- [x] Full suite: `poetry run pytest -q` — 186 passed, 1 xfailed
- [x] Coverage `discord_bot/*` = **100%**
- [x] `poetry run mypy discord_bot/ apps/` — clean (69 files)
- [x] Pre-commit on commit — all hooks green
- [ ] CI green (lint + test) on PR

After this PR merges, the closure PR will:
- Add the M7 section to `PROGRESS.md` (retro per Issue, DoD, summary, tech debt)
- Document the manual smoke transcript of all 4 slash commands in dev guild
- Close milestone 7 via `gh api -X PATCH .../milestones/7 -f state=closed`