### PR TITLE
feat(notifications): DiscordDMHandler for bedmage Discord DMs (M8-D37, #129)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ CELERY_SCRAPE_FRESHNESS_MINUTES=30
 DEATH_LEVEL_THRESHOLD=30
 
 BEDMAGE_REGEN_MINUTES=100
-BEDMAGE_NOTIFICATION_HANDLER=apps.notifications.handlers.LoggingHandler
+BEDMAGE_NOTIFICATION_HANDLER=apps.notifications.handlers.DiscordDMHandler
 
 #  MongoDB
 MONGO_URL=mongodb://localhost:27017

--- a/apps/notifications/handlers.py
+++ b/apps/notifications/handlers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Protocol
 
+
 if TYPE_CHECKING:
     from apps.bedmages.models import BedmageWatch
 
@@ -31,4 +32,44 @@ class LoggingHandler:
             watch.user.username,
             watch.character.name,
             watch.character.last_login,
+        )
+
+
+class DiscordDMHandler:
+    """Implements BedmageNotificationHandler. Sends DM via DiscordRESTClient.
+
+    Failures (403 user blocked DMs, 5xx Discord down, invalid discord_id)
+    logged but NOT re-raised — M5 service marks last_notified_login anyway
+    to avoid retry storm on every scrape cycle.
+    """
+
+    def notify(self, watch: BedmageWatch) -> None:
+        from apps.notifications.discord_client import DiscordRESTClient
+
+        try:
+            user_discord_id = int(watch.user.discord_id or "")
+        except ValueError:
+            logger.error(
+                "Invalid discord_id for user pk=%s — bedmage DM skipped",
+                watch.user.pk,
+            )
+            return
+
+        content = self._render(watch)
+        client = DiscordRESTClient()
+        ok = client.send_dm(user_discord_id, content)
+        if not ok:
+            logger.warning(
+                "Bedmage DM failed for user=%s character=%s",
+                watch.user.username,
+                watch.character.name,
+            )
+
+    def _render(self, watch: BedmageWatch) -> str:
+        from django.conf import settings
+
+        return (
+            f"🛏️ Your bedmage **{watch.character.name}** has been logged out for "
+            f"{settings.BEDMAGE_REGEN_MINUTES} minutes — mana fully regenerated.\n"
+            f"Last login: {watch.character.last_login:%Y-%m-%d %H:%M UTC}"
         )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -155,10 +155,9 @@ CELERY_SCRAPE_FRESHNESS_MINUTES = env.int("CELERY_SCRAPE_FRESHNESS_MINUTES", def
 DEATH_LEVEL_THRESHOLD = env.int("DEATH_LEVEL_THRESHOLD", default=30)
 
 BEDMAGE_REGEN_MINUTES = env.int("BEDMAGE_REGEN_MINUTES", default=100)
-
 BEDMAGE_NOTIFICATION_HANDLER = env(
     "BEDMAGE_NOTIFICATION_HANDLER",
-    default="apps.notifications.handlers.LoggingHandler",
+    default="apps.notifications.handlers.DiscordDMHandler",  # M5 LoggingHandler → M8 DiscordDMHandler
 )
 
 # MongoDB — used ONLY for app_logs / scrape_logs (CLAUDE.md §4).

--- a/tests/integration/test_m5_bedmages_e2e.py
+++ b/tests/integration/test_m5_bedmages_e2e.py
@@ -5,9 +5,11 @@ threshold → invoke check_bedmage_watches_for_character → verify the configur
 notification handler was called once with the correct watch. Second invocation
 must be a no-op (idempotency invariant from CLAUDE.md §7).
 
-Mocks `LoggingHandler.notify` — the M5 default handler. Doesn't go through
-the GraphQL layer (the unit tests cover that boundary); this verifies the
-business-logic chain D24+D25 wires up end-to-end.
+Mocks `LoggingHandler.notify` and overrides BEDMAGE_NOTIFICATION_HANDLER to
+pin LoggingHandler as the resolved handler — without the override M8-D37
+flipped the project default to DiscordDMHandler, and patching LoggingHandler
+would no longer intercept the call. The test stays focused on the M5 wiring
+contract, isolated from whichever production handler M8+ resolves to.
 """
 
 from __future__ import annotations
@@ -28,7 +30,10 @@ from apps.characters.models import Character
 
 
 @pytest.mark.django_db(transaction=True)
-@override_settings(BEDMAGE_REGEN_MINUTES=100)
+@override_settings(
+    BEDMAGE_REGEN_MINUTES=100,
+    BEDMAGE_NOTIFICATION_HANDLER="apps.notifications.handlers.LoggingHandler",
+)
 @mock.patch("apps.notifications.handlers.LoggingHandler.notify")
 def test_e2e_add_bedmage_watch_then_check_fires_handler(
     mock_notify: mock.MagicMock,

--- a/tests/unit/notifications/test_discord_dm_handler.py
+++ b/tests/unit/notifications/test_discord_dm_handler.py
@@ -1,0 +1,137 @@
+"""Tests for DiscordDMHandler — bedmage Discord DM delivery via DiscordRESTClient."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from django.utils import timezone
+
+from apps.notifications.handlers import DiscordDMHandler
+
+
+@pytest.fixture
+def watch() -> MagicMock:
+    """Minimal BedmageWatch-shaped mock — no DB hit needed for handler unit tests.
+
+    Sets the four attributes the handler actually reads:
+    `user.discord_id`, `user.pk`, `user.username`, `character.name`,
+    `character.last_login`. Tests override individual fields when exercising
+    edge cases (e.g. non-numeric discord_id).
+    """
+    mock = MagicMock()
+    mock.user.discord_id = "12345"
+    mock.user.pk = 42
+    mock.user.username = "alice"
+    mock.character.name = "Yhral"
+    mock.character.last_login = timezone.now().replace(
+        year=2026, month=5, day=15, hour=10, minute=0, second=0, microsecond=0
+    )
+    return mock
+
+
+@pytest.fixture
+def mock_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Patch DiscordRESTClient at its source module.
+
+    Handler does a lazy `from apps.notifications.discord_client import
+    DiscordRESTClient` inside `notify()` (defers httpx loading until first
+    DM and keeps the mypy pre-commit hook happy without httpx in its venv).
+    The lazy import re-resolves the name from `discord_client` on every call,
+    so patching the source module's attribute is enough — no need to chase
+    the handler's bound name.
+    """
+    client = MagicMock()
+    client.send_dm.return_value = True
+    monkeypatch.setattr(
+        "apps.notifications.discord_client.DiscordRESTClient", lambda: client
+    )
+    return client
+
+
+def test_handler_notify_calls_send_dm_with_int_discord_id_and_rendered_content(
+    watch: MagicMock, mock_client: MagicMock
+) -> None:
+    """Happy path: handler casts discord_id str→int, renders message, calls send_dm.
+
+    Pins three contract points at once:
+    1. `int(watch.user.discord_id)` cast — `DiscordRESTClient.send_dm` takes int
+    2. Rendered content (not raw watch) passed as second arg
+    3. Exactly one DM per notify() call (no duplicates from accidental loops)
+    """
+    DiscordDMHandler().notify(watch)
+
+    mock_client.send_dm.assert_called_once()
+    user_id_arg, content_arg = mock_client.send_dm.call_args.args
+    assert user_id_arg == 12345
+    assert isinstance(user_id_arg, int)
+    assert "Yhral" in content_arg
+
+
+def test_handler_renders_message_with_character_name_regen_minutes_and_last_login(
+    watch: MagicMock, mock_client: MagicMock, settings: pytest.FixtureRequest
+) -> None:
+    """Message template includes: 🛏️ emoji, character name (bolded), regen minutes
+    from settings (NOT hardcoded), and last_login formatted as `YYYY-MM-DD HH:MM UTC`.
+
+    Pułapka C from #129 — using `settings.BEDMAGE_REGEN_MINUTES` (current value,
+    not hardcoded "100"). Test overrides the setting and verifies the rendered
+    string reflects the override, locking the dynamic-read contract.
+    """
+    settings.BEDMAGE_REGEN_MINUTES = 90  # type: ignore[attr-defined]
+
+    DiscordDMHandler().notify(watch)
+
+    content = mock_client.send_dm.call_args.args[1]
+    assert "🛏️" in content
+    assert "**Yhral**" in content
+    assert "90" in content  # not 100 — proves the setting is read dynamically
+    assert "2026-05-15 10:00 UTC" in content
+
+
+def test_handler_logs_error_and_skips_send_when_discord_id_is_none(
+    watch: MagicMock,
+    mock_client: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Pułapka A: User with `discord_id=None` (Django admin manual create) must
+    NOT crash the handler. Implementation coerces None to "" via `or ""` so
+    `int("")` raises ValueError, which the handler catches → logs ERROR with
+    user pk → returns BEFORE attempting send_dm. No garbage DM, no exception
+    leak to M5 `check_bedmage_watches_for_character` (Pułapka G — leaked
+    exception would skip the whole batch for the character).
+    """
+    watch.user.discord_id = None
+
+    with caplog.at_level(logging.ERROR, logger="apps.notifications.handlers"):
+        DiscordDMHandler().notify(watch)
+
+    mock_client.send_dm.assert_not_called()
+    assert any(
+        "Invalid discord_id" in r.getMessage() and "pk=42" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_handler_swallows_send_failure_with_warning_log(
+    watch: MagicMock,
+    mock_client: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Pułapka G: `send_dm` returning False (403/404/5xx-after-retry) must NOT
+    raise. Handler logs WARNING with user + character context and returns
+    normally so M5 service can mark `last_notified_login` and avoid a retry
+    storm on every subsequent scrape cycle.
+    """
+    mock_client.send_dm.return_value = False
+
+    with caplog.at_level(logging.WARNING, logger="apps.notifications.handlers"):
+        DiscordDMHandler().notify(watch)  # must not raise
+
+    assert any(
+        "Bedmage DM failed" in r.getMessage()
+        and "user=alice" in r.getMessage()
+        and "character=Yhral" in r.getMessage()
+        for r in caplog.records
+    )

--- a/tests/unit/notifications/test_handler_resolution.py
+++ b/tests/unit/notifications/test_handler_resolution.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from apps.notifications import get_bedmage_handler
-from apps.notifications.handlers import LoggingHandler
+from apps.notifications.handlers import DiscordDMHandler, LoggingHandler
 
 
 class MockHandler:
@@ -24,15 +24,17 @@ class MockHandler:
         pass
 
 
-def test_get_bedmage_handler_returns_logging_handler_by_default() -> None:
-    """Default settings.BEDMAGE_NOTIFICATION_HANDLER points at LoggingHandler.
+def test_get_bedmage_handler_returns_discord_dm_handler_by_default() -> None:
+    """Default settings.BEDMAGE_NOTIFICATION_HANDLER points at DiscordDMHandler.
 
-    Sanity check that the project default (declared in config/settings/base.py)
-    resolves to the M5 reference implementation.
+    M5 originally pointed at LoggingHandler (dev/test); M8-D37 flipped the
+    default to the production DiscordDMHandler so deployed instances actually
+    send DMs without env var override. LoggingHandler is still importable and
+    used by tests that need a side-effect-free notify implementation.
     """
     handler = get_bedmage_handler()
 
-    assert isinstance(handler, LoggingHandler)
+    assert isinstance(handler, DiscordDMHandler)
 
 
 def test_get_bedmage_handler_resolves_custom_class_via_settings(settings) -> None:


### PR DESCRIPTION
## Summary

Second PR for M8. Bedmage alerts now go to Discord DMs in production. Consumes `DiscordRESTClient.send_dm` from M8-D36; M5 `LoggingHandler` stays in place as a side-effect-free variant for tests.

**Closes #129**

## What's in

### `apps/notifications/handlers.py`
- **`DiscordDMHandler`** implementing `BedmageNotificationHandler` Protocol:
  - `notify(watch)`:
    - `int(watch.user.discord_id or "")` → ValueError on None/empty/non-numeric; log ERROR with user pk and return **before** attempting send (no garbage DM, no exception leak per Pułapka G)
    - `_render(watch)` builds a message with `🛏️` emoji, **bolded** character name, `BEDMAGE_REGEN_MINUTES` from settings (dynamic, not hardcoded), and `last_login` as `YYYY-MM-DD HH:MM UTC`
    - Send failures (403/404/5xx-after-retry) logged as WARNING with user+character context, **never re-raised** so M5 service marks `last_notified_login` and avoids retry storms
- **Lazy import** of `DiscordRESTClient` inside `notify()` — defers `httpx` loading until first DM send AND keeps the pre-commit mypy hook happy without `httpx` in its isolated venv (per CLAUDE.md §12, infra changes to `.pre-commit-config.yaml` belong in a separate PR)

### Settings default flip
- **`config/settings/base.py`**: `BEDMAGE_NOTIFICATION_HANDLER` default changed from `LoggingHandler` → `DiscordDMHandler` in a single block (initial implementation had a duplicate definition that has been collapsed)
- **`.env.example`**: mirrors the new default so fresh installs inherit `DiscordDMHandler` without env override

### Tests
- **New `tests/unit/notifications/test_discord_dm_handler.py`** — 4 tests:
  - `test_handler_notify_calls_send_dm_with_int_discord_id_and_rendered_content` — happy path: str→int cast, rendered content as second arg, exactly one call
  - `test_handler_renders_message_with_character_name_regen_minutes_and_last_login` — render contract, **dynamic** `BEDMAGE_REGEN_MINUTES` read (overrides setting to `90`, asserts `90` appears in output, not hardcoded `100`)
  - `test_handler_logs_error_and_skips_send_when_discord_id_is_none` — `discord_id=None` path: log ERROR + `send_dm` not called
  - `test_handler_swallows_send_failure_with_warning_log` — `send_dm → False`: handler does NOT raise, logs WARNING with user+character context (Pułapka G regression guard)
- **Updated `test_handler_resolution.py`** — `test_get_bedmage_handler_returns_logging_handler_by_default` → `test_get_bedmage_handler_returns_discord_dm_handler_by_default` (assertion + name + docstring follow the new default)
- **Updated `test_m5_bedmages_e2e.py`** — added `@override_settings(BEDMAGE_NOTIFICATION_HANDLER="apps.notifications.handlers.LoggingHandler")` so the existing `@mock.patch("...LoggingHandler.notify")` keeps intercepting after the default flip (Pułapka D regression guard)

## Design notes

- **Lazy import vs adding `httpx` to mypy hook deps** — chose lazy import because it (a) unblocks D37 without a separate `.pre-commit-config.yaml` infra PR, (b) defers loading `httpx` until actually needed at runtime, matching the existing `from django.conf import settings` pattern inside `_render`. Mypy hook stays clean because Django plugin init no longer transitively imports `httpx` via the notifications app chain.
- **`int(... or "")` for None handling** — coerces `None` → `""` → `int("")` → `ValueError` → caught. Cleaner than `except (TypeError, ValueError)` because it eliminates one branch, and `discord_id=""` (empty string in DB) is functionally equivalent to "no usable Discord ID" from the handler's perspective. mypy strict happy without `# type: ignore`.
- **`LoggingHandler` not removed** — explicitly kept as a side-effect-free test variant; M5 integration tests use it via `@override_settings`. The flip only changes the *default*, not the available handler set.

## Test plan

- [x] `poetry run pytest tests/unit/notifications/ tests/unit/bedmages/ tests/integration/test_m5_bedmages_e2e.py tests/unit/accounts/test_register_api.py -q` — **44/44 passed**
- [x] `poetry run pytest --cov=apps.notifications.handlers --cov-report=term-missing` — `apps/notifications/handlers.py` **100% coverage** (24/24 statements)
- [x] `poetry run pre-commit run --files <touched files>` — all hooks green (mypy, ruff, ruff-format, gitleaks, conventional-commit)
- [ ] CI green (lint + test) on PR
- [ ] Manual smoke in dev guild: trigger a bedmage scenario, verify DM lands in user's inbox with `🛏️` emoji, bolded character name, correct regen minutes, formatted last_login

## Manual smoke recipe (for the merge reviewer)

```bash
# Local dev — assumes Postgres + Redis + bot running
# 1. Create your own bedmage watch via Discord
/bedmage add <CharacterName>

# 2. Force the character into "past threshold" state in shell
poetry run python manage.py shell
>>> from apps.characters.models import Character
>>> from django.utils import timezone
>>> from datetime import timedelta
>>> Character.objects.filter(name="<CharacterName>").update(
...     last_login=timezone.now() - timedelta(minutes=120)
... )

# 3. Trigger the M5 check service for that character
>>> from apps.bedmages.services import check_bedmage_watches_for_character
>>> from apps.characters.models import Character
>>> check_bedmage_watches_for_character(Character.objects.get(name="<CharacterName>"))
1  # <- one watch fired
```

Expected: `🛏️ Your bedmage **<CharacterName>** has been logged out for 100 minutes...` in your Discord DMs from the bot.

## Next: D38

`DeathEvent.announced_on_discord` migration + `DeathAnnouncementHandler` + `DiscordChannelHandler` — D38 (#130) will reuse `DiscordRESTClient.send_channel_message` from D36 for the deaths-announcement flow.