### PR TITLE
feat(deaths): announce_unannounced_deaths service + scrape_deaths integration + 10 tests (M8-D39, #131)

### DIFF
--- a/apps/deaths/services.py
+++ b/apps/deaths/services.py
@@ -1,9 +1,15 @@
 from datetime import datetime
 from typing import TypedDict
+import logging
+import time
 
 from django.db import IntegrityError, transaction
 
 from apps.deaths.models import DeathEvent
+from apps.notifications import get_death_handler
+from discord_bot.models import DiscordChannel
+
+logger = logging.getLogger(__name__)
 
 
 class DeathPayload(TypedDict):
@@ -26,3 +32,71 @@ def save_death_event(payload: DeathPayload) -> DeathEvent | None:
             return DeathEvent.objects.create(**payload)
     except IntegrityError:
         return None
+
+
+def announce_unannounced_deaths() -> dict[str, int]:
+    """Iterate unannounced DeathEvents, fan-out do applicable guildów, mark announced.
+
+    Multi-guild fan-out: dla każdej unannounced event'a fetch wszystkie
+    DiscordChannel gdzie threshold <= level_at_death. Wyślij do każdej guild
+    (rate-limited 200ms sleep). Mark announced_on_discord=True gdy ALL succeed.
+    Failed event stays False — retry next scrape cycle.
+
+    "No applicable guilds" semantyka: gdy 0 guildów ma threshold <= level,
+    mark announced=True mimo braku message'a (semantyka "evaluated + skipped").
+    Unikamy retry storm w queryach każdego scrape cycle.
+
+    Known limitation (§3.3): gdy admin dodaje nowy DiscordChannel z niższym
+    threshold PO ogłoszeniu, historyczne śmierci `announced_on_discord=True`
+    NIE są retroaktywnie wysłane. Backfill out of scope dla M8 — M-future
+    conversion do M2M tracking model.
+
+    Returns: {"events_announced": N, "events_skipped": M, "fail_count": K}
+    """
+    handler = get_death_handler()
+    events_announced = 0
+    events_skipped = 0
+    fail_count = 0
+
+    unannounced = DeathEvent.objects.filter(announced_on_discord=False).order_by(
+        "died_at"
+    )
+    for event in unannounced:
+        applicable_guilds = DiscordChannel.objects.filter(
+            death_level_threshold__lte=event.level_at_death
+        )
+
+        if not applicable_guilds.exists():
+            event.announced_on_discord = True
+            event.save(update_fields=["announced_on_discord"])
+            events_skipped += 1
+            continue
+
+        all_ok = True
+        for channel in applicable_guilds:
+            try:
+                ok = handler.announce(event, channel)
+            except Exception:
+                logger.exception(
+                    "DeathAnnouncementHandler.announce raised for event=%s channel=%s",
+                    event.pk,
+                    channel.pk,
+                )
+                ok = False
+            all_ok = all_ok and ok
+            time.sleep(0.2)  # rate limit defensive
+
+        if all_ok:
+            event.announced_on_discord = True
+            event.save(update_fields=["announced_on_discord"])
+            events_announced += 1
+        else:
+            fail_count += 1
+
+    summary = {
+        "events_announced": events_announced,
+        "events_skipped": events_skipped,
+        "fail_count": fail_count,
+    }
+    logger.info("announce_unannounced_deaths: %s", summary)
+    return summary

--- a/apps/deaths/tasks.py
+++ b/apps/deaths/tasks.py
@@ -4,6 +4,7 @@ import sys
 import json
 
 from celery import shared_task, Task
+from apps.deaths.services import announce_unannounced_deaths
 
 
 logger = logging.getLogger(__name__)
@@ -47,4 +48,13 @@ def scrape_deaths(self: Task) -> dict[str, int]:
 
     summary["returncode"] = result.returncode
     logger.info("scrape_deaths: %s", summary)
+
+    try:
+        announce_summary = announce_unannounced_deaths()
+        summary.update(announce_summary)
+    except Exception:
+        logger.exception(
+            "announce_unannounced_deaths raised — events stay unannounced for next cycle"
+        )
+
     return summary

--- a/tests/integration/test_m4_deaths_e2e.py
+++ b/tests/integration/test_m4_deaths_e2e.py
@@ -72,15 +72,25 @@ def test_e2e_first_scrape_creates_50_deaths_second_scrape_dedups(
     Asserts BOTH counters in both rounds (M3 retro #61 lesson — single-counter
     asserts let counter swap bugs slip through) AND DB row count remains stable
     after round 2 (true idempotency, not just "duplicates reported correctly").
+
+    M8-D39 note: scrape_deaths return shape was extended with the announce
+    summary (events_announced/events_skipped/fail_count). The M4 contract this
+    test guards is the scrape counters — assertions are subset-style so future
+    additions to the task return dict don't break this regression guard
+    (Pułapka F from #131 — keys added, never removed).
     """
     # Round 1 — fresh DB, all 50 inserted
     result1 = scrape_deaths.apply().get()
-    assert result1 == {"yielded": 50, "duplicates": 0, "returncode": 0}
+    assert result1["yielded"] == 50
+    assert result1["duplicates"] == 0
+    assert result1["returncode"] == 0
     assert DeathEvent.objects.count() == 50
 
     # Round 2 — same fixture, full dedup, count stable
     result2 = scrape_deaths.apply().get()
-    assert result2 == {"yielded": 50, "duplicates": 50, "returncode": 0}
+    assert result2["yielded"] == 50
+    assert result2["duplicates"] == 50
+    assert result2["returncode"] == 0
     assert DeathEvent.objects.count() == 50
 
     assert mock_run.call_count == 2

--- a/tests/unit/deaths/test_announce_unannounced_deaths.py
+++ b/tests/unit/deaths/test_announce_unannounced_deaths.py
@@ -1,0 +1,251 @@
+"""Tests for announce_unannounced_deaths service — multi-guild fan-out + mark-on-success."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from django.utils import timezone
+
+from apps.deaths.models import DeathEvent
+from apps.deaths.services import announce_unannounced_deaths
+from discord_bot.models import DiscordChannel
+
+
+@pytest.fixture
+def mock_handler(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Replace `get_death_handler` resolver with a controllable mock.
+
+    Tests configure `mock.announce.return_value` or `.side_effect` to exercise
+    success/failure/raise paths without hitting real Discord. Patched at the
+    service's import binding (`apps.deaths.services.get_death_handler`) so
+    the lookup inside `announce_unannounced_deaths` resolves to the mock.
+    """
+    handler = MagicMock()
+    handler.announce.return_value = True
+    monkeypatch.setattr("apps.deaths.services.get_death_handler", lambda: handler)
+    return handler
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pułapka G — autouse mock of `time.sleep` so the defensive 200ms wait
+    between guild fan-out calls doesn't slow the suite. Service uses the
+    stdlib `time` module imported at the top of `services.py`.
+    """
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+
+def _make_event(*, level: int, announced: bool = False) -> DeathEvent:
+    """Minimal DeathEvent factory — only the fields the service touches."""
+    return DeathEvent.objects.create(
+        character_name="Yhral",
+        level_at_death=level,
+        killed_by="a dragon lord",
+        died_at=timezone.now(),
+        announced_on_discord=announced,
+    )
+
+
+def _make_channel(*, threshold: int, guild_id: int = 111) -> DiscordChannel:
+    """Minimal DiscordChannel factory — unique guild_id required by the model."""
+    return DiscordChannel.objects.create(
+        guild_id=guild_id,
+        channel_id=guild_id * 10,
+        death_level_threshold=threshold,
+    )
+
+
+@pytest.mark.django_db
+def test_announce_processes_only_unannounced_events(mock_handler: MagicMock) -> None:
+    """`filter(announced_on_discord=False)` is the only queryset — already-announced
+    rows are never re-sent.
+
+    Catches accidental re-announcement bugs (e.g. someone changing the filter
+    to `True`, or dropping the filter entirely) that would spam users with
+    duplicate notifications on every scrape cycle.
+    """
+    _make_channel(threshold=30)
+    already_announced = _make_event(level=60, announced=True)
+    new_event = _make_event(level=70)
+
+    announce_unannounced_deaths()
+
+    # mock called exactly once — for the unannounced event, NOT for the announced
+    assert mock_handler.announce.call_count == 1
+    event_arg = mock_handler.announce.call_args.args[0]
+    assert event_arg.pk == new_event.pk
+    already_announced.refresh_from_db()
+    assert already_announced.announced_on_discord is True  # untouched
+
+
+@pytest.mark.django_db
+def test_announce_marks_event_as_announced_on_success(
+    mock_handler: MagicMock,
+) -> None:
+    """Happy path: handler returns True → `announced_on_discord` flips to True
+    via `save(update_fields=[...])` (Pułapka B — single-column atomic write).
+
+    Locks the success contract that D40 e2e + prod observability will rely on:
+    after a successful scrape+announce cycle, no unannounced rows remain for
+    events whose level cleared the threshold.
+    """
+    _make_channel(threshold=30)
+    event = _make_event(level=60)
+
+    announce_unannounced_deaths()
+
+    event.refresh_from_db()
+    assert event.announced_on_discord is True
+    mock_handler.announce.assert_called_once()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "failure_mode",
+    ["returns_false", "raises_exception"],
+)
+def test_announce_keeps_unannounced_on_handler_failure(
+    mock_handler: MagicMock, failure_mode: str
+) -> None:
+    """Failure (False return OR raised exception — Pułapka E) leaves the event
+    `announced_on_discord=False` so the next scrape cycle retries it.
+
+    Parametrized to cover both paths in one test method: returns False (graceful
+    handler decline) and raises Exception (e.g. httpx.ConnectError leaking past
+    DiscordRESTClient's own try/except). Service's defensive `try/except
+    Exception` around `handler.announce` must catch the raise and count it as
+    failure without aborting the whole batch.
+    """
+    if failure_mode == "returns_false":
+        mock_handler.announce.return_value = False
+    else:
+        mock_handler.announce.side_effect = RuntimeError("simulated handler crash")
+
+    _make_channel(threshold=30)
+    event = _make_event(level=60)
+
+    summary = announce_unannounced_deaths()
+
+    event.refresh_from_db()
+    assert event.announced_on_discord is False
+    assert summary["fail_count"] == 1
+    assert summary["events_announced"] == 0
+
+
+@pytest.mark.django_db
+def test_announce_iterates_all_applicable_guilds_per_event(
+    mock_handler: MagicMock,
+) -> None:
+    """Multi-guild fan-out: a single event with N applicable channels triggers
+    N `announce()` calls — each with the same event + a different channel.
+
+    Pins the per-event multi-target wiring. Channels with threshold > event
+    level must NOT receive the announcement (the service's filter is
+    `death_level_threshold__lte=event.level_at_death`).
+    """
+    _make_channel(threshold=30, guild_id=111)  # applicable
+    _make_channel(threshold=50, guild_id=222)  # applicable
+    _make_channel(threshold=99, guild_id=333)  # NOT applicable
+    event = _make_event(level=60)
+
+    announce_unannounced_deaths()
+
+    assert mock_handler.announce.call_count == 2
+    channel_args = [call.args[1] for call in mock_handler.announce.call_args_list]
+    guild_ids = {c.guild_id for c in channel_args}
+    assert guild_ids == {111, 222}  # threshold 99 channel skipped
+    # all calls receive the same event
+    event_args = {call.args[0].pk for call in mock_handler.announce.call_args_list}
+    assert event_args == {event.pk}
+
+
+@pytest.mark.django_db
+def test_announce_marks_event_announced_when_no_applicable_guilds(
+    mock_handler: MagicMock,
+) -> None:
+    """ "Evaluated + skipped" semantics: when ZERO channels have
+    `threshold <= level`, the event is still marked `announced_on_discord=True`.
+
+    Without this branch, low-level events would be re-evaluated on every scrape
+    cycle forever (retry storm against the DB even though nothing changes).
+    The mark says "we've decided this event has no targets — don't re-check."
+    """
+    _make_channel(threshold=99)  # threshold above any event we make
+    event = _make_event(level=10)
+
+    summary = announce_unannounced_deaths()
+
+    event.refresh_from_db()
+    assert event.announced_on_discord is True
+    mock_handler.announce.assert_not_called()
+    assert summary["events_skipped"] == 1
+    assert summary["events_announced"] == 0
+
+
+@pytest.mark.django_db
+def test_announce_stays_unannounced_when_any_guild_fails(
+    mock_handler: MagicMock,
+) -> None:
+    """Partial failure = full failure: if ANY guild in the fan-out fails, the
+    event stays `False` so the next scrape cycle retries the WHOLE set.
+
+    Trade-off documented in spec §3.3: simpler than per-(event, channel) state,
+    but means a single guild outage causes duplicate sends to healthy guilds
+    next cycle. M-future could split into an M2M tracking table; out of scope
+    for M8.
+    """
+    mock_handler.announce.side_effect = [True, False]  # guild 1 ok, guild 2 fails
+    _make_channel(threshold=30, guild_id=111)
+    _make_channel(threshold=40, guild_id=222)
+    event = _make_event(level=60)
+
+    summary = announce_unannounced_deaths()
+
+    event.refresh_from_db()
+    assert event.announced_on_discord is False
+    assert mock_handler.announce.call_count == 2  # both attempted
+    assert summary["fail_count"] == 1
+    assert summary["events_announced"] == 0
+
+
+@pytest.mark.django_db
+def test_announce_summary_dict_reports_counts(mock_handler: MagicMock) -> None:
+    """Summary dict shape contract: three integer counters that D40 e2e and the
+    scrape_deaths task return value depend on.
+
+    Constructs a mixed batch (success + skipped + fail) in one call to lock
+    all three counters in a single assertion. Order matters because the
+    service iterates `order_by("died_at")`; uses controlled `died_at`s to make
+    the side_effect list deterministic.
+    """
+    _make_channel(threshold=30)
+
+    # 1 success: high-level event, handler returns True
+    success_event = _make_event(level=80)
+    success_event.died_at = timezone.now()
+    success_event.save(update_fields=["died_at"])
+
+    # 1 skipped: low-level event, no applicable guild
+    skipped_event = _make_event(level=5)
+    skipped_event.died_at = timezone.now() + timezone.timedelta(seconds=1)
+    skipped_event.save(update_fields=["died_at"])
+
+    # 1 fail: high-level event, but handler returns False for it
+    fail_event = _make_event(level=90)
+    fail_event.died_at = timezone.now() + timezone.timedelta(seconds=2)
+    fail_event.save(update_fields=["died_at"])
+
+    # order_by("died_at") = success, skipped, fail
+    # service iterates: success (calls announce, True) → mark True
+    #                   skipped (no applicable, threshold=30 IS <= 5? no, 30>5, so skipped) → mark True
+    #                   fail (calls announce, False) → keep False
+    mock_handler.announce.side_effect = [True, False]  # success→True, fail→False
+
+    summary = announce_unannounced_deaths()
+
+    assert summary == {
+        "events_announced": 1,
+        "events_skipped": 1,
+        "fail_count": 1,
+    }

--- a/tests/unit/deaths/test_scrape_deaths_task.py
+++ b/tests/unit/deaths/test_scrape_deaths_task.py
@@ -104,6 +104,79 @@ def test_returncode_nonzero_logs_warning_and_returns_summary(
     with caplog.at_level(logging.WARNING, logger="apps.deaths.tasks"):
         result = scrape_deaths.apply().get()
 
-    assert result == {"yielded": 50, "duplicates": 50, "returncode": 1}
+    assert "yielded" in result and "duplicates" in result and "returncode" in result
+    assert result["yielded"] == 50
+    assert result["duplicates"] == 50
+    assert result["returncode"] == 1
     task_warnings = [r for r in caplog.records if r.name == "apps.deaths.tasks"]
     assert any("returncode=1" in r.message for r in task_warnings)
+
+
+@mock.patch("apps.deaths.tasks.announce_unannounced_deaths")
+@mock.patch("apps.deaths.tasks.subprocess.run")
+def test_scrape_deaths_calls_announce_after_subprocess_and_merges_summary(
+    mock_run: mock.MagicMock,
+    mock_announce: mock.MagicMock,
+) -> None:
+    """M8-D39 wiring: after scrape subprocess completes, the task calls
+    `announce_unannounced_deaths()` and merges its summary into the task
+    return value via `dict.update()`.
+
+    Pins two contract points: (1) order — announce runs AFTER subprocess parse
+    so it only sees events the current scrape persisted, (2) shape — task
+    return is the union of scrape keys (yielded/duplicates/returncode) and
+    announce keys (events_announced/events_skipped/fail_count), backward
+    compatible with M4 task consumers (Pułapka F from #131).
+    """
+    mock_run.return_value = _completed(
+        stdout='{"yielded": 5, "duplicates": 0}', returncode=0
+    )
+    mock_announce.return_value = {
+        "events_announced": 2,
+        "events_skipped": 1,
+        "fail_count": 0,
+    }
+
+    result = scrape_deaths.apply().get()
+
+    assert result == {
+        "yielded": 5,
+        "duplicates": 0,
+        "returncode": 0,
+        "events_announced": 2,
+        "events_skipped": 1,
+        "fail_count": 0,
+    }
+    mock_announce.assert_called_once_with()
+
+
+@mock.patch("apps.deaths.tasks.announce_unannounced_deaths")
+@mock.patch("apps.deaths.tasks.subprocess.run")
+def test_scrape_deaths_swallows_announce_exception_and_returns_scrape_summary(
+    mock_run: mock.MagicMock,
+    mock_announce: mock.MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Defensive try/except around announce in tasks.py: if the announce phase
+    raises (DB connection lost, unexpected handler bug), the task still
+    returns the scrape summary so Celery doesn't mark the task as failed and
+    Beat keeps firing the next cycle.
+
+    Locks Pułapka F's symmetric concern — announce failure must NOT tank
+    the scrape return value, and a logger.exception entry must record it.
+    """
+    mock_run.return_value = _completed(
+        stdout='{"yielded": 3, "duplicates": 1}', returncode=0
+    )
+    mock_announce.side_effect = RuntimeError("DB down")
+
+    with caplog.at_level(logging.ERROR, logger="apps.deaths.tasks"):
+        result = scrape_deaths.apply().get()
+
+    # scrape summary preserved; announce keys absent (update() never ran)
+    assert result == {"yielded": 3, "duplicates": 1, "returncode": 0}
+    assert any(
+        "announce_unannounced_deaths raised" in r.message
+        for r in caplog.records
+        if r.name == "apps.deaths.tasks"
+    )


### PR DESCRIPTION
## Summary

Fourth PR for M8. End-to-end outbound notifications wiring closes here — after every `scrape_deaths` cycle, unannounced events are fanned out through `get_death_handler()` (D38) per applicable `DiscordChannel` and marked as announced based on handler return values. D40 (#132) wraps the milestone with e2e + retro.

**Closes #131**

## What's in

### Service (`apps/deaths/services.py`)
**`announce_unannounced_deaths() -> dict[str, int]`** iterates
`DeathEvent.objects.filter(announced_on_discord=False).order_by("died_at")`:

- **Per event** — fetch `DiscordChannel.objects.filter(death_level_threshold__lte=event.level_at_death)`
- **Zero applicable guilds** → mark `announced=True` via *"evaluated + skipped"* semantics so the row isn't re-checked every cycle (Pułapka A — `.exists()` early return + retry-storm avoidance)
- **N applicable guilds** → fan out `handler.announce(event, channel)` per channel with `time.sleep(0.2)` between sends (Pułapka G defensive rate-limit). `all_ok` accumulator pattern:
  - **All succeed** → mark `announced=True` via `save(update_fields=["announced_on_discord"])` (Pułapka B — single-column atomic write)
  - **Any fail** (False return OR raised exception) → leave `announced=False` for next-cycle retry (Pułapka E — try/except around `handler.announce` catches unexpected raises and counts them as failures without aborting the batch)
- **Returns** `{events_announced: N, events_skipped: M, fail_count: K}`

### Task integration (`apps/deaths/tasks.py`)
`scrape_deaths` calls `announce_unannounced_deaths()` inline after subprocess parse and merges the summary via `dict.update()`. Defensive `try/except Exception` swallows announce-phase failures so Celery never marks the task failed (Beat keeps firing). Backward-compatible — `yielded`/`duplicates`/`returncode` keys preserved, M4 contract intact (Pułapka F).

### Tests (10 total)

**NEW `tests/unit/deaths/test_announce_unannounced_deaths.py`** — 7 from AC + 1 parametrize variant = 8 cases:
- filter respects `announced_on_discord=False` (no re-announce of already-marked rows)
- mark-on-success contract (atomic `save(update_fields=[...])`)
- `keep_unannounced_on_handler_failure[returns_false]` and `[raises_exception]` (parametrized — covers both graceful False and Pułapka E unexpected raise)
- multi-guild fan-out with threshold filter (assertion on guild IDs + same event reused)
- "evaluated + skipped" branch for no applicable guilds (mark True without any send)
- partial-failure leaves event for retry (`side_effect=[True, False]` → 2 calls, event stays False)
- summary dict shape with mixed (success + skipped + fail) batch

**EXTENDED `tests/unit/deaths/test_scrape_deaths_task.py`** (+2):
- `test_scrape_deaths_calls_announce_after_subprocess_and_merges_summary` (from AC)
- `test_scrape_deaths_swallows_announce_exception_and_returns_scrape_summary` (bonus — Pułapka F symmetric concern: announce raise must NOT tank scrape return, ERROR log emitted)

**UPDATED `tests/integration/test_m4_deaths_e2e.py`** — strict dict equality replaced with subset assertions:
```python
# Before: assert result1 == {"yielded": 50, "duplicates": 0, "returncode": 0}
# After:  assert result1["yielded"] == 50
#         assert result1["duplicates"] == 0
#         assert result1["returncode"] == 0
```
Future additions to the task return dict (D40, M-future) won't break the M4 regression guard. Pułapka F documented in the test docstring.

## Design notes

- **`time.sleep(0.2)` in sync Celery worker** — Pułapka G. Blocks the worker thread per send. At 50 events × 1 guild = 10s extra in the task. Acceptable for current scale; M-future could batch async if traffic grows.
- **All-or-nothing per-event** — partial guild failure leaves the event for full retry on the next cycle. Simpler than per-`(event, channel)` state but means a single guild outage causes duplicate sends to healthy guilds. Trade-off documented in spec §3.3; M-future could split into M2M tracking.
- **"Evaluated + skipped" mark for no applicable guilds** — without this, low-level events would be re-evaluated forever on every cycle. The mark says *"we've decided this event has no targets, don't re-check."* Pułapka also acknowledges spec §3.3 limitation: adding a new lower-threshold channel post-announcement does NOT retroactively backfill historical deaths.
- **Why I tweaked the existing M4 e2e test** — strict `result == {...}` equality would silently break with every future task-return extension. Subset assertions preserve the M4 contract semantics while being forward-compatible.

## Test plan

- [x] `poetry run pytest tests/unit/deaths/ tests/unit/notifications/ tests/integration/test_m4_deaths_e2e.py tests/integration/test_m5_bedmages_e2e.py -q` — **51/51 passed**
- [x] `poetry run pytest --cov=apps.deaths.services --cov=apps.deaths.tasks --cov-report=term-missing` — **100%** on both (79/79 statements)
- [x] `poetry run pre-commit run --files <touched files>` — all hooks green (mypy, ruff, ruff-format, gitleaks, conventional-commit, end-of-file-fixer)
- [ ] CI green (lint + test) on PR
- [ ] Manual smoke in dev guild: trigger `scrape_deaths.delay()` against a fixture with at least one high-level death; verify the configured channel receives the embed with crimson skull title + killed_by description + ISO timestamp; verify the `DeathEvent` row in django-admin shows `announced_on_discord=True` after the task completes

## Manual smoke recipe

```bash
# 1. Configure a DiscordChannel for your dev guild (M7-D34 /deaths threshold command)
/deaths threshold 30

# 2. Trigger one scrape cycle (Celery eager or beat-scheduled)
poetry run python manage.py shell
>>> from apps.deaths.tasks import scrape_deaths
>>> scrape_deaths.apply().get()
# {"yielded": ..., "duplicates": ..., "returncode": 0,
#  "events_announced": N, "events_skipped": M, "fail_count": 0}

# 3. Verify in Discord channel — embed lands with crimson skull title.
# 4. Verify in django-admin — DeathEvent rows now have announced_on_discord=True.
```

## Next: D40 — M8 closure

`PROGRESS.md` retro + milestone close + (optional) full e2e integration test wiring scrape→announce→Discord through the actual stack with mocked HTTP. Per spec, no new feature work in D40.