### PR TITLE
test(notifications,deaths): M8 e2e handler chain sanity (M8-D40, #132)

### DIFF
--- a/tests/integration/test_m8_outbound_e2e.py
+++ b/tests/integration/test_m8_outbound_e2e.py
@@ -1,0 +1,122 @@
+"""E2E sanity for M8 — handler chain delegates to DiscordRESTClient correctly.
+
+Two flows, mocked at the lowest layer (`DiscordRESTClient`):
+
+1. Bedmage flow — `check_bedmage_watches_for_character` → settings-resolved
+   `DiscordDMHandler` → mocked `send_dm`. Asserts the handler chain (service
+   reads handler from settings, instantiates it, calls .notify) is wired and
+   that `discord_id` is cast str→int before reaching the client.
+2. Deaths flow — `announce_unannounced_deaths` → settings-resolved
+   `DiscordChannelHandler` → mocked `send_channel_message`. Asserts embed
+   format flows through and per-guild `channel_id` is passed unchanged.
+
+Lazy import note (Pułapka A, M8-D37/D38 lesson): handlers do
+`from apps.notifications.discord_client import DiscordRESTClient` INSIDE
+`notify()`/`announce()`. The monkeypatch target is the source module
+(`apps.notifications.discord_client.DiscordRESTClient`), not a handlers-module
+re-binding — same pattern as the M8 unit tests.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from django.test import override_settings
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.bedmages.models import BedmageWatch
+from apps.bedmages.services import check_bedmage_watches_for_character
+from apps.characters.models import Character
+from apps.deaths.models import DeathEvent
+from apps.deaths.services import announce_unannounced_deaths
+from discord_bot.models import DiscordChannel
+
+
+@pytest.mark.django_db
+@override_settings(
+    BEDMAGE_REGEN_MINUTES=100,
+    BEDMAGE_NOTIFICATION_HANDLER="apps.notifications.handlers.DiscordDMHandler",
+)
+def test_bedmage_flow_calls_send_dm_via_handler_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bedmage chain (service → settings → DiscordDMHandler → client.send_dm).
+
+    Pins three contract points end-to-end:
+    1. `BEDMAGE_NOTIFICATION_HANDLER` setting resolves to `DiscordDMHandler`
+       (no env-default coupling — `@override_settings` makes the test robust
+       against M8-D37's flip of the project default).
+    2. Handler casts `User.discord_id` from str to int before calling
+       `send_dm(user_id: int, content: str)`.
+    3. Rendered content carries the character name (the bedmage subject).
+    """
+    mock_client = MagicMock()
+    mock_client.send_dm.return_value = True
+    monkeypatch.setattr(
+        "apps.notifications.discord_client.DiscordRESTClient", lambda: mock_client
+    )
+
+    user = User.objects.create_user(
+        username="discord_42", email="bedmage@example.com", discord_id="42"
+    )
+    character = Character.objects.create(
+        name="Yhral", last_login=timezone.now() - timedelta(minutes=120)
+    )
+    BedmageWatch.objects.create(user=user, character=character)
+
+    fired = check_bedmage_watches_for_character(character)
+
+    assert fired == 1
+    mock_client.send_dm.assert_called_once()
+    user_id_arg, content_arg = mock_client.send_dm.call_args.args
+    assert user_id_arg == 42
+    assert isinstance(user_id_arg, int)
+    assert "Yhral" in content_arg
+
+
+@pytest.mark.django_db
+@override_settings(
+    DEATH_NOTIFICATION_HANDLER="apps.notifications.handlers.DiscordChannelHandler",
+)
+def test_death_flow_calls_send_channel_message_via_handler_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Death chain (service → settings → DiscordChannelHandler → client.send_channel_message).
+
+    Pins:
+    1. `DEATH_NOTIFICATION_HANDLER` setting resolves to `DiscordChannelHandler`.
+    2. Per-guild `channel_id` from `DiscordChannel` is passed as kwarg unchanged
+       (Pułapka A from M8-D38 — BigIntegerField, no str conversion).
+    3. Embed payload carries the character name in the title (visible Discord
+       card heading from `DiscordChannelHandler._render_embed`).
+
+    `time.sleep` is mocked because `announce_unannounced_deaths` has a defensive
+    200ms wait between per-guild fan-out calls (Pułapka B).
+    """
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    mock_client = MagicMock()
+    mock_client.send_channel_message.return_value = True
+    monkeypatch.setattr(
+        "apps.notifications.discord_client.DiscordRESTClient", lambda: mock_client
+    )
+
+    DiscordChannel.objects.create(
+        guild_id=111, channel_id=222, death_level_threshold=30
+    )
+    DeathEvent.objects.create(
+        character_name="Yhral",
+        level_at_death=60,
+        killed_by="a dragon lord",
+        died_at=timezone.now(),
+    )
+
+    summary = announce_unannounced_deaths()
+
+    assert summary["events_announced"] == 1
+    mock_client.send_channel_message.assert_called_once()
+    call_kwargs = mock_client.send_channel_message.call_args.kwargs
+    assert call_kwargs["channel_id"] == 222
+    assert "Yhral" in call_kwargs["embed"]["title"]

--- a/tests/unit/notifications/test_discord_client.py
+++ b/tests/unit/notifications/test_discord_client.py
@@ -174,6 +174,72 @@ def test_client_retries_once_on_5xx(mock_httpx: MockHttpx) -> None:
     assert len(mock_httpx.requests) == 2
 
 
+def test_send_channel_message_wraps_embed_in_embeds_list(
+    mock_httpx: MockHttpx,
+) -> None:
+    """Embed payload is wrapped in `embeds: [...]` (list of dicts, not bare dict).
+
+    Pins the Discord REST contract — the API expects `embeds` (plural, array)
+    even for a single embed. Without the wrap, Discord rejects the request as
+    "embed must be an object" and DiscordChannelHandler silently fails. Test
+    locks the wire-format shape that D38 `DiscordChannelHandler` depends on.
+    """
+    mock_httpx.set_handler(lambda _r: httpx.Response(200, json={"id": "msg_1"}))
+
+    client = DiscordRESTClient(bot_token="fake-token")
+    embed = {"title": "💀 Yhral", "color": 0xDC143C}
+    ok = client.send_channel_message(channel_id=42, embed=embed)
+
+    assert ok is True
+    request = mock_httpx.requests[0]
+    assert b'"embeds":[{"title"' in request.content
+    assert b'"content"' not in request.content  # bare embed call, no content
+
+
+def test_post_returns_none_when_bot_token_empty(
+    mock_httpx: MockHttpx, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Empty bot_token short-circuits BEFORE any HTTP request — defensive guard.
+
+    Catches the misconfigured-env case (DISCORD_BOT_TOKEN missing from .env
+    in prod): we log an ERROR and return None instead of attempting an
+    unauthenticated request that would surface as a 401 deeper in the stack.
+    `mock_httpx` fixture asserts the contract by remaining empty — zero
+    outbound requests confirms the early return path.
+    """
+    import logging
+
+    # `__init__` does `bot_token or settings.DISCORD_BOT_TOKEN`, so we set the
+    # attribute directly after construction to bypass the settings fallback.
+    client = DiscordRESTClient(bot_token="placeholder")
+    client.bot_token = ""
+
+    with caplog.at_level(logging.ERROR, logger="apps.notifications.discord_client"):
+        ok = client.send_channel_message(channel_id=42, content="hi")
+
+    assert ok is False
+    assert len(mock_httpx.requests) == 0
+    assert any("DISCORD_BOT_TOKEN empty" in r.getMessage() for r in caplog.records)
+
+
+def test_client_gives_up_after_second_5xx(mock_httpx: MockHttpx) -> None:
+    """5xx on BOTH attempts → returns False (None from `_post`).
+
+    Locks the "exactly 1 retry on 5xx" contract — after the retry also fails
+    we don't loop forever. Counterpart to `test_client_retries_once_on_5xx`
+    which proves we DO retry once; this proves we DON'T retry twice.
+    Downstream (D38 `DiscordChannelHandler`, D37 `DiscordDMHandler`) relies
+    on the False return to log a WARNING and skip marking-as-announced.
+    """
+    mock_httpx.set_handler(lambda _r: httpx.Response(503, json={}))
+
+    client = DiscordRESTClient(bot_token="fake-token")
+    ok = client.send_channel_message(channel_id=42, content="hi")
+
+    assert ok is False
+    assert len(mock_httpx.requests) == 2  # initial + 1 retry, no more
+
+
 def test_client_respects_retry_after_on_429(
     mock_httpx: MockHttpx, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #132 (feature PR — closure PR follows from fresh master after merge).

## Summary

- **2 integration tests** in `tests/integration/test_m8_outbound_e2e.py` covering the full M8 handler chains end-to-end (service → settings-resolved handler → mocked `DiscordRESTClient`):
  - Bedmage flow — `check_bedmage_watches_for_character` fires `DiscordDMHandler.notify`, which casts `discord_id` str→int and calls `send_dm(int, content)`.
  - Death flow — `announce_unannounced_deaths` fires `DiscordChannelHandler.announce`, which passes `channel_id` unchanged and builds an embed with the character name in the title.
- Both use `@override_settings(*_NOTIFICATION_HANDLER=...)` to pin handler resolution explicitly — robust against M8-D37's flip of the project default and against env differences between local/CI.
- Mocks `DiscordRESTClient` at its source module (`apps.notifications.discord_client.DiscordRESTClient`), matching the M8 unit-test pattern. Handlers do a lazy `from … import` inside `notify()`/`announce()`, so chasing the handler-module name binding (as the issue body draft suggested) wouldn't work.

## Coverage bump

To clear the AC threshold (≥95% cumulative `apps/notifications/*` + `apps/deaths/services.py`), three additional unit tests in `tests/unit/notifications/test_discord_client.py`:

- `test_send_channel_message_wraps_embed_in_embeds_list` — locks the Discord REST contract (single embed wrapped in `embeds: [...]` array).
- `test_post_returns_none_when_bot_token_empty` — defensive guard for missing `DISCORD_BOT_TOKEN` env, asserts ERROR log + zero outbound requests.
- `test_client_gives_up_after_second_5xx` — locks the "exactly 1 retry on 5xx" contract; counterpart to the existing single-retry test.

Final cumulative coverage: **96%** (up from 93%). Remaining uncovered lines in `discord_client.py` (42-46 malformed DM JSON, 88-90 timeout/connect error, 123 unreachable fall-through) are M8-D36 carry-over tech debt, out of scope here.

## Verification

```
poetry run pytest tests/unit/notifications/ tests/unit/deaths/ \
  tests/integration/test_m8_outbound_e2e.py tests/integration/test_m5_bedmages_e2e.py \
  --cov=apps.notifications --cov=apps.deaths.services --cov-report=term
```

Result: **55 passed**, coverage 96%.

Pre-commit (ruff + ruff-format + end-of-file-fixer + mixed-line-ending + gitleaks) clean on both changed files.

## Test plan

- [x] `pytest tests/integration/test_m8_outbound_e2e.py -v` — 2/2 passed
- [x] Full M8 suite + M5 regression — 55/55 passed
- [x] Cumulative coverage `apps/notifications/*` + `apps/deaths/services.py` ≥ 95% (actual: 96%)
- [x] `pre-commit run --files <changed>` clean
- [ ] CI lint + test green