### PR TITLE
docs(m9): add Dockeryzacja + prod-ready design spec + implementation plan + issue bodies

### DIFF
--- a/.github/issue-bodies/m9-d41.md
+++ b/.github/issue-bodies/m9-d41.md
@@ -1,0 +1,269 @@
+**Milestone:** M9 — Dockeryzacja + prod-ready
+**Czas:** 2-3h
+**Branch:** `feat/<this-issue-#>-health-endpoint`
+**Type:** `feat`
+**Zależy od:** M8 closed
+**Spec:** [`docs/superpowers/specs/2026-05-15-m9-dockerization-design.md`](../blob/master/docs/superpowers/specs/2026-05-15-m9-dockerization-design.md) §4, §6.1
+**Plan:** [`docs/superpowers/plans/2026-05-15-m9-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-15-m9-implementation-plan.md) Task #1
+
+---
+
+## 🎯 Cel
+
+Utworzyć nowy nested Django app `apps/core/` z minimalnym scope: `apps.py` (`CoreConfig`), `health.py` (view `health_check` zwracający 200 + `{"db": "ok", "redis": "ok"}` po sprawdzeniu DB cursor + Redis ping; 503 + `{"db": "fail"|"ok", "redis": "fail"|"ok", "error": "..."}` przy fail), `urls.py` (`path("", health_check)`). Dorzucenie `path("health/", include("apps.core.urls"))` w `config/urls.py` + `"apps.core"` w `LOCAL_APPS`. 4 unit testy w `apps/core/tests/test_health.py`. Po D41: endpoint `/health/` osiągalny lokalnie, gotowy do użycia w Docker HEALTHCHECK w D42.
+
+## 🧠 Czego się nauczysz
+
+- **Minimal Django app structure** — `apps/core/` to drugi nested app bez modeli i migracji (po `apps/notifications/` z M5). Tylko `apps.py` + view + urls + tests. Pattern dla cross-cutting concerns.
+- **`@require_GET` decorator** — `from django.views.decorators.http import require_GET` ogranicza view na GET (POST/PUT/DELETE → 405). Defensywne dla health endpoint — Docker HEALTHCHECK i LBs używają GET.
+- **`django.db.connection.cursor()`** jako sync DB check — niski koszt (~1-2ms), `cursor.execute("SELECT 1")` to canonical "ping". Wyłapuje `OperationalError` gdy PG down.
+- **`redis.Redis.from_url(url).ping()`** jako sync Redis check — `redis-py` (direct dep z M5). `socket_timeout=2` defensive. Rzuca `ConnectionError`/`TimeoutError`.
+- **`JsonResponse(data, status=503)`** — Django default 200, override przez `status=`. Content-Type `application/json` auto.
+- **`pytest-django` mocking DB/Redis** — `unittest.mock.patch` na `django.db.connection.cursor` i `redis.Redis.from_url` żeby symulować fail bez real downtime.
+
+## ✅ Acceptance criteria
+
+### `apps/core/__init__.py`
+
+- [ ] Empty.
+
+### `apps/core/apps.py`
+
+- [ ] Pełna zawartość:
+  ```python
+  from django.apps import AppConfig
+
+
+  class CoreConfig(AppConfig):
+      default_auto_field = "django.db.models.BigAutoField"
+      name = "apps.core"
+  ```
+
+### `apps/core/health.py`
+
+- [ ] Pełna zawartość:
+  ```python
+  from __future__ import annotations
+
+  import logging
+  from typing import Any
+
+  import redis
+  from django.conf import settings
+  from django.db import OperationalError, connection
+  from django.http import HttpRequest, JsonResponse
+  from django.views.decorators.http import require_GET
+
+  logger = logging.getLogger(__name__)
+
+
+  @require_GET
+  def health_check(request: HttpRequest) -> JsonResponse:
+      """Liveness + readiness check dla Docker HEALTHCHECK i load balancer'a.
+
+      Sprawdza:
+      - DB connectivity (cursor.execute("SELECT 1"))
+      - Redis connectivity (redis.Redis(...).ping())
+
+      Returns:
+          200 + {"db": "ok", "redis": "ok"} gdy oba OK.
+          503 + {"db": "fail"|"ok", "redis": "fail"|"ok", "error": "..."} gdy fail.
+
+      Out of scope (M-future): Mongo check (logging może gracefully degradować),
+      Celery worker ping (osobny healthcheck per service w compose).
+      """
+      status: dict[str, Any] = {"db": "ok", "redis": "ok"}
+      status_code = 200
+
+      try:
+          with connection.cursor() as cursor:
+              cursor.execute("SELECT 1")
+      except OperationalError as exc:
+          logger.exception("Health check: DB query failed")
+          status["db"] = "fail"
+          status["error"] = str(exc)
+          status_code = 503
+
+      try:
+          client = redis.Redis.from_url(settings.REDIS_URL, socket_timeout=2)
+          client.ping()
+      except (redis.ConnectionError, redis.TimeoutError) as exc:
+          logger.exception("Health check: Redis ping failed")
+          status["redis"] = "fail"
+          status["error"] = str(exc)
+          status_code = 503
+
+      return JsonResponse(status, status=status_code)
+  ```
+
+### `apps/core/urls.py`
+
+- [ ] Pełna zawartość:
+  ```python
+  from django.urls import path
+
+  from apps.core.health import health_check
+
+  urlpatterns = [
+      path("", health_check, name="health-check"),
+  ]
+  ```
+
+### `config/urls.py` (modify)
+
+- [ ] Dorzucenie `path("health/", include("apps.core.urls"))` do `urlpatterns`. Verify importy `include` zachowane.
+
+### `config/settings/base.py` (modify)
+
+- [ ] `LOCAL_APPS` rozszerzone o `"apps.core"` (na pierwszą pozycję lub alfabetycznie — sprawdź istniejący pattern).
+
+### `apps/core/tests/__init__.py`
+
+- [ ] Empty.
+
+### `apps/core/tests/test_health.py`
+
+- [ ] 4 tests:
+  ```python
+  """Tests for /health/ endpoint — DB + Redis ping sanity for Docker HEALTHCHECK."""
+
+  from __future__ import annotations
+
+  from unittest.mock import MagicMock, patch
+
+  import pytest
+  import redis
+  from django.db import OperationalError
+  from django.test import Client
+  from django.urls import reverse
+
+
+  @pytest.fixture
+  def client() -> Client:
+      return Client()
+
+
+  @pytest.fixture(autouse=True)
+  def mock_redis_ok(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+      """Default: Redis ping returns True. Tests override side_effect for failure."""
+      mock_client = MagicMock()
+      mock_client.ping.return_value = True
+      monkeypatch.setattr(
+          "redis.Redis.from_url", lambda *a, **kw: mock_client,
+      )
+      return mock_client
+
+
+  @pytest.mark.django_db
+  def test_health_returns_200_when_db_and_redis_ok(client: Client) -> None:
+      """Happy path: oba checki przechodzą, JSON shape pinned, 200 OK."""
+      response = client.get(reverse("health-check"))
+
+      assert response.status_code == 200
+      assert response["Content-Type"].startswith("application/json")
+      body = response.json()
+      assert body == {"db": "ok", "redis": "ok"}
+
+
+  @pytest.mark.django_db
+  def test_health_returns_503_when_db_fails(client: Client) -> None:
+      """DB cursor raises OperationalError → 503 + db: fail + error message."""
+      with patch(
+          "apps.core.health.connection.cursor",
+          side_effect=OperationalError("connection refused"),
+      ):
+          response = client.get(reverse("health-check"))
+
+      assert response.status_code == 503
+      body = response.json()
+      assert body["db"] == "fail"
+      assert body["redis"] == "ok"
+      assert "connection refused" in body["error"]
+
+
+  @pytest.mark.django_db
+  def test_health_returns_503_when_redis_fails(
+      client: Client, mock_redis_ok: MagicMock,
+  ) -> None:
+      """Redis ping raises ConnectionError → 503 + redis: fail."""
+      mock_redis_ok.ping.side_effect = redis.ConnectionError("Connection refused")
+
+      response = client.get(reverse("health-check"))
+
+      assert response.status_code == 503
+      body = response.json()
+      assert body["db"] == "ok"
+      assert body["redis"] == "fail"
+      assert "Connection refused" in body["error"]
+
+
+  @pytest.mark.django_db
+  def test_health_response_shape_keys_locked(client: Client) -> None:
+      """JSON keys subset of {db, redis, error}.
+
+      Forward-compat lock dla M-future Mongo/Celery checks — gdy ktoś doda
+      "mongo" lub "celery" do response bez aktualizacji testu, ten test pada
+      i wymusza świadomą decyzję o rozszerzeniu shape.
+      """
+      response = client.get(reverse("health-check"))
+      body = response.json()
+
+      assert set(body.keys()).issubset({"db", "redis", "error"})
+  ```
+
+### Coverage
+
+- [ ] `apps/core/health.py` ≥ 95% (`poetry run pytest apps/core/tests/ --cov=apps.core.health --cov-report=term-missing`).
+
+### Manual smoke (w PR description)
+
+- [ ] `poetry run python manage.py runserver` + `curl -i http://localhost:8000/health/` → HTTP/1.1 200 + `{"db": "ok", "redis": "ok"}`.
+- [ ] `docker compose -f docker-compose.dev.yml stop postgres` + `curl -i http://localhost:8000/health/` → HTTP/1.1 503 + `"db": "fail"`. Restart postgres po teście.
+
+## ⚠️ Pułapki do uwagi
+
+- **A — `LOCAL_APPS = [..., "apps.core"]` z `apps.` prefix.** Nie `"core"` (top-level jak `discord_bot/`). `apps/core/` to **nested** app pod `apps/`, `INSTALLED_APPS` wymaga dotted path `apps.core`.
+- **B — `CoreConfig.name = "apps.core"`** — nie `"core"`. Spójność z M5/M6/M7 nested apps. Bez tego Django startup crash `LookupError: No installed app with label 'apps'`.
+- **C — `redis.Redis.from_url(settings.REDIS_URL, socket_timeout=2)`** — `socket_timeout` jest kluczowe. Bez niego, Redis down + DNS resolves → `ping()` wisi 30s. Docker HEALTHCHECK timeout 5s — must return < 5s.
+- **D — `from django.db import OperationalError`** w except, NIE `psycopg.OperationalError`. Django ORM wraps DBAPI exceptions.
+- **E — `@require_GET` import** — `from django.views.decorators.http import require_GET`. Nie `require_http_methods(["GET"])` (works ale verbose).
+- **F — `with connection.cursor() as cursor:`** — context manager required, bez `with` cursor pozostaje open → connection leak w testach.
+- **G — Test mocking strategy: `patch("apps.core.health.connection.cursor", side_effect=OperationalError(...))`** — `connection.cursor()` call rzuca side_effect bezpośrednio (no context manager entry).
+- **H — `JsonResponse` body comparison** — `response.json()` zwraca dict, używaj dict equality. NIE string compare body bytes (whitespace/key order może się różnić).
+- **I — `reverse("health-check")`** w testach — używaj name'a z `urls.py`, nie hardcoded "/health/". Refactor-safe.
+- **J — mypy + redis stubs**: jeśli `pre-commit run mypy --files apps/core/health.py` zgłosi `Cannot find implementation or library stub for module redis`, najpierw `poetry run pre-commit clean` (M7 retro). Dopiero potem dorzuć `types-redis (>=4.6.0,<5.0.0)` do `[tool.poetry.group.dev.dependencies]`.
+- **K — `autouse=True` na `mock_redis_ok` fixture** — zapewnia że KAŻDY test ma Redis mock by default. Inaczej test_db_fails would ping real Redis, fail w CI.
+- **L — `test_health_response_shape_keys_locked` używa `subset`** nie `==` — dopuszcza `error` key gdy któryś check fail, ale blokuje accidental dodanie `mongo`/`celery` bez aktualizacji testu.
+
+## 🧪 Testing plan
+
+```bash
+# Unit testy
+poetry run pytest apps/core/tests/test_health.py -v
+
+# Coverage
+poetry run pytest apps/core/tests/ --cov=apps.core.health --cov-report=term-missing
+
+# Manual smoke (happy path)
+poetry run python manage.py runserver
+# w drugim terminalu:
+curl -i http://localhost:8000/health/
+
+# Manual smoke (DB fail)
+docker compose -f docker-compose.dev.yml stop postgres
+curl -i http://localhost:8000/health/
+docker compose -f docker-compose.dev.yml start postgres
+
+# Mypy sanity
+poetry run pre-commit run mypy --files apps/core/health.py apps/core/apps.py
+```
+
+**Coverage cel:** `apps/core/health.py` ≥ 95%.
+
+## 📦 Definition of Done
+
+- [ ] AC spełnione (4 tests passing, manual smoke 200 + 503 confirmed).
+- [ ] PR zmergowany squash (`feat(core): add /health/ endpoint with DB + Redis ping (M9-D41, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] `apps/core/health.py` coverage ≥ 95%.
+- [ ] Healthcheck endpoint testable z laptopu (manual smoke confirmed w PR body).

--- a/.github/issue-bodies/m9-d42.md
+++ b/.github/issue-bodies/m9-d42.md
@@ -1,0 +1,208 @@
+**Milestone:** M9 — Dockeryzacja + prod-ready
+**Czas:** 3-4h
+**Branch:** `feat/<this-issue-#>-dockerfile`
+**Type:** `feat` (+ `build(deps)` osobny commit dla `gunicorn` dependency)
+**Zależy od:** M9-D41 merged
+**Spec:** [`docs/superpowers/specs/2026-05-15-m9-dockerization-design.md`](../blob/master/docs/superpowers/specs/2026-05-15-m9-dockerization-design.md) §3.1, §3.2, §3.7
+**Plan:** [`docs/superpowers/plans/2026-05-15-m9-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-15-m9-implementation-plan.md) Task #2
+
+---
+
+## 🎯 Cel
+
+Dorzucić `gunicorn` jako prod dependency w osobnym `build(deps)` commit. Utworzyć `Dockerfile` multi-stage (builder + runtime) zgodny ze spec §3.1: builder stage instaluje poetry + poetry-plugin-export, exportuje `poetry.lock → requirements.txt`, `pip install --user`; runtime stage używa `python:3.13-slim-bookworm`, dorzuca curl dla HEALTHCHECK, tworzy non-root user `app` (UID 1000), COPY z builder, COPY app code, `EXPOSE 8000`, `HEALTHCHECK` curl `/health/`, `CMD gunicorn config.wsgi:application`. Plus `.dockerignore` excluding `.git`, `.venv`, `__pycache__`, `tests/`, `docs/`, `.env*`. Po D42: `docker build -t tibiantis:dev .` exit 0, image size ~150-200MB, `docker run --rm tibiantis:dev python manage.py check` exit 0.
+
+## 🧠 Czego się nauczysz
+
+- **Multi-stage Dockerfile** — `FROM X AS builder` + `FROM X AS runtime` + `COPY --from=builder`. Tylko `runtime` ląduje w final image. Builder layers (poetry, build deps) discarded → mniejszy image.
+- **`pip install --user` w builder + COPY `/root/.local`** — `--user` instaluje w `~/.local/`, łatwe do COPY do runtime userspace. Ścieżki binary w `PATH=/home/app/.local/bin:$PATH`.
+- **`HEALTHCHECK` Dockerfile instruction** — Docker built-in. Container status `healthy` widoczny w `docker ps`. Exit code: 0=healthy, 1=unhealthy, 2=reserved.
+- **Non-root user pattern** — `RUN useradd --uid 1000 app` + `USER app`. UID 1000 matches typical host user, eliminuje host volume permission issues.
+- **`.dockerignore`** — analog `.gitignore` ale dla docker build context. Excludes wykluczone z `COPY . /app` → mniejszy build context (faster transfer to daemon), brak secrets, brak `.git`.
+- **Poetry 2.x `poetry-plugin-export`** — w Poetry 1.x export był built-in. Poetry 2.0+ wymaga `poetry-plugin-export` jako separate install.
+- **Layer caching strategy** — `COPY pyproject.toml poetry.lock ./` PRZED `COPY . /app` → zmiana w kodzie nie unieważnia poetry install cache.
+- **Exec form vs shell form CMD** — `CMD ["gunicorn", ...]` (exec, JSON array) → PID 1 to gunicorn (signal handling correct). `CMD gunicorn ...` (shell) → PID 1 to sh, sygnały nie propagują.
+
+## ✅ Acceptance criteria
+
+### Dependency commit (osobny)
+
+- [ ] `poetry add "gunicorn (>=23.0,<24.0)"` — dorzuca do `[project.dependencies]` w `pyproject.toml`.
+- [ ] Sanity: `poetry show gunicorn` — verify version w zakresie + no transitive conflict z httpx/celery/django stubs.
+- [ ] Osobny commit `build(deps): add gunicorn for prod WSGI server (M9-D42, #<#>)`.
+
+### `Dockerfile`
+
+- [ ] Pełna zawartość:
+  ```dockerfile
+  # syntax=docker/dockerfile:1.7
+
+  FROM python:3.13-slim-bookworm AS builder
+
+  ENV PYTHONUNBUFFERED=1 \
+      PIP_NO_CACHE_DIR=1 \
+      POETRY_VERSION=2.0.1
+
+  RUN pip install --no-cache-dir "poetry==${POETRY_VERSION}" "poetry-plugin-export>=1.8"
+
+  WORKDIR /build
+  COPY pyproject.toml poetry.lock ./
+  RUN poetry export --without-hashes --only=main -o requirements.txt
+  RUN pip install --user --no-cache-dir -r requirements.txt
+
+
+  FROM python:3.13-slim-bookworm AS runtime
+
+  ENV PYTHONUNBUFFERED=1 \
+      PYTHONDONTWRITEBYTECODE=1 \
+      PATH="/home/app/.local/bin:$PATH" \
+      DJANGO_SETTINGS_MODULE=config.settings.prod
+
+  RUN apt-get update \
+   && apt-get install -y --no-install-recommends curl \
+   && rm -rf /var/lib/apt/lists/*
+
+  RUN useradd --create-home --shell /bin/bash --uid 1000 app
+  USER app
+  WORKDIR /app
+
+  COPY --from=builder --chown=app:app /root/.local /home/app/.local
+  COPY --chown=app:app . /app
+
+  EXPOSE 8000
+
+  HEALTHCHECK --interval=15s --timeout=5s --start-period=60s --retries=3 \
+    CMD curl -fsS http://localhost:8000/health/ || exit 1
+
+  CMD ["gunicorn", "config.wsgi:application", \
+       "--bind", "0.0.0.0:8000", \
+       "--workers", "2", \
+       "--threads", "2", \
+       "--timeout", "60", \
+       "--access-logfile", "-", \
+       "--error-logfile", "-"]
+  ```
+
+### `.dockerignore`
+
+- [ ] Pełna zawartość:
+  ```
+  # Git
+  .git
+  .gitignore
+  .gitattributes
+
+  # Python
+  .venv
+  __pycache__
+  *.pyc
+  *.pyo
+  *.pyd
+  .pytest_cache
+  .mypy_cache
+  .ruff_cache
+  .coverage
+  htmlcov/
+  *.egg-info/
+
+  # Tests + docs (not needed in runtime image)
+  tests/
+  docs/
+
+  # Local env (secrets!) — keep .env.example as template
+  .env
+  .env.*
+  !.env.example
+
+  # IDE
+  .idea/
+  .vscode/
+
+  # Claude / superpowers scratch
+  .claude/
+
+  # Logs
+  *.log
+
+  # Compose (operator uses external file, image doesn't ship one)
+  docker-compose*.yml
+
+  # CI artifacts
+  .github/
+
+  # Markdown docs (keep README)
+  *.md
+  !README.md
+
+  # OS-specific
+  .DS_Store
+  Thumbs.db
+  ```
+
+### Smoke (w PR description)
+
+- [ ] `docker build -t tibiantis:dev .` → exit 0. Capture build time + final image hash.
+- [ ] `docker image ls tibiantis:dev` → image size raport. Target ~150-200MB. Jeśli > 300MB, audit warstw przez `docker history tibiantis:dev --no-trunc` i flag jako tech debt w PR body.
+- [ ] `docker run --rm -e DJANGO_SECRET_KEY=test -e DATABASE_URL=sqlite:///:memory: tibiantis:dev python manage.py check` → exit 0 + "System check identified no issues".
+- [ ] `docker inspect tibiantis:dev --format '{{.Config.User}}'` → `app` (non-root verified).
+- [ ] `docker inspect tibiantis:dev --format '{{json .Config.Healthcheck}}'` → JSON z `Test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health/ || exit 1"]`.
+
+## ⚠️ Pułapki do uwagi
+
+- **A — `poetry-plugin-export` MUSI być explicit installed** w builder stage. Poetry 2.x wyłączył `poetry export` jako built-in. Bez `pip install "poetry-plugin-export>=1.8"`, `poetry export` rzuca "command not found".
+- **B — `requirements.txt` transient** — NIE commituj do repo. Jeśli przypadkowo, dorzuć do `.gitignore`.
+- **C — `apt-get install curl` MUSI mieć `&& rm -rf /var/lib/apt/lists/*`** — cache APT zwiększa image o ~10MB.
+- **D — `--no-install-recommends` flag w `apt-get`** — bez tego curl ciągnie ~5-10MB recommended deps.
+- **E — `COPY --chown=app:app . /app`** — chown w trakcie COPY (single layer), nie `chown -R` w osobnym RUN (extra layer).
+- **F — `EXPOSE 8000` to dokumentacja, NIE port mapping** — tylko hint dla `docker run -P`. Real binding w compose `ports:`.
+- **G — `HEALTHCHECK --start-period=60s`** — pokrywa Django + DB pool + Redis init startup (~30-45s). Empirical tuning po D43 manual smoke.
+- **H — `CMD` exec form (JSON array)** — NIE shell form. PID 1 = gunicorn (SIGTERM graceful shutdown).
+- **I — `pip install --user --no-cache-dir`** — `--no-cache-dir` ważne (pip cache ~30-50MB).
+- **J — `.dockerignore` `.env*` + `!.env.example`** — wykluczamy real `.env` (secrets!), ale dorzucamy `.env.example` (template).
+- **K — `python:3.13-slim-bookworm`** NIE `python:3.13-slim` — explicit Debian codename (`bookworm` = Debian 12). Pin codename = reproducible builds.
+- **L — `--access-logfile - --error-logfile -`** — gunicorn loguje do plików by default. Container chce stdout — explicit `-` = stdout. Bez tego `docker logs web` puste.
+- **M — `# syntax=docker/dockerfile:1.7`** PIERWSZA linia — enables BuildKit features (heredocs, --mount cache). Optional ale recommended.
+- **N — `PYTHONDONTWRITEBYTECODE=1`** — nie zapisuje `.pyc` files (read-only filesystem friendly w container). Plus `PYTHONUNBUFFERED=1` żeby print() flush'ował od razu (Docker logs immediate).
+- **O — `DJANGO_SETTINGS_MODULE=config.settings.prod`** w ENV runtime stage — overrides `manage.py` default `dev`. Plus override'able przez env var w compose.
+
+## 🧪 Testing plan
+
+```bash
+# Build smoke
+docker build -t tibiantis:dev .
+
+# Image size
+docker image ls tibiantis:dev
+
+# Layer audit (gdy size > 250MB)
+docker history tibiantis:dev --no-trunc
+
+# Django check w container
+docker run --rm \
+  -e DJANGO_SECRET_KEY=test \
+  -e DATABASE_URL=sqlite:///:memory: \
+  -e REDIS_URL=redis://localhost:6379/0 \
+  tibiantis:dev \
+  python manage.py check
+
+# Non-root user verify
+docker inspect tibiantis:dev --format '{{.Config.User}}'
+# expected: app
+
+# HEALTHCHECK config verify
+docker inspect tibiantis:dev --format '{{json .Config.Healthcheck}}'
+
+# Pre-commit local
+poetry run pre-commit run --files Dockerfile .dockerignore
+```
+
+**Brak unit testów** (Dockerfile to infra). Manual smoke w PR description.
+
+## 📦 Definition of Done
+
+- [ ] AC spełnione (Dockerfile builds, smoke passes, image size < 250MB target).
+- [ ] PR zmergowany squash (2 commity: `build(deps): add gunicorn ...` + `feat(docker): multi-stage Dockerfile + .dockerignore (M9-D42, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] Image size report w PR body (`docker image ls` output).
+- [ ] Non-root user confirmed (`docker inspect`).
+- [ ] HEALTHCHECK config verified (`docker inspect`).

--- a/.github/issue-bodies/m9-d43.md
+++ b/.github/issue-bodies/m9-d43.md
@@ -1,0 +1,335 @@
+**Milestone:** M9 — Dockeryzacja + prod-ready
+**Czas:** 3-4h
+**Branch:** `feat/<this-issue-#>-prod-compose`
+**Type:** `feat`
+**Zależy od:** M9-D42 merged
+**Spec:** [`docs/superpowers/specs/2026-05-15-m9-dockerization-design.md`](../blob/master/docs/superpowers/specs/2026-05-15-m9-dockerization-design.md) §3.3, §3.4, §3.6
+**Plan:** [`docs/superpowers/plans/2026-05-15-m9-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-15-m9-implementation-plan.md) Task #3
+
+---
+
+## 🎯 Cel
+
+Utworzyć `docker-compose.yml` (prod, **różny** od istniejącego `docker-compose.dev.yml`) z 7 application services + 1 one-shot `migrate` service. Hybrid `image: ghcr.io/...:master` + `build: .` dla D43 dev iteration (registry tag NIE istnieje przed D44 push). Healthchecki per service zgodnie ze spec §3.3. `depends_on` chain ze spec §3.4. Update `.env.example` na Docker DNS hostnames (`postgres`/`redis`/`mongo`) + komentarze "Operator wypełnia" przy każdym sekrecie. Manual smoke "full stack up" w PR description (punkty 1-4 ze spec §9; punkt #5 ghcr.io push odroczony do D44).
+
+## 🧠 Czego się nauczysz
+
+- **`docker-compose.yml` vs `docker-compose.dev.yml`** — różne pliki dla różnych workflowów. Dev compose = DB only + app w `poetry run`. Prod compose = full 7-service stack.
+- **Hybrid `image:` + `build:` pattern** — gdy `image:` nie istnieje, compose fallback'uje na `build:` (Compose v2.20+ spec). Lokalnie buildujesz, prod pull'uje.
+- **`depends_on` z conditions** — `service_healthy` (czeka na healthcheck pass), `service_completed_successfully` (czeka na one-shot exit 0). Compose v2 syntax.
+- **One-shot service pattern** — `restart: "no"` + command runs once + exits. Idempotentne (`migrate` no-op gdy migracje up-to-date).
+- **`celery_beat` PID file healthcheck** — Beat tworzy pidfile (`--pidfile=`), proces żyje. `test -f $PID && ps -p $(cat $PID)` verifies.
+- **`celery -A config inspect ping`** — Celery worker built-in inspection. Wysyła ping przez broker (Redis), oczekuje pong. Identyfikuje hung workerów.
+- **`env_file: .env` w compose** — Docker compose ładuje `.env` automatycznie + per-service `env_file:`. Single source of truth.
+
+## ✅ Acceptance criteria
+
+### `docker-compose.yml`
+
+- [ ] Pełna zawartość:
+  ```yaml
+  services:
+
+    # ─── Infrastructure ───────────────────────────────────────────────
+
+    postgres:
+      image: postgres:16-alpine
+      env_file: .env
+      volumes:
+        - postgres_data:/var/lib/postgresql/data
+      healthcheck:
+        test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+        interval: 10s
+        timeout: 5s
+        retries: 5
+        start_period: 30s
+      restart: unless-stopped
+
+    redis:
+      image: redis:7-alpine
+      healthcheck:
+        test: ["CMD", "redis-cli", "ping"]
+        interval: 10s
+        timeout: 5s
+        retries: 5
+      restart: unless-stopped
+
+    mongo:
+      image: mongo:7
+      volumes:
+        - mongo_data:/data/db
+      healthcheck:
+        test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+        interval: 10s
+        timeout: 5s
+        retries: 5
+        start_period: 30s
+      restart: unless-stopped
+
+    # ─── Migration (one-shot) ─────────────────────────────────────────
+
+    migrate:
+      image: ghcr.io/bgozlinski/tibiantis-scraper:master
+      build: .
+      env_file: .env
+      command: python manage.py migrate --noinput
+      depends_on:
+        postgres:
+          condition: service_healthy
+      restart: "no"
+
+    # ─── Application services (shared image) ──────────────────────────
+
+    web:
+      image: ghcr.io/bgozlinski/tibiantis-scraper:master
+      build: .
+      env_file: .env
+      command:
+        - gunicorn
+        - config.wsgi:application
+        - --bind=0.0.0.0:8000
+        - --workers=2
+        - --threads=2
+        - --timeout=60
+        - --access-logfile=-
+        - --error-logfile=-
+      ports:
+        - "8000:8000"
+      depends_on:
+        postgres:
+          condition: service_healthy
+        redis:
+          condition: service_healthy
+        migrate:
+          condition: service_completed_successfully
+      healthcheck:
+        test: ["CMD", "curl", "-fsS", "http://localhost:8000/health/"]
+        interval: 15s
+        timeout: 5s
+        retries: 3
+        start_period: 60s
+      restart: unless-stopped
+
+    celery_worker:
+      image: ghcr.io/bgozlinski/tibiantis-scraper:master
+      build: .
+      env_file: .env
+      command:
+        - celery
+        - -A
+        - config
+        - worker
+        - -l
+        - info
+      depends_on:
+        postgres:
+          condition: service_healthy
+        redis:
+          condition: service_healthy
+        migrate:
+          condition: service_completed_successfully
+      healthcheck:
+        test: ["CMD-SHELL", "celery -A config inspect ping -d celery@$$HOSTNAME"]
+        interval: 30s
+        timeout: 10s
+        retries: 3
+        start_period: 60s
+      restart: unless-stopped
+
+    celery_beat:
+      image: ghcr.io/bgozlinski/tibiantis-scraper:master
+      build: .
+      env_file: .env
+      command:
+        - celery
+        - -A
+        - config
+        - beat
+        - -l
+        - info
+        - --pidfile=/tmp/celerybeat.pid
+        - --schedule=/tmp/celerybeat-schedule
+        - --scheduler=django_celery_beat.schedulers:DatabaseScheduler
+      depends_on:
+        postgres:
+          condition: service_healthy
+        redis:
+          condition: service_healthy
+        migrate:
+          condition: service_completed_successfully
+      healthcheck:
+        test: ["CMD-SHELL", "test -f /tmp/celerybeat.pid && ps -p $$(cat /tmp/celerybeat.pid) > /dev/null"]
+        interval: 30s
+        timeout: 5s
+        retries: 3
+        start_period: 60s
+      restart: unless-stopped
+
+    discord_bot:
+      image: ghcr.io/bgozlinski/tibiantis-scraper:master
+      build: .
+      env_file: .env
+      command: python manage.py run_discord_bot
+      depends_on:
+        postgres:
+          condition: service_healthy
+        mongo:
+          condition: service_healthy
+        migrate:
+          condition: service_completed_successfully
+      restart: unless-stopped
+
+  volumes:
+    postgres_data:
+    mongo_data:
+  ```
+
+### `.env.example` (modify)
+
+- [ ] Pełna zaktualizowana zawartość:
+  ```
+  # ─── Django ──────────────────────────────────────────────────────────
+  # Operator MUSI wypełnić — generate via:
+  #   python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+  DJANGO_SECRET_KEY=
+
+  # Set True only for local dev. Production must keep False.
+  DJANGO_DEBUG=False
+
+  # Comma-separated list, np. example.com,api.example.com
+  DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
+
+  # ─── PostgreSQL ──────────────────────────────────────────────────────
+  # Operator MUSI ustawić POSTGRES_PASSWORD na real value przed prod deploy.
+  POSTGRES_USER=tibiantis
+  POSTGRES_PASSWORD=tibiantis
+  POSTGRES_DB=tibiantis
+
+  # Docker DNS hostname `postgres` (compose service name).
+  # Dla DEV (bez compose, `runserver` lokalnie): zmień `postgres:5432` na `localhost:5435`.
+  DATABASE_URL=postgres://tibiantis:tibiantis@postgres:5432/tibiantis
+
+  # ─── Redis ───────────────────────────────────────────────────────────
+  # Docker DNS hostname `redis`. Dla DEV: `redis://localhost:6379/0`.
+  REDIS_URL=redis://redis:6379/0
+  CELERY_BROKER_URL=redis://redis:6379/1
+  CELERY_RESULT_BACKEND=redis://redis:6379/2
+
+  # ─── MongoDB ─────────────────────────────────────────────────────────
+  # Docker DNS hostname `mongo`. Dla DEV: `mongodb://localhost:27017`.
+  MONGO_URL=mongodb://mongo:27017
+  MONGO_DB=tibiantis_logs
+
+  # ─── Domain logic ────────────────────────────────────────────────────
+  CELERY_SCRAPE_FRESHNESS_MINUTES=30
+
+  DEATH_LEVEL_THRESHOLD=30
+
+  BEDMAGE_REGEN_MINUTES=100
+  BEDMAGE_NOTIFICATION_HANDLER=apps.notifications.handlers.DiscordDMHandler
+  DEATH_NOTIFICATION_HANDLER=apps.notifications.handlers.DiscordChannelHandler
+
+  # ─── Discord bot ─────────────────────────────────────────────────────
+  # Operator MUSI wypełnić — Discord Developer Portal → Application → Bot → Token.
+  # https://discord.com/developers/applications
+  DISCORD_BOT_TOKEN=
+
+  # Discord dev guild Server ID (Developer Mode → Copy ID). Empty dla prod.
+  DISCORD_DEV_GUILD_ID=
+  ```
+
+### Manual smoke (w PR description)
+
+- [ ] **YAML + chain walidacja:**
+  ```
+  docker compose -f docker-compose.yml config --quiet
+  ```
+  → exit 0, no errors.
+
+- [ ] **Full stack up:**
+  ```
+  cp .env.example .env
+  # operator fills: DJANGO_SECRET_KEY, DISCORD_BOT_TOKEN (real dev guild token), POSTGRES_PASSWORD
+  docker compose -f docker-compose.yml up -d
+  sleep 90
+  docker compose ps
+  ```
+  Expected: 7 services `Up (healthy)` + `migrate Exited (0)`. `discord_bot` może być `Up` bez healthcheck.
+
+- [ ] **Migration logs:**
+  ```
+  docker compose logs migrate
+  docker compose exec web python manage.py showmigrations --plan | grep '\[ \]' || echo "All applied"
+  ```
+  Expected: "Applying X..." w logs, "All applied" w stdout.
+
+- [ ] **Health endpoint:**
+  ```
+  curl -fsS http://localhost:8000/health/
+  ```
+  Expected: HTTP 200 + `{"db": "ok", "redis": "ok"}`.
+
+- [ ] **Cleanup:**
+  ```
+  docker compose -f docker-compose.yml down -v
+  ```
+  Expected: wszystkie services stopped + volumes removed.
+
+- [ ] Punkt #5 (ghcr.io pull) ODROCZONY do D44 — registry tag jeszcze nie istnieje.
+
+## ⚠️ Pułapki do uwagi
+
+- **A — `docker-compose.yml` vs `docker-compose.dev.yml`** — dwa różne pliki, dwa workflowy. Operator MUSI wiedzieć który użyć. `docker compose` bez `-f` używa `docker-compose.yml` (prod default).
+- **B — Hybrid `image:` + `build:`** — przed D44 push, `image:` tag nie istnieje. Compose najpierw `docker pull` — fail. Fallback `build:` z local Dockerfile. Sanity w D43: `docker compose build` explicit PRZED `up -d`.
+- **C — `depends_on` directed acyclic graph** — bez cykli. Sanity: `docker compose config --quiet`. Cykl rzuca "circular dependency detected".
+- **D — `service_completed_successfully` wymaga Compose v2.20+** — verify lokalnie `docker compose version`. Docker Desktop 4.20+ ma wbudowane.
+- **E — `celery_beat` `--pidfile=/tmp/celerybeat.pid` + `--schedule=/tmp/...`** EXPLICITLY w command. Bez `--pidfile` Beat nie zapisuje pidfile → healthcheck fails. `--schedule=/tmp/...` żeby tmp był writable dla user'a `app` (UID 1000, /tmp writable).
+- **F — `celery_worker` healthcheck overhead ~3s per call** — `interval: 30s` defensive (nie 10s). `interval: 10s` znaczyłby ~30% worker CPU na ping.
+- **G — `discord_bot` świadomie brak healthcheck** — long-running gateway connection bez exposed port. `restart: unless-stopped` + py-cord internal heartbeat. M-future: Mongo heartbeat write + custom healthcheck script.
+- **H — `volumes:` declared TWICE** — per-service (`postgres_data:/var/lib/...`) + top-level (`postgres_data:`). Top-level = named volume, persists across `docker compose down`.
+- **I — `env_file: .env` + `$$VAR` w command** — `$VAR` w compose to substitution z compose context (shell-time), `$$VAR` to literal `$VAR` przekazywane do container shell (runtime). Healthcheck `$$POSTGRES_USER` używa runtime env, NIE compose-time.
+- **J — `command: [list]` syntax z YAML** — items rozdzielone myślnikami w array notation. Compose `command:` ma dwa formaty: string ("python manage.py migrate") albo list (zalecane dla wielu flag, no shell quoting issues).
+- **K — `.env.example` `DATABASE_URL=postgres://...@postgres:5432/...`** — `postgres` to **service name w compose**, NIE `localhost`. Operator developujący lokalnie BEZ compose musi przepisać na `localhost:5435`. Komentarz tłumaczy.
+- **L — Compose default network** — Compose tworzy bridge per project automatycznie. Wszystkie services resolve'ują się po service name (`postgres`, `redis`, `mongo`). Bez explicit `networks:` default działa.
+- **M — `docker compose down -v` usuwa volumes** — `-v` flag deletes named volumes. **W prod NIE używaj** (data loss). W D43 manual smoke `down -v` to cleanup po teście.
+- **N — Mongo image NIE ma `-alpine` tag** — `mongo:7` zostaje, mongo dropped Alpine support w 6.x z reason'ów libc compatibility. Akceptowalne, większy image (~200MB vs Postgres ~80MB).
+- **O — `migrate` service ma `image:` + `build:` ten sam co reszta** — używa tego samego artefaktu, no separate "tools" image. Migracja chodzi z Django configuration z `config/settings/prod.py`.
+
+## 🧪 Testing plan
+
+```bash
+# YAML + chain walidacja (no execution)
+docker compose -f docker-compose.yml config --quiet
+
+# Build all
+docker compose -f docker-compose.yml build
+
+# Full stack up (wymaga .env z real DISCORD_BOT_TOKEN dla dev guild)
+cp .env.example .env
+# fill DJANGO_SECRET_KEY, DISCORD_BOT_TOKEN, POSTGRES_PASSWORD
+docker compose -f docker-compose.yml up -d
+
+# Sanity po 90s
+sleep 90
+docker compose ps
+
+# Migration verify
+docker compose logs migrate | tail -20
+docker compose exec web python manage.py showmigrations --plan | grep '\[ \]' || echo "All applied"
+
+# Health
+docker compose exec web curl -fsS http://localhost:8000/health/
+
+# Cleanup
+docker compose -f docker-compose.yml down -v
+```
+
+**Brak unit testów** (compose to infra). Manual smoke w PR description.
+
+## 📦 Definition of Done
+
+- [ ] AC spełnione (compose validates, full stack up ≤ 90s, healthchecki green, /health/ 200, migrations applied).
+- [ ] PR zmergowany squash (`feat(docker): production compose with 7 services + migrate one-shot (M9-D43, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] Manual smoke 4 punkty (z 5 spec'owanych — #5 ghcr.io odroczony do D44) w PR body.
+- [ ] `.env.example` Docker hostnames + "Operator wypełnia" komentarze.

--- a/.github/issue-bodies/m9-d44.md
+++ b/.github/issue-bodies/m9-d44.md
@@ -1,0 +1,216 @@
+**Milestone:** M9 — Dockeryzacja + prod-ready
+**Czas:** 3-4h
+**Branch:** `feat/<this-issue-#>-docker-ci` + `docs/close-m9-dockerization` (M5-D27 + M6-D30 + M7-D35 + M8-D40 pattern: 2 PR-y w 1 issue)
+**Type:** `feat` (CI workflow) + `docs` (closure)
+**Zależy od:** M9-D43 merged
+**Spec:** [`docs/superpowers/specs/2026-05-15-m9-dockerization-design.md`](../blob/master/docs/superpowers/specs/2026-05-15-m9-dockerization-design.md) §3.5, §8, §9
+**Plan:** [`docs/superpowers/plans/2026-05-15-m9-implementation-plan.md`](../blob/master/docs/superpowers/plans/2026-05-15-m9-implementation-plan.md) Task #4
+
+---
+
+## 🎯 Cel
+
+Utworzyć `.github/workflows/docker.yml` ze spec §13.2 (CLAUDE.md verbatim — build na PR + push do `ghcr.io/bgozlinski/tibiantis-scraper:<tag>` na push do master + tag v*; `docker/metadata-action@v5` dla tags: branch, semver, sha-short). M9 e2e smoke (closure PR description): full stack via `docker compose pull && docker compose up -d` z pre-built image z registry — potwierdzenie end-to-end push → pull → run flow. Closure PR od fresh master (M5-D27 + M6-D30 + M7-D35 + M8-D40 pattern repeat) — PROGRESS.md sekcja M9 z retro per Issue + 5-punkt manual smoke + Tech debt M9 + milestone close via `gh api`.
+
+D44 ma **2 PR-y w 1 issue** (M5-D27 + M6-D30 + M7-D35 + M8-D40 pattern):
+
+1. **Feature PR** (`feat/<#>-docker-ci`) — `.github/workflows/docker.yml`.
+2. **Closure PR** (`docs/close-m9-dockerization` od **fresh master** po feature merge) — PROGRESS.md retro + manual smoke + milestone close.
+
+## 🧠 Czego się nauczysz
+
+- **`docker/metadata-action@v5`** — generuje image tags z GitHub event context. `type=ref,event=branch` → `:master`. `type=semver,pattern={{version}}` → `:1.2.3` z git tag. `type=sha,prefix=sha-,format=short` → `:sha-acaa3c9`.
+- **`docker/build-push-action@v6`** — buildx-based, multi-platform, layer cache, registry push. `cache-from: type=gha + cache-to: type=gha,mode=max` (GHA native cache).
+- **`packages: write` permission** — workflow potrzebuje permission do `ghcr.io`. `permissions: { contents: read, packages: write }` w job-level. `GITHUB_TOKEN` auto-generated ma scope.
+- **`gh api -X PATCH .../milestones/9 -f state=closed`** — M5-D27 + M6-D30 + M7-D35 + M8-D40 precedens (5. raz, M9 = 6.).
+
+## ✅ Acceptance criteria
+
+### Feature PR (`feat/<#>-docker-ci`)
+
+- [ ] `.github/workflows/docker.yml`:
+  ```yaml
+  name: Docker build
+
+  on:
+    pull_request:
+      paths:
+        - "Dockerfile"
+        - ".dockerignore"
+        - "docker-compose.yml"
+        - "pyproject.toml"
+        - "poetry.lock"
+        - ".github/workflows/docker.yml"
+    push:
+      branches: [master]
+      tags: ["v*"]
+
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        packages: write
+      steps:
+        - uses: actions/checkout@v4
+
+        - uses: docker/setup-buildx-action@v3
+
+        - uses: docker/login-action@v3
+          if: github.event_name != 'pull_request'
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - uses: docker/metadata-action@v5
+          id: meta
+          with:
+            images: ghcr.io/${{ github.repository }}
+            tags: |
+              type=ref,event=branch
+              type=semver,pattern={{version}}
+              type=sha,prefix=sha-,format=short
+
+        - uses: docker/build-push-action@v6
+          with:
+            context: .
+            push: ${{ github.event_name != 'pull_request' }}
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+  ```
+- [ ] PR build (PR-only event): `push: false`, image build sanity ale NIE push.
+- [ ] Master push: `push: true`, image w `ghcr.io/bgozlinski/tibiantis-scraper:master` + `:sha-<commit>`.
+- [ ] Tag `v1.0.0` push: image jako `:1.0.0` + `:sha-<commit>` + `:master` (jeśli master branch też).
+- [ ] CI workflow zielony na feature PR (build-only verification).
+- [ ] Feature PR zmergowany squash (`feat(ci): docker.yml workflow with ghcr.io build + push (M9-D44, #<#>)`).
+
+### Post-feature-merge sanity (przed closure PR)
+
+- [ ] `gh run list --workflow=docker.yml --limit 1` → status `completed`, conclusion `success`.
+- [ ] `docker pull ghcr.io/bgozlinski/tibiantis-scraper:master` z lokalu (logged in via `docker login ghcr.io -u bgozlinski` z PAT z `read:packages` scope).
+- [ ] Image visible at `https://github.com/bgozlinski/tibiantis-scraper/pkgs/container/tibiantis-scraper`.
+
+### Closure PR (`docs/close-m9-dockerization`)
+
+- [ ] `PROGRESS.md` rozszerzone o:
+  - `## 🎉 Milestone M9 — Dockeryzacja + prod-ready COMPLETED (2026-MM-DD)` header
+  - `### Ukończone (M9)` — lista 4 issues + PR linki + squash hashes
+  - `### Notatki z retro M9 (dopisywane progresywnie)` — per Issue D41-D44
+  - `### Definition of Done M9` (ze spec'a §8) — wszystkie [x] poza ostatnim ("milestone closed" — TODO post-merge)
+  - `### Podsumowanie M9` (data range, dni vs budżet, najwartościowsze lekcje)
+  - `### Tech debt z M9` (carry-over do M10+)
+- [ ] **Manual smoke** udokumentowany w closure PR description (5 punktów ze spec §9):
+  1. Local `docker build .` → exit 0, image size ~150-200MB
+  2. Local `docker compose -f docker-compose.yml up -d` → wszystkie 7 services healthy w ≤90s
+  3. `docker compose logs migrate` → exit 0, migrations applied
+  4. `curl /health/` z hosta przez exposed `web:8000` → 200 + JSON
+  5. Post-master-merge: `docker pull ghcr.io/bgozlinski/tibiantis-scraper:master` z lokalu → success (end-to-end CI push → local pull confirmed)
+- [ ] **Po merge closure PR'a:** `gh api -X PATCH repos/bgozlinski/tibiantis-scraper/milestones/9 -f state=closed`.
+- [ ] **Sanity:** `gh issue list --milestone "M9 — Dockeryzacja + prod-ready" --state open` → empty.
+
+## ⚠️ Pułapki do uwagi
+
+- **A — `paths:` filter w `pull_request` trigger** — workflow odpala TYLKO gdy PR dotyka wymienionych ścieżek. Bez tego każdy PR (np. docs-only) triggeruje docker build → marnotrawstwo CI minutes.
+- **B — `if: github.event_name != 'pull_request'` na login-action** — login do ghcr.io NIE na PR build. Bez tego forki PR mogłyby próbować login z forked workflow → security issue.
+- **C — `push: ${{ github.event_name != 'pull_request' }}` na build-push-action** — push TYLKO na master/tag, NIE na PR. Spec pattern z CLAUDE.md §13.2.
+- **D — `concurrency: cancel-in-progress: true`** — drugi push na ten sam ref zabija pierwszy run. Oszczędność CI minutes przy szybkich consecutive merges.
+- **E — `cache-from: type=gha + cache-to: type=gha,mode=max`** — GitHub Actions native cache. `mode=max` cache'uje wszystkie warstwy (default `mode=min` tylko final).
+- **F — `docker/metadata-action@v5` `images:` lowercase** — `ghcr.io/${{ github.repository }}` resolves do `ghcr.io/bgozlinski/tibiantis-scraper`. GitHub username case-sensitive ale ghcr lower-cases. Sanity: pull lowercase.
+- **G — First push po merge może fail jeśli `packages: write` scope nie auto-aktywuje** — repo settings: Settings → Actions → General → Workflow permissions → "Read and write permissions". Sanity po pierwszym merge: workflow run logs pokazują "Login Succeeded" przed push. Jeśli "Permission denied" — fix repo settings.
+- **H — Closure branch od fresh master** (M1-D8 + M5-D27 + M6-D30 + M7-D35 + M8-D40 lekcja repeat **6. raz**) — `git checkout master && git pull && git checkout -b docs/close-m9-dockerization` PRZED edycją PROGRESS.md.
+- **I — `gh api -X PATCH milestones/9`** — `9` to **number**, nie title. Verify: `gh api repos/bgozlinski/tibiantis-scraper/milestones --jq '.[] | select(.title|startswith("M9")) | .number'` → `9`.
+- **J — Milestone exact title match** — `gh issue list --milestone "M9 — Dockeryzacja + prod-ready"` wymaga dokładnego tytułu (em-dash `—`, NIE myślnika `-`).
+- **K — `docker login ghcr.io -u bgozlinski`** wymaga PAT z `read:packages` scope (dla pull) lub `write:packages` (dla push). PR push uses `GITHUB_TOKEN` (auto-scoped), ale lokalny pull dla manual smoke wymaga PAT z user settings → Developer settings → Personal access tokens.
+- **L — `tags: ["v*"]` glob match** — `v1.0.0`, `v1.0.0-rc.1`, `v2.0.0-beta` wszystkie match. Conventional bump tags: `git tag v0.1.0; git push --tags`.
+
+## 🧪 Testing plan
+
+### Feature PR
+
+```bash
+# Workflow runs auto na PR
+gh pr checks <PR-#>
+# expected: "Docker build" job → pass (build only, no push)
+
+# Sanity workflow YAML
+yamllint .github/workflows/docker.yml
+
+# Pre-commit
+poetry run pre-commit run --files .github/workflows/docker.yml
+```
+
+### Post-merge feature → sanity
+
+```bash
+# Workflow run status
+gh run list --workflow=docker.yml --limit 1
+
+# Image w registry
+docker pull ghcr.io/bgozlinski/tibiantis-scraper:master
+docker image inspect ghcr.io/bgozlinski/tibiantis-scraper:master --format '{{.Created}}'
+```
+
+### Closure PR — Manual smoke (operator's laptop)
+
+W closure PR body zacytuj wyniki (zrzut ekranu lub verbatim transcript):
+
+1. **Local build:**
+   ```bash
+   docker build -t tibiantis:dev .
+   docker image ls tibiantis:dev
+   ```
+   → exit 0, image ~150-200MB.
+
+2. **Full stack up:**
+   ```bash
+   cp .env.example .env
+   # fill DJANGO_SECRET_KEY, DISCORD_BOT_TOKEN, POSTGRES_PASSWORD
+   docker compose -f docker-compose.yml up -d
+   sleep 90
+   docker compose ps
+   ```
+   → 7 services `Up healthy` + `migrate Exited (0)`.
+
+3. **Migration:**
+   ```bash
+   docker compose logs migrate
+   docker compose exec web python manage.py showmigrations --plan | grep '\[ \]' || echo "All applied"
+   ```
+   → exit 0 w logs, "All applied".
+
+4. **Health endpoint:**
+   ```bash
+   curl -fsS http://localhost:8000/health/
+   ```
+   → `{"db": "ok", "redis": "ok"}` + HTTP 200.
+
+5. **Post-master-merge registry pull:**
+   ```bash
+   docker login ghcr.io -u bgozlinski   # PAT z read:packages scope
+   docker pull ghcr.io/bgozlinski/tibiantis-scraper:master
+   docker image inspect ghcr.io/bgozlinski/tibiantis-scraper:master
+   ```
+   → success.
+
+## 📦 Definition of Done
+
+### Feature PR
+- [ ] AC spełnione (`docker.yml` workflow exists, PR build sanity, master push triggers ghcr.io push).
+- [ ] Feature PR zmergowany squash (`feat(ci): docker.yml workflow with ghcr.io build + push (M9-D44, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] Image visible at `https://github.com/bgozlinski/tibiantis-scraper/pkgs/container/tibiantis-scraper` po master merge.
+
+### Closure PR
+- [ ] Closure PR zmergowany squash (`docs(progress): close M9 — Dockeryzacja + prod-ready COMPLETED + retro D41-D44`).
+- [ ] CI lint zielony.
+- [ ] PROGRESS.md sekcja M9 dorzucona.
+- [ ] Manual smoke description w closure PR body (5 punktów z testing plan).
+- [ ] Milestone M9 zamknięty na GitHub via `gh api -X PATCH .../milestones/9 -f state=closed`.
+- [ ] Wszystkie M9 issues CLOSED (`gh issue list --milestone "M9 — Dockeryzacja + prod-ready" --state open` → empty).

--- a/docs/superpowers/plans/2026-05-15-m9-implementation-plan.md
+++ b/docs/superpowers/plans/2026-05-15-m9-implementation-plan.md
@@ -1,0 +1,631 @@
+# M9 — Dockeryzacja + prod-ready — Implementation plan
+
+**Data:** 2026-05-15
+**Spec:** [`docs/superpowers/specs/2026-05-15-m9-dockerization-design.md`](../specs/2026-05-15-m9-dockerization-design.md)
+**Status:** READY (spec accepted, decyzje §3.1-3.7 zaakceptowane przez developera 2026-05-15).
+
+---
+
+## Źródła
+
+- **CLAUDE.md** §2 (Django 6.0 + Gunicorn WSGI, ASGI uvicorn YAGNI), §10 (Docker stack, multi-stage Dockerfile, 7 services + healthchecki + volumes, `.env` strategy), §13.2 (`docker.yml` workflow template z `docker/metadata-action@v5` + `docker/build-push-action@v6`), §15 reguła #1 (nie modyfikuj stosu bez zgody — gunicorn jako nowa prod dep wymaga note'y w spec'u).
+- **Design spec M9** — kluczowy dokument referencyjny. Każdy issue body linkuje do spec'a §X.
+- **Precedensy z M0-M8:**
+  - **M0-D3** — pre-commit `gitleaks` blokuje commits z secret'ami (wartości w `.env` real, w `.env.example` blank). M9 dorzuca komentarz "Operator wypełnia" do każdego sekretu w `.env.example`.
+  - **M0-D2** — `docker-compose.dev.yml` z postgres+redis+mongo + healthchecki. M9 prod compose **extends** ten pattern dla 4 app services (web/celery_worker/celery_beat/discord_bot).
+  - **M2-D11** — `config/urls.py` routing zaprojektowany z `apps.accounts.urls` jako template. M9 dorzuca `path("health/", include("apps.core.urls"))`.
+  - **M3-D17** — Celery worker uruchamiany lokalnie przez `poetry run celery -A config worker -l info -P solo` (Windows pool fix, `feedback_celery_windows_pool` memory). M9 w Linux container używa **default prefork pool** — `-P solo` to Windows dev only, NIE w Dockerfile CMD.
+  - **M3-D17** — `django-celery-beat` DB-backed scheduler (`--scheduler django_celery_beat.schedulers:DatabaseScheduler` w command). M9 `celery_beat` service używa tego samego scheduler'a.
+  - **M5-D24** — `services.py` type-hint convention: direct `from apps.accounts.models import User` (memory `feedback_services_user_type_hint`). M9 `apps/core/health.py` nie używa User (DB cursor + Redis raw client), no relevance.
+  - **M6-D28** — graceful disable handlers przy braku resource (empty `MONGO_URL` → `NullHandler`, eager resource lookup w `__init__` to pułapka). M9 `health.py` używa lazy `redis.Redis.from_url(...)` per request (no eager singleton).
+  - **M6 retro lekcja #2** — `propagate: True` na named logger keeps pytest caplog working. M9 `apps/core/health.py` używa `logging.getLogger(__name__)` = `apps.core.health` — propagacja do root → Mongo dispatch via M6.
+  - **M7-D31** — pierwszy top-level Django app (`discord_bot/` — bez `apps.` prefix). M9 `apps/core/` to **standardowy nested app pod `apps/`** (jak `apps/notifications/`, NIE jak `discord_bot/`). Powód: `apps/core/` nie ma modeli ani `migrations/`, tylko view + urls + tests. `LOCAL_APPS = [..., "apps.core"]` (z `apps.` prefix).
+  - **M7-D32** — django-environ `env.int(...)` z empty env var crashuje (Pułapka H). M9 `.env.example` musi mieć komentarz "Operator wypełnia" przy każdym **wymaganym** secrecie, inaczej `env("DJANGO_SECRET_KEY")` crashuje przy `docker compose up` jeśli operator skopiuje `.env.example → .env` bez fill-in.
+  - **M7-D32** — Python range narrowing `>=3.13,<3.14` w `pyproject.toml`. M9 Dockerfile używa `python:3.13-slim-bookworm` (matching).
+  - **M7-D33 + hotfix #124** — manual smoke jest jedyną siecią dla py-cord cogów. M9 manual smoke (D44 closure) jest jedyną siecią dla **full Docker stack** (Dockerfile build + 7 services up + healthchecki green + ghcr.io push). Nie testujemy real deploy.
+  - **M8-D36** — `httpx` jako direct dep z tighter pin `(>=0.28.1,<0.29.0)` zamiast spec'owego `(>=0.27,<1.0)`. M9 `gunicorn` analogicznie: spec mówi `(>=23.0,<24.0)`, faktyczna wersja zalezna od `poetry add gunicorn` z najnowszego dostępnego release'a.
+  - **M8-D37/D38 lazy import dla pre-commit mypy isolated venv** — `from apps.notifications.discord_client import DiscordRESTClient` inside `notify()` zamiast top-level. M9 `health.py` używa `import redis` top-level — `redis` jest już direct dep z M5, więc mypy isolated venv ma stub'y (no lazy import needed). Verify: `pre-commit run mypy --files apps/core/health.py` po implementacji.
+  - **M8-D40 pattern: feature PR + closure PR w 1 issue** (M5-D27 + M6-D30 + M7-D35 lineage). M9-D44 powtarza pattern: feature PR (`feat/<#>-docker-ci`) + closure PR (`docs/close-m9-dockerization`).
+  - **M5-D27 + M6-D30 + M7-D35 + M8-D40 closure pattern** — `git checkout master && git pull && git checkout -b docs/close-mN-...` PRZED PROGRESS.md edycją (Pułapka C utrwalona przez 5 milestone'ów).
+
+---
+
+## Pre-flight checklist (przed startem D41)
+
+- [ ] **`apps/notifications/` istnieje** — sprawdzone 2026-05-15 (z M5). M9 dorzuca **siostrzany** `apps/core/` (osobny, no shared code).
+- [ ] **`docker-compose.dev.yml` istnieje** — sprawdzone 2026-05-15, ma postgres+redis+mongo + healthchecki. M9 prod compose **NIE zastępuje** dev compose — oba pliki coexist. Operator wybiera `docker compose -f docker-compose.dev.yml` (dev) lub `docker compose -f docker-compose.yml` (prod).
+- [ ] **`pyproject.toml` — `gunicorn` NIE jest jeszcze dependencją** — sprawdzone 2026-05-15 (po `grep gunicorn pyproject.toml` empty). M9-D42 dorzuca jako `gunicorn (>=23.0,<24.0)` w osobnym `build(deps)` commit.
+- [ ] **`pyproject.toml` — `redis (>=7.4.0,<8.0.0)` JUŻ jest direct dep** — sprawdzone 2026-05-15 (`pyproject.toml:22`, z M5). M9 NIE dorzuca redis ponownie.
+- [ ] **`config/settings/prod.py` istnieje** — sprawdzone 2026-05-15, minimal (`from .base import *` + `DEBUG = False`). M9 Dockerfile ustawia `ENV DJANGO_SETTINGS_MODULE=config.settings.prod`.
+- [ ] **`.env.example` exists** — sprawdzone 2026-05-15 (37 linii). M9-D43 aktualizuje na Docker hostnames (`postgres`/`redis`/`mongo`) zamiast `localhost`.
+- [ ] **`.github/workflows/ci.yml` istnieje** — sprawdzone 2026-05-15 (jedyny workflow w repo). M9-D44 dorzuca `docker.yml` jako **drugi** workflow (no zmiany w `ci.yml`).
+- [ ] **`docker buildx` available** — wymagane dla `docker/build-push-action@v6` w CI (multi-platform support, layer cache). Local sanity: `docker buildx version` na laptopie. Docker Desktop ma buildx built-in.
+- [ ] **`gh auth status` z `repo` + `write:packages` scopes** — wymagane dla `ghcr.io` push z GHA. CI używa `GITHUB_TOKEN` z auto-generowanego scope (per workflow `permissions: contents: read, packages: write`).
+- [ ] **PROCESS: pre-commit `no-commit-to-branch` hook** (PR #105 M5) — blokuje commits na master. **Każdy D-task wymaga `git checkout -b feat/<#>-...` PRZED kodowaniem** (CLAUDE.md §12).
+- [ ] **PROCESS: `pre-commit clean` przed `# type: ignore` na nowych mypy errors** (M7 retro lekcja #3) — stale cache po fresh `gunicorn` install może false-positive'ować. `poetry run pre-commit clean` przed flagowaniem nowych errors jako blocker.
+
+---
+
+## Otwarte pytania (rozstrzygnięte 2026-05-15, spec §3)
+
+Wszystkie 7 decyzji designowych ze spec'a §3 zaakceptowane bez modyfikacji:
+
+1. ✅ **§3.1** Dockerfile multi-stage z `poetry export → requirements.txt` w builder (odstąpienie od CLAUDE.md §10 "no requirements.txt" — kontekst BUILD stage, nie dev workflow).
+2. ✅ **§3.2** Gunicorn WSGI dla `web` (`--workers 2 --threads 2 --timeout 60`). Uvicorn ASGI to YAGNI.
+3. ✅ **§3.3** Per-service healthchecki (8 services włącznie z `migrate`, ale `migrate` nie ma healthcheck — one-shot exit). `discord_bot` świadomie BEZ healthcheck (restart policy wystarcza).
+4. ✅ **§3.4** Migration jako osobny one-shot service `migrate` z `service_completed_successfully` dependency dla `web`.
+5. ✅ **§3.5** Rolling `:master` tag + `:sha-<commit>` audit. Semver `:v1.2.3` to M-future.
+6. ✅ **§3.6** `env_file: .env` strategy. Docker secrets / Vault to M-future.
+7. ✅ **§3.7** Non-root user `app` (UID 1000) w runtime stage. Distroless image to M-future.
+
+**Open questions z §11** (do M9 retro, NIE w M9 scope):
+- `STATIC_URL` / collectstatic — admin SSH tunnel workflow w M9, WhiteNoise w M10
+- Image size target (150-200MB target, hard data po D42)
+- Image scanning (Trivy/Snyk) — kandydat na M10
+- `web:8000` exposed `ports:` vs `expose:` — M9 daje `ports:` dla local smoke, M-future + nginx zmienia
+- Celery beat scheduler choice — `django-celery-beat` DB-backed zostaje (M3-D17 setup, no change w M9)
+
+---
+
+## Risk + mitigation
+
+| Ryzyko | Prawdopodobieństwo | Impact | Mitigation |
+|---|---|---|---|
+| **`gunicorn` resolver pulls niezgodne `setuptools`/`packaging`** | Niskie (gunicorn ma stable ~10+ years deps) | `poetry add` fails, blokuje D42 start | Spec specifies `gunicorn (>=23.0,<24.0)` jako stable range. Verify: `poetry add gunicorn; poetry show gunicorn` — sanity check no transitive conflict z httpx/celery deps. |
+| **`poetry export` plugin missing w fresh Poetry 2.x install** | Wysokie (Poetry 2.0+ wyłączył `export` jako built-in, wymaga `poetry-plugin-export`) | `poetry export` w Dockerfile builder fail | Dockerfile builder explicit `pip install "poetry==${POETRY_VERSION}" "poetry-plugin-export>=1.8"`. Bez tego export rzuci "command not found". |
+| **`apt-get install curl` w runtime stage zwiększa image size** | Średnie | Image +20-30MB (curl + deps) | Trade-off accepted — curl jedyna stabilna opcja dla HEALTHCHECK CMD. Alternative: użyć Python httpx w HEALTHCHECK (`CMD python -c "import httpx; httpx.get('http://localhost:8000/health/').raise_for_status()"`) — zachowa rozmiar, ale wolniejsze (Python interpreter startup ~200ms vs curl ~20ms). Decyzja: zostać przy curl, audit rozmiaru po D42 manual smoke (sanity point #2). |
+| **`mypy strict + redis.Redis missing stubs`** | Wysokie (redis-py od 5.x ma własne stub'y, ale isolated venv może nie widzieć) | `pre-commit run mypy --files apps/core/health.py` red | `pre-commit clean` przed flagowaniem (M7 retro lekcja #3). Jeśli nadal red — dorzucić `types-redis` do `[tool.poetry.group.dev.dependencies]` w D41. NIE dodawać `# type: ignore` jako pierwszą reakcję. |
+| **`docker compose up` deadlock — wszystkie services czekają na siebie** | Niskie (depends_on ma directed acyclic chain) | Cały stack hang, manual `docker compose down` | Spec §3.4 chain: `postgres+redis+mongo` → `migrate` → `web` → reszta. Bez cykli. Sanity: `docker compose config --quiet` (walidacja YAML + chain) w D43 PR przed merge. |
+| **Healthcheck `web` curl fails bo gunicorn startuje wolno** | Średnie (60s start_period to luźna estymata) | Service flapuje `starting → unhealthy`, restart loop | Spec §3.3: `start_period: 60s` daje margines. Manual smoke D43: ile faktycznie trwa od container start do `curl /health/` 200? Jeśli > 60s, bump na 90s. Jeśli < 30s, można obniżyć. Empiryczne po D43 manual smoke. |
+| **`celery_beat` healthcheck pidfile race** | Średnie (pidfile może nie istnieć przez pierwsze ~5s po start) | Healthcheck fails podczas startup | `start_period: 60s` + `command: celery -A config beat --pidfile=/tmp/celerybeat.pid --schedule=/tmp/celerybeat-schedule --scheduler ...`. Beat tworzy pidfile w ~1s. Healthcheck retries 3x z 30s interval = 90s tolerance po `start_period`. |
+| **`ghcr.io push` fails — auth scope missing** | Średnie przy pierwszym setup | Workflow red, image NIE w registry | Spec §13.2 i M9-D44 issue body explicit: `permissions: { contents: read, packages: write }` w workflow + `username: ${{ github.actor }} password: ${{ secrets.GITHUB_TOKEN }}` w login-action. Brak custom PAT (auto-token wystarcza). Verify: workflow run logs pokazują "Login Succeeded" przed push. |
+| **`.env` w container empty/missing przy `docker compose up`** | Wysokie przy pierwszym deploy (operator nie ma `.env`) | Cały stack crashuje na `env("DJANGO_SECRET_KEY")` (django-environ default behavior — raise) | `.env.example` ma `# Operator MUSI wypełnić` komentarz przy każdym wymaganym secrecie. Plus `docker compose up` bez `.env` rzuca explicit error "env file .env not found". |
+| **Migration race podczas operator restart** | Niskie (Postgres ma migration locks via `django_migrations` table) | Dwa `migrate` services próbują równocześnie | Django `migrate` używa Postgres advisory locks. Drugi `migrate` czeka albo no-op (`No migrations to apply`). Akceptowalne. |
+| **CI workflow podwójnie triggered (pull_request + push to master)** | Średnie | 2× build = 2× GHA minutes spent | Spec §13.2 ma `concurrency: cancel-in-progress`. M9 `docker.yml` dorzuca same `concurrency` group. Plus `push:` trigger explicit `branches: [master]` + `tags: ["v*"]`. PR-only build (na branch !master) NIE pushuje. Net: PR build (verify) + master merge build+push = 2 builds per merge, akceptowalne. |
+| **`migrate` service zamknięty z exit 1 (legitimate migration error)** | Niskie (M0-M8 migracje testowane lokalnie) | `web` nie startuje (`service_completed_successfully` not met) | Spec §6.2: operator widzi `docker compose logs migrate` → fix migration lokalnie → rebuild image → retry. Brak auto-rollback (M-future). |
+| **D43 compose manual smoke wymaga `.env` z real Discord token** | Średnie (operator może nie mieć dev guild ready) | D43 manual smoke punkt #2 incomplete | D43 issue body explicit: jeśli brak `DISCORD_BOT_TOKEN`, `discord_bot` service nie startuje OK (gateway connection fail). Akceptowalne dla manual smoke — `docker compose ps` pokazuje 6/7 healthy + 1 restarting. Real token only dla post-merge prod deploy. |
+
+---
+
+## Task overview
+
+| # | ID | Tytuł | Czas | Zależy od | Branch |
+|---|---|---|---|---|---|
+| 1 | M9-D41 | `apps/core` healthcheck app + `/health/` endpoint + 4 testy | 2-3h | M8 closed | `feat/<#>-health-endpoint` |
+| 2 | M9-D42 | Multi-stage `Dockerfile` + `.dockerignore` + `gunicorn` dep + local container smoke | 3-4h | D41 merged | `feat/<#>-dockerfile` |
+| 3 | M9-D43 | Production `docker-compose.yml` + 7 services + migrate one-shot + healthchecki + `.env.example` Docker hostnames | 3-4h | D42 merged | `feat/<#>-prod-compose` |
+| 4 | M9-D44 | `docker.yml` CI workflow (build + push ghcr.io) + M9 e2e (full stack smoke) + closure (PROGRESS.md retro + milestone close) | 3-4h | D43 merged | `feat/<#>-docker-ci` + `docs/close-m9-dockerization` |
+
+**Total:** ~11-15h, ~3 dni roboczych. Mieści się w 16h M9 budget (4 dni × 4h).
+
+---
+
+## Task #1 — [M9-D41] `apps/core` healthcheck app + `/health/` endpoint + 4 testy
+
+### 🎯 Cel
+
+Utworzyć nowy nested Django app `apps/core/` z minimalnym scope: `apps.py` (`CoreConfig`), `health.py` (view `health_check` zwracający 200 + `{"db": "ok", "redis": "ok"}` po sprawdzeniu DB cursor + Redis ping; 503 + `{"db": "fail"|"ok", "redis": "fail"|"ok", "error": "..."}` przy fail), `urls.py` (`path("", health_check)`). Dorzucenie `path("health/", include("apps.core.urls"))` w `config/urls.py` + `"apps.core"` w `LOCAL_APPS`. 4 unit testy w `apps/core/tests/test_health.py`. Po D41: endpoint `/health/` osiągalny lokalnie (`poetry run python manage.py runserver`, `curl http://localhost:8000/health/` → 200), gotowy do użycia w Docker HEALTHCHECK w D42.
+
+### 🧠 Czego się nauczysz
+
+- **Minimal Django app structure** — `apps/core/` to **drugi** nested app bez modeli i migracji (po `apps/notifications/` z M5). Tylko `apps.py` + view + urls + tests. Pattern dla cross-cutting concerns (utils, health checks, monitoring endpoints).
+- **`@require_GET` decorator** — Django built-in `from django.views.decorators.http import require_GET` ogranicza view na metody HTTP (POST/PUT/DELETE → 405 Method Not Allowed). Defensywne dla health endpoint — load balancer'y i Docker HEALTHCHECK używają GET, ale klient może wysłać POST przez pomyłkę.
+- **`django.db.connection.cursor()` jako sync DB check** — niski koszt (~1-2ms), sprawdza ze połączenie z PG działa + uprawnienia. `cursor.execute("SELECT 1")` to canonical "ping" dla relational DBs. Wyłapuje `OperationalError` gdy PG down lub auth fail.
+- **`redis.Redis.from_url(url).ping()` jako sync Redis check** — `redis-py` (już direct dep z M5) ma synchronous `ping()` method. `socket_timeout=2` defensive (~2s max wait jeśli Redis nie odpowiada). Rzuca `ConnectionError`/`TimeoutError` — handled.
+- **`JsonResponse` z explicit `status=`** — Django default status=200, można nadpisać `status=503` dla unhealthy. Body zostaje JSON, content-type `application/json` auto.
+- **`pytest-django` mocking DB/Redis przez `unittest.mock.patch`** — D41 testy mockują `django.db.connection.cursor` i `redis.Redis.from_url` żeby symulować fail bez crashowania real DB/Redis. Pattern: `mock.patch("django.db.connection.cursor", side_effect=OperationalError("simulated"))`.
+
+### ✅ Acceptance criteria
+
+(Pełne AC w issue body — `.github/issue-bodies/m9-d41.md`.)
+
+**Kluczowe punkty:**
+
+- `apps/core/__init__.py` — empty.
+- `apps/core/apps.py`:
+  ```python
+  from django.apps import AppConfig
+
+  class CoreConfig(AppConfig):
+      default_auto_field = "django.db.models.BigAutoField"
+      name = "apps.core"
+  ```
+- `apps/core/health.py` — view `health_check(request) -> JsonResponse` z `@require_GET` dekoratorem, sprawdza DB (cursor.execute "SELECT 1") + Redis (Redis.from_url(REDIS_URL, socket_timeout=2).ping()), zwraca 200 z `{"db": "ok", "redis": "ok"}` lub 503 z `{"db": "fail"|"ok", "redis": "fail"|"ok", "error": str}`. Pełna sygnatura w spec §4.1.
+- `apps/core/urls.py` — `urlpatterns = [path("", health_check, name="health-check")]`.
+- `config/urls.py` — dorzucenie `path("health/", include("apps.core.urls"))`. Sanity: `curl http://localhost:8000/health/` (NIE `/health` bez slash — Django default `APPEND_SLASH=True` redirect'uje, ale Docker HEALTHCHECK powinien hit'ować final URL bezpośrednio).
+- `config/settings/base.py` — `LOCAL_APPS` rozszerzone o `"apps.core"`.
+- `apps/core/tests/test_health.py` — 4 tests:
+  - `test_health_returns_200_when_db_and_redis_ok` — happy path, JSON shape `{"db": "ok", "redis": "ok"}`, status 200, content-type application/json.
+  - `test_health_returns_503_when_db_fails` — mock `connection.cursor` → `OperationalError("connection refused")`, expects 503 + `"db": "fail"` + `"error"` containing "connection refused".
+  - `test_health_returns_503_when_redis_fails` — mock `redis.Redis.from_url(...).ping()` → `ConnectionError("Connection refused")`, expects 503 + `"redis": "fail"`.
+  - `test_health_response_shape_keys_locked` — JSON keys lock test (forward-compat dla M-future Mongo/Celery checks): assert keys w response są subset `{"db", "redis", "error"}`.
+- Coverage `apps/core/health.py` ≥ 95%.
+
+### ⚠️ Pułapki do uwagi
+
+- **A — `LOCAL_APPS = [..., "apps.core"]` z `apps.` prefix.** Nie `"core"` (top-level top-level jak `discord_bot/`). `apps/core/` to **nested** app pod `apps/`, `INSTALLED_APPS` musi mieć dotted path `apps.core`. Bez tego Django `apps.get_app_config("core")` rzuca `LookupError`.
+- **B — `apps/core/apps.py CoreConfig.name = "apps.core"`** — nie `"core"`. Spójność z M5/M6/M7 nested apps. Jeśli zostawisz `"core"`, Django startup crash z `LookupError: No installed app with label 'apps'`.
+- **C — `redis.Redis.from_url(settings.REDIS_URL, socket_timeout=2)`** — `socket_timeout` jest kluczowe. Bez niego, gdy Redis down + DNS resolves → `ping()` może wisieć 30s na default TCP timeout. Healthcheck musi return w < 5s (HEALTHCHECK `timeout=5s` w Dockerfile).
+- **D — `from django.db import OperationalError` w except** — NIE `psycopg.OperationalError`. Django ORM wraps DBAPI exceptions w własną hierarchie. `OperationalError` z `django.db` to canonical exception.
+- **E — `JsonResponse` body order** — Python dict order to insertion order (3.7+), więc `{"db": "ok", "redis": "ok"}` JSON renderuje keys w tej kolejności. Testy assertujące JSON shape powinny używać `json.loads()` + dict comparison, NIE string comparison (bo whitespace/key order może się różnić od assumed).
+- **F — `@require_GET` dekorator import** — `from django.views.decorators.http import require_GET`. Nie `require_http_methods(["GET"])` (works ale verbose). `require_GET` to canonical.
+- **G — mypy + `redis.Redis.from_url`** — redis-py 5.x ma własne stub'y (`from redis import Redis`). Jeśli pre-commit mypy zgłosi `Cannot find implementation`, najpierw `poetry run pre-commit clean` (M7 retro). Dopiero jeśli nadal red — dorzucić `types-redis (>=4.6.0,<5.0.0)` do `[tool.poetry.group.dev.dependencies]` w tym samym PR.
+- **H — `connection.cursor()` context manager** — `with connection.cursor() as cursor: cursor.execute("SELECT 1")`. Bez `with`, cursor pozostaje open → potential connection leak w test'ach (`pytest-django` reuse connection).
+- **I — Test mocking `connection.cursor` to mock context manager**, nie raw function. `mock.patch.object(connection, "cursor")` zwraca MagicMock; configure `mock_cursor.return_value.__enter__.return_value.execute.side_effect = OperationalError(...)` — ale prościej: `mock.patch("django.db.connection.cursor", side_effect=OperationalError(...))` — wtedy `connection.cursor()` calls side_effect → raises bezpośrednio (no context manager entry). Test obu wariantów.
+
+### 🧪 Testing plan
+
+```bash
+# Unit testy
+poetry run pytest apps/core/tests/test_health.py -v
+
+# Coverage
+poetry run pytest apps/core/tests/ --cov=apps.core.health --cov-report=term-missing
+
+# Smoke manual
+poetry run python manage.py runserver
+# w drugim terminalu:
+curl -i http://localhost:8000/health/
+# expected: HTTP/1.1 200 OK, Content-Type: application/json, body {"db": "ok", "redis": "ok"}
+
+# Failure mode smoke (zatrzymaj postgres)
+docker compose -f docker-compose.dev.yml stop postgres
+curl -i http://localhost:8000/health/
+# expected: HTTP/1.1 503, body {"db": "fail", "redis": "ok", "error": "..."}
+docker compose -f docker-compose.dev.yml start postgres
+```
+
+**Coverage cel:** `apps/core/health.py` ≥ 95%.
+
+### 📦 Definition of Done
+
+- [ ] AC spełnione (4 tests passing, manual smoke 200 + 503).
+- [ ] PR zmergowany squash (`feat(core): add /health/ endpoint with DB + Redis ping (M9-D41, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] `apps/core/health.py` coverage ≥ 95%.
+- [ ] Healthcheck endpoint testable z laptopu (manual smoke confirmed).
+
+---
+
+## Task #2 — [M9-D42] Multi-stage `Dockerfile` + `.dockerignore` + `gunicorn` dep + local container smoke
+
+### 🎯 Cel
+
+Dorzucić `gunicorn` jako prod dependency w osobnym `build(deps)` commit. Utworzyć `Dockerfile` multi-stage (builder + runtime) zgodny ze spec §3.1: builder stage instaluje poetry + poetry-plugin-export, exportuje `poetry.lock → requirements.txt`, `pip install --user`; runtime stage używa `python:3.13-slim-bookworm`, dorzuca curl dla HEALTHCHECK, tworzy non-root user `app` (UID 1000), COPY z builder, COPY app code, `EXPOSE 8000`, `HEALTHCHECK` curl `/health/`, `CMD gunicorn config.wsgi:application`. Plus `.dockerignore` excluding `.git`, `.venv`, `__pycache__`, `tests/`, `docs/`, `.env*`, scratch files. Po D42: `docker build -t tibiantis:dev .` exit 0, image size ~150-200MB, `docker run --rm tibiantis:dev python manage.py check` exit 0.
+
+### 🧠 Czego się nauczysz
+
+- **Multi-stage Dockerfile semantics** — `FROM X AS builder` + `FROM X AS runtime` + `COPY --from=builder` daje layered build, tylko `runtime` ląduje w final image. Builder layers (poetry, build deps) discarded → mniejszy final image. Standard pattern dla Python apps.
+- **`pip install --user` w builder + COPY `/root/.local`** — `--user` instaluje w `~/.local/`, łatwe do COPY do runtime userspace. Trade-off: ścieżki binary muszą być w `PATH` (`/home/app/.local/bin`). Plus dyrektywy `--chown=app:app` przy COPY zapewniają non-root ownership.
+- **`HEALTHCHECK` Dockerfile instruction** — Docker built-in (zob. `HEALTHCHECK --interval=15s --timeout=5s --start-period=60s --retries=3 CMD curl ...`). Container status `healthy` widoczny w `docker ps`. Healthcheck command exit code: 0=healthy, 1=unhealthy, 2=reserved.
+- **Non-root user pattern** — `RUN useradd --create-home --shell /bin/bash --uid 1000 app` + `USER app`. UID 1000 to typical Linux user (matches host user na większości distrosach), eliminuje host volume permission issues.
+- **`.dockerignore` semantyka** — analogiczne do `.gitignore`, ale dla `docker build` context. Excludes wykluczone z `COPY . /app` → mniejszy build context (faster transfer to daemon), brak secrets w image, brak `.git` (16MB+).
+- **Poetry 2.x export plugin** — w Poetry 1.x export był built-in. Poetry 2.0+ wymaga `poetry-plugin-export` jako separate install. Bez tego `poetry export` rzuca "command not found".
+- **Layer caching strategy** — `COPY pyproject.toml poetry.lock ./` PRZED `COPY . /app` w builder oznacza, że zmiana w kodzie nie unieważnia poetry install cache (deps install reuse'uje warstwy z poprzedniego buildu).
+
+### ✅ Acceptance criteria
+
+(Pełne AC w issue body — `.github/issue-bodies/m9-d42.md`.)
+
+**Kluczowe punkty:**
+
+- **Dependency commit (osobny):**
+  - `poetry add "gunicorn (>=23.0,<24.0)"` — dorzuca do `[project.dependencies]`.
+  - Sanity: `poetry show gunicorn` — verify version w zakresie + no transitive conflict z django/celery.
+  - Osobny commit `build(deps): add gunicorn for prod WSGI server (M9-D42, #<#>)`.
+
+- **`Dockerfile`** — pełna zawartość ze spec §3.1 (cytuj literally). Multi-stage builder + runtime, non-root user `app` UID 1000, HEALTHCHECK curl `/health/`, CMD gunicorn.
+- **`.dockerignore`** — excludes:
+  ```
+  .git
+  .gitignore
+  .venv
+  __pycache__
+  *.pyc
+  *.pyo
+  .pytest_cache
+  .mypy_cache
+  .ruff_cache
+  tests/
+  docs/
+  .env
+  .env.*
+  !.env.example
+  .idea/
+  .vscode/
+  .claude/
+  *.md
+  !README.md
+  *.log
+  ```
+- **Local smoke (w PR description):**
+  - `docker build -t tibiantis:dev .` → exit 0.
+  - `docker image ls tibiantis:dev` → image size raport. Target ~150-200MB. Jeśli > 300MB, audit warstw (potencjalnie `apt-get` `--no-install-recommends` missing, builder layers leak).
+  - `docker run --rm -e DJANGO_SECRET_KEY=test -e DATABASE_URL=sqlite:///:memory: tibiantis:dev python manage.py check` → exit 0 + "System check identified no issues".
+  - `docker inspect tibiantis:dev --format '{{.Config.User}}'` → `app` (non-root verified).
+
+### ⚠️ Pułapki do uwagi
+
+- **A — `poetry-plugin-export` MUSI być explicit installed** w builder stage. Poetry 2.x wyłączył `poetry export` jako built-in. Bez `pip install "poetry-plugin-export>=1.8"`, `poetry export` rzuca "command not found". Spec §3.1 ma to w Dockerfile.
+- **B — `requirements.txt` w builder jest TRANSIENT** — NIE commituj do repo. Jeśli przypadkowo commit'niesz, dorzuć do `.gitignore`. Trade-off: trzymamy go tylko w builder layer, runtime nie ma `requirements.txt`.
+- **C — `apt-get install curl` w runtime musi mieć `&& rm -rf /var/lib/apt/lists/*`** — cache APT zwiększa image o ~10MB. Standard cleanup w Docker recipes.
+- **D — `--no-install-recommends` flag w `apt-get`** — bez tego curl ciągnie recommended packages (~5-10MB transitive). Zawsze dorzucaj dla slim images.
+- **E — `COPY --chown=app:app . /app` to wolniejsze niż `COPY . /app && chown -R`** — kompromis: chown w trakcie COPY działa w jednym kroku (no separate RUN layer), `chown -R` to dodatkowy layer. Wybieramy `--chown=` (less layers = smaller image).
+- **F — `EXPOSE 8000` to dokumentacja, NIE actual port mapping** — to tylko hint dla `docker run -P`. Real port binding w compose `ports: ["8000:8000"]`. Bez EXPOSE wszystko działa, ale `docker inspect` nie pokaże intended port.
+- **G — `HEALTHCHECK --start-period=60s` musi pokrywać Django startup + DB connect** — gunicorn `--workers 2` startuje ~3-5s, ale pierwsze GET `/health/` ciągnie DB pool + Redis client init → +20-40s. 60s daje margines. Empiryczne tuning po D43 manual smoke.
+- **H — `CMD ["gunicorn", "config.wsgi:application", ...]` syntax — exec form (JSON array)**, nie shell form. Exec form NIE używa `sh -c ...` wrappera, więc PID 1 to gunicorn directly (signal handling: `SIGTERM` w `docker stop` → gunicorn graceful shutdown). Shell form (`CMD gunicorn ...`) wrap'uje w `sh`, PID 1 = sh, sygnały nie propagują.
+- **I — `pip install --user --no-cache-dir`** — `--no-cache-dir` ważne, bez tego pip trzyma ~30-50MB w `/root/.cache/pip`. Builder cache discardujemy, ale defensive.
+- **J — `.dockerignore` `.env*` z `!.env.example`** — wykluczamy real `.env` (secrets!), ale dorzucamy `.env.example` (template). Bez tego: albo `.env` w image (security disaster) albo brak `.env.example` w image (operator nie ma template'u).
+- **K — `python:3.13-slim-bookworm` NIE `python:3.13-slim`** — explicit Debian codename (`bookworm` = Debian 12). Bez codename Docker pull latest, ale gdy Debian 13 wyjdzie i tag aliased zmieni się — break. Pin codename = reproducible builds.
+
+### 🧪 Testing plan
+
+```bash
+# Build smoke
+docker build -t tibiantis:dev .
+docker image ls tibiantis:dev   # size sanity ~150-200MB
+
+# Layer audit (optional, gdy size > target)
+docker history tibiantis:dev --no-trunc
+
+# Run smoke (no DB needed dla `manage.py check`)
+docker run --rm -e DJANGO_SECRET_KEY=test -e DATABASE_URL=sqlite:///:memory: tibiantis:dev python manage.py check
+
+# Non-root user verify
+docker inspect tibiantis:dev --format '{{.Config.User}}'
+# expected: app
+
+# HEALTHCHECK config verify
+docker inspect tibiantis:dev --format '{{.Config.Healthcheck.Test}}'
+# expected: [CMD-SHELL curl -fsS http://localhost:8000/health/ || exit 1]
+```
+
+**Brak unit testów** (Dockerfile to infra, nie kod). Manual smoke w PR description.
+
+### 📦 Definition of Done
+
+- [ ] AC spełnione (Dockerfile builds, smoke passes, image size < 250MB target).
+- [ ] PR zmergowany squash (2 commity: `build(deps)` gunicorn + `feat(docker)` Dockerfile/.dockerignore).
+- [ ] CI lint + test zielone (test job NIE wymaga zmian — Dockerfile nie jest testowany w CI w D42, dopiero D44 wprowadzi docker.yml).
+- [ ] Image size report w PR body (`docker image ls tibiantis:dev`).
+- [ ] Non-root user confirmed (`docker inspect`).
+
+---
+
+## Task #3 — [M9-D43] Production `docker-compose.yml` + 7 services + migrate one-shot + healthchecki + `.env.example` Docker hostnames
+
+### 🎯 Cel
+
+Utworzyć `docker-compose.yml` (prod, **różny** od istniejącego `docker-compose.dev.yml`) z 7 application services + 1 one-shot `migrate` service. Hybrid `image: ghcr.io/...:master` + `build: .` dla D43 dev iteration (registry tag NIE istnieje przed D44 push). Healthchecki per service zgodnie ze spec §3.3. `depends_on` chain ze spec §3.4. Update `.env.example` na Docker DNS hostnames (`postgres`/`redis`/`mongo` zamiast `localhost`) + komentarze "Operator wypełnia" przy każdym sekrecie. Manual smoke "full stack up" w PR description (5 punktów ze spec §9, częściowy — punkt #5 ghcr.io push czeka na D44).
+
+### 🧠 Czego się nauczysz
+
+- **`docker-compose.yml` vs `docker-compose.dev.yml`** — różne pliki dla różnych workflowów. Operator wybiera `-f docker-compose.dev.yml` (DB only, app w `poetry run`) lub `-f docker-compose.yml` (full prod stack). Compose `-f` default to `docker-compose.yml`, więc prod jest default.
+- **Hybrid `image:` + `build:` pattern** — gdy `image:` nie istnieje lokalnie ani w registry, compose fallback'uje na `build:` (per Compose v2.20+ spec). Pozwala lokalnie iterować bez registry, prod tylko pull.
+- **`depends_on` z conditions** — `service_healthy` (czeka na healthcheck pass), `service_started` (czeka na container start, no healthcheck check), `service_completed_successfully` (czeka na one-shot service exit 0). Compose v2 syntax.
+- **One-shot service pattern** — `restart: "no"` + command runs once + exits. `migrate` ma `service_completed_successfully` jako gate dla `web`. Idempotentne (migrate no-op gdy migracje up-to-date).
+- **`celery_beat` PID file healthcheck** — Celery Beat tworzy pidfile (`--pidfile=/tmp/celerybeat.pid`), proces żyje. Healthcheck `test -f $PID && ps -p $(cat $PID)` verifies. Bez pidfile beat nie ma "isAlive" API.
+- **`celery -A config inspect ping`** — Celery worker built-in inspection. Wysyła ping message przez broker (Redis), oczekuje pong od named worker. Identyfikuje hung workerów (proces żyje, ale nie consume'uje queue).
+- **`env_file: .env` w compose** — Docker compose ładuje `.env` automatycznie + per-service `env_file:`. Single source of truth: `.env`.
+
+### ✅ Acceptance criteria
+
+(Pełne AC w issue body — `.github/issue-bodies/m9-d43.md`.)
+
+**Kluczowe punkty:**
+
+- **`docker-compose.yml`** (prod, w root repo) — 7 services + 1 `migrate`:
+  - `postgres` (image `postgres:16-alpine`, healthcheck pg_isready, volume `postgres_data`, env_file `.env`)
+  - `redis` (image `redis:7-alpine`, healthcheck redis-cli ping)
+  - `mongo` (image `mongo:7`, healthcheck mongosh ping, volume `mongo_data`)
+  - `migrate` (image `ghcr.io/bgozlinski/tibiantis-scraper:master` + `build: .`, command `python manage.py migrate --noinput`, depends_on postgres healthy, restart: "no")
+  - `web` (same image + build, command `gunicorn ... --bind 0.0.0.0:8000 ...`, ports `["8000:8000"]`, depends_on postgres+redis healthy + migrate completed, healthcheck `curl /health/`)
+  - `celery_worker` (same image + build, command `celery -A config worker -l info`, depends_on postgres+redis healthy, healthcheck `celery inspect ping`)
+  - `celery_beat` (same image + build, command `celery -A config beat ...`, depends_on postgres+redis healthy, healthcheck pidfile)
+  - `discord_bot` (same image + build, command `python manage.py run_discord_bot`, depends_on postgres+mongo healthy, brak healthcheck, `restart: unless-stopped`)
+  - Volumes: `postgres_data`, `mongo_data` (volume named, deklarowane na końcu pliku).
+- **`.env.example`** zaktualizowane:
+  - `DATABASE_URL=postgres://tibiantis:tibiantis@postgres:5432/tibiantis` (był `localhost:5435`)
+  - `REDIS_URL=redis://redis:6379/0` (był `redis://localhost:6379/0`)
+  - `CELERY_BROKER_URL=redis://redis:6379/1` (analog)
+  - `MONGO_URL=mongodb://mongo:27017` (był `localhost:27017`)
+  - Komentarz nad każdym secret'em `# Operator MUSI wypełnić — generowane lub z dashboardu`:
+    - `DJANGO_SECRET_KEY=` — przepis na generację w komentarzu (`python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"`)
+    - `DISCORD_BOT_TOKEN=` — link do Discord Developer Portal
+    - `POSTGRES_PASSWORD=` — generowane lokalnie
+- **Manual smoke w PR description** (punkty 1-4 ze spec §9; punkt #5 ghcr.io pull odroczony do D44):
+  - `cp .env.example .env` + fill in real values
+  - `docker compose -f docker-compose.yml up -d`
+  - `docker compose ps` → wszystkie 7 services `Up healthy` po ≤90s (oprócz `migrate` które exit 0 po ~5s)
+  - `docker compose logs migrate` → "Applying X..." lines, exit 0
+  - `docker compose exec web curl -fsS http://localhost:8000/health/` → 200 + JSON
+  - `docker compose exec web python manage.py showmigrations --plan | grep '\[ \]'` → empty (no pending)
+  - `docker compose down -v` cleanup
+
+### ⚠️ Pułapki do uwagi
+
+- **A — `docker compose -f docker-compose.yml`** vs **`docker-compose.dev.yml`** — dwa różne pliki, dwa workflowy. Operator MUSI wiedzieć który użyć. README/dev runbook ma to opisać (post-M9).
+- **B — `image: ghcr.io/.../master` + `build: .` hybrid** — przed D44 push do registry, `image:` tag nie istnieje. Compose najpierw spróbuje `docker pull` — fail (network/auth). Drugi fallback to `build:` z local Dockerfile. Sanity w D43: `docker compose -f docker-compose.yml build` (explicit build) PRZED `up -d`, żeby `up` od razu wziął cached image.
+- **C — `depends_on` chain musi mieć directed acyclic graph** — bez cykli. Sanity: `docker compose config --quiet` (walidacja YAML + chain). Cykl rzuca "circular dependency detected".
+- **D — `service_completed_successfully` wymaga Compose v2.20+** — verify lokalnie `docker compose version`. Docker Desktop 4.20+ ma to wbudowane.
+- **E — `celery_beat` `--pidfile=/tmp/celerybeat.pid`** musi być EXPLICITLY w command. Bez `--pidfile` Celery beat nie zapisuje pidfile → healthcheck fails. Plus `--schedule=/tmp/celerybeat-schedule` (db-scheduler nie używa file ale Beat domyślnie zapisuje crontab tracking — explicit ścieżka żeby tmp był writable dla user'a `app`).
+- **F — `celery_worker` healthcheck `celery -A config inspect ping`** wymaga `redis_url` accessible (broker). `depends_on redis: healthy` zapewnia. Healthcheck overhead ~3s per call — `interval: 30s` defensive (nie 10s).
+- **G — `discord_bot` brak healthcheck** świadomy — long-running gateway connection bez exposed port. `restart: unless-stopped` policy + py-cord internal heartbeat wystarczy. M-future: dorzucić Mongo heartbeat write + healthcheck script reading Mongo collection.
+- **H — `postgres` użytkownik i hasło w `.env`** — z M0 `POSTGRES_USER=tibiantis POSTGRES_PASSWORD=tibiantis`. Nadal tak (prod operator zmieni). M-future: rotation strategy.
+- **I — `volumes:` declared TWICE** — raz per-service (`volumes: [postgres_data:/var/lib/...]`), raz top-level (`volumes: postgres_data:`). Bez top-level declaration, Compose używa anonymous volume (re-creates per `docker compose down`). Top-level = named, persists.
+- **J — Compose default network** — Compose tworzy bridge network per project automatically. Wszystkie services mogą resolve'ować się po service name (`postgres`, `redis`, `mongo`). Bez explicit `networks:` declaration, default działa.
+- **K — `.env.example` `DATABASE_URL=postgres://tibiantis:tibiantis@postgres:5432/tibiantis`** — `postgres` to **service name w compose**, nie `localhost`. W dev compose port `:5435` (host port avoid conflict z lokalnym PG), w prod compose port wewnętrzny `:5432` (no host port mapping required). Update `.env.example` musi pokazać prod hostname; comment "for dev use port 5435 with localhost".
+
+### 🧪 Testing plan
+
+```bash
+# Validate YAML + chain
+docker compose -f docker-compose.yml config --quiet
+# expected: exit 0, no output (no errors)
+
+# Build all (forces D43 dev iteration, before D44 push)
+docker compose -f docker-compose.yml build
+
+# Full stack up (wymaga .env z real secrets)
+docker compose -f docker-compose.yml up -d
+
+# Sanity (≤90s)
+docker compose ps
+# expected:
+#   postgres    Up healthy
+#   redis       Up healthy
+#   mongo       Up healthy
+#   migrate     Exited (0)
+#   web         Up healthy
+#   celery_worker  Up healthy
+#   celery_beat    Up healthy
+#   discord_bot    Up (no healthcheck) — może być Restarting jeśli DISCORD_BOT_TOKEN niepoprawny
+
+# Migration verify
+docker compose logs migrate | tail -20
+docker compose exec web python manage.py showmigrations --plan | grep '\[ \]' || echo "All migrations applied"
+
+# Health endpoint
+docker compose exec web curl -fsS http://localhost:8000/health/
+
+# Cleanup
+docker compose -f docker-compose.yml down -v
+```
+
+**Brak unit testów** (compose to infra). Manual smoke w PR description.
+
+### 📦 Definition of Done
+
+- [ ] AC spełnione (compose validates, full stack up <= 90s, healthchecki green, /health/ 200).
+- [ ] PR zmergowany squash (`feat(docker): production compose with 7 services + migrate one-shot (M9-D43, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] Manual smoke 4 punkty (z 5 spec'owanych — punkt #5 odroczony do D44) w PR body.
+- [ ] `.env.example` Docker hostnames + "Operator wypełnia" komentarze.
+
+---
+
+## Task #4 — [M9-D44] `docker.yml` CI workflow (build + push ghcr.io) + M9 e2e (full stack smoke) + closure
+
+### 🎯 Cel
+
+Utworzyć `.github/workflows/docker.yml` ze spec §13.2 (CLAUDE.md verbatim — build na PR + push do `ghcr.io/bgozlinski/tibiantis-scraper:<tag>` na push do master + tag v*; `docker/metadata-action@v5` dla tags: branch, semver, sha-short). M9 e2e smoke (closure PR description): full stack via `docker compose pull && docker compose up -d` z pre-built image z registry — potwierdzenie end-to-end push → pull → run flow. Closure PR od fresh master (M5-D27 + M6-D30 + M7-D35 + M8-D40 pattern repeat) — PROGRESS.md sekcja M9 z retro per Issue + 5-punkt manual smoke + Tech debt M9 + milestone close via `gh api`.
+
+D44 ma **2 PR-y w 1 issue** (M5-D27 + M6-D30 + M7-D35 + M8-D40 pattern):
+
+1. **Feature PR** (`feat/<#>-docker-ci`) — `.github/workflows/docker.yml`.
+2. **Closure PR** (`docs/close-m9-dockerization` od **fresh master** po feature merge) — PROGRESS.md retro + manual smoke + milestone close.
+
+### 🧠 Czego się nauczysz
+
+- **`docker/metadata-action@v5`** — generuje image tags na podstawie GitHub event context. `type=ref,event=branch` → `:master` na push do master. `type=semver,pattern={{version}}` → `:1.2.3` tylko gdy git tag `v1.2.3`. `type=sha,prefix=sha-,format=short` → `:sha-acaa3c9` zawsze (audit trail).
+- **`docker/build-push-action@v6`** — buildx-based build z support na multi-platform, layer cache, registry push. M9 używa `cache-from: type=gha + cache-to: type=gha,mode=max` (GitHub Actions native cache, zamiast registry cache).
+- **`packages: write` permission** — workflow potrzebuje permission do publikowania do `ghcr.io`. `permissions: { contents: read, packages: write }` w job-level. `GITHUB_TOKEN` auto-generated ma scope, bez custom PAT.
+- **`gh api -X PATCH .../milestones/9 -f state=closed`** — M5-D27 + M6-D30 + M7-D35 + M8-D40 precedens (5. raz). Wymaga `repo` scope w `gh auth`.
+- **`gh api -X PATCH milestones`** vs **`gh api -X DELETE`** — PATCH zmienia state (closed/open), DELETE usuwa kompletnie. M9 close (nie delete) — `state=closed` zachowuje historię + audit.
+
+### ✅ Acceptance criteria
+
+(Pełne AC w issue body — `.github/issue-bodies/m9-d44.md`.)
+
+**Feature PR kluczowe punkty:**
+
+- `.github/workflows/docker.yml`:
+  ```yaml
+  name: Docker build
+
+  on:
+    pull_request:
+      paths:
+        - "Dockerfile"
+        - ".dockerignore"
+        - "docker-compose.yml"
+        - "pyproject.toml"
+        - "poetry.lock"
+        - ".github/workflows/docker.yml"
+    push:
+      branches: [master]
+      tags: ["v*"]
+
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        packages: write
+      steps:
+        - uses: actions/checkout@v4
+        - uses: docker/setup-buildx-action@v3
+        - uses: docker/login-action@v3
+          if: github.event_name != 'pull_request'
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+        - uses: docker/metadata-action@v5
+          id: meta
+          with:
+            images: ghcr.io/${{ github.repository }}
+            tags: |
+              type=ref,event=branch
+              type=semver,pattern={{version}}
+              type=sha,prefix=sha-,format=short
+        - uses: docker/build-push-action@v6
+          with:
+            context: .
+            push: ${{ github.event_name != 'pull_request' }}
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+  ```
+- PR build (PR-only event): `push: false`, image build sanity ale NIE push do registry.
+- Master push event: `push: true`, image leci do `ghcr.io/bgozlinski/tibiantis-scraper:master` + `:sha-<commit>`.
+- Tag push event (`v1.0.0`): image leci jako `:1.0.0` + `:sha-<commit>` + `:master` (master branch).
+
+**Closure PR kluczowe punkty:**
+
+- `PROGRESS.md` rozszerzone o:
+  - `## 🎉 Milestone M9 — Dockeryzacja + prod-ready COMPLETED (2026-MM-DD)` header.
+  - `### Ukończone (M9)` — lista 4 issues + PR linki + squash hashes.
+  - `### Notatki z retro M9 (dopisywane progresywnie)` — per Issue D41-D44.
+  - `### Definition of Done M9` (ze spec'a §8) — wszystkie [x] poza ostatnim ("milestone closed" — TODO post-merge).
+  - `### Podsumowanie M9` (data range, dni vs budżet, najwartościowsze lekcje).
+  - `### Tech debt z M9` (carry-over do M10+).
+- **Manual smoke** udokumentowany w closure PR description (5 punktów z spec §9):
+  1. Local `docker build .` → exit 0, image size ~150-200MB
+  2. Local `docker compose -f docker-compose.yml up -d` → wszystkie 7 services healthy w ≤90s
+  3. `docker compose logs migrate` → exit 0, migrations applied
+  4. `curl /health/` z hosta przez exposed `web:8000` → 200 + JSON
+  5. Post-master-merge: `docker pull ghcr.io/bgozlinski/tibiantis-scraper:master` z lokalu → success (end-to-end CI push → local pull confirmed)
+- **Po merge closure PR'a:** `gh api -X PATCH repos/bgozlinski/tibiantis-scraper/milestones/9 -f state=closed`.
+- **Sanity:** `gh issue list --milestone "M9 — Dockeryzacja + prod-ready" --state open` → empty.
+
+### ⚠️ Pułapki do uwagi
+
+- **A — `paths:` filter w `pull_request` trigger** — workflow odpala TYLKO gdy PR dotyka wymienionych ścieżek. Bez tego każdy PR (np. docs-only) triggeruje docker build → marnotrawstwo CI minutes. Spec lista: `Dockerfile`, `.dockerignore`, `docker-compose.yml`, `pyproject.toml`, `poetry.lock`, `.github/workflows/docker.yml`.
+- **B — `if: github.event_name != 'pull_request'` na login-action** — login do ghcr.io NIE na PR build (wystarczy build sanity, no push). Bez tego forki PR mogłyby próbować login z forked workflow → security issue.
+- **C — `push: ${{ github.event_name != 'pull_request' }}` na build-push-action** — push TYLKO na master/tag, NIE na PR. Spec pattern z CLAUDE.md §13.2.
+- **D — `concurrency: cancel-in-progress: true`** — drugi push na ten sam ref zabija pierwszy run. Oszczędność CI minutes przy szybkich consecutive merges.
+- **E — `cache-from: type=gha + cache-to: type=gha,mode=max`** — GitHub Actions native cache (no registry cache push). `mode=max` cache'uje wszystkie warstwy (default `mode=min` tylko final layers).
+- **F — `docker/metadata-action@v5` `images:` lower-case** — `ghcr.io/${{ github.repository }}` resolves do `ghcr.io/bgozlinski/tibiantis-scraper`. GitHub username case-sensitive ale ghcr lower-cases. Sanity: `docker pull ghcr.io/bgozlinski/tibiantis-scraper:master` (lowercase).
+- **G — First push po merge może fail jeśli `packages: write` scope nie auto-aktywuje** — workflow-level permissions wymaga **branch protection rule** lub manual repo settings: Settings → Actions → General → Workflow permissions → "Read and write permissions". Sanity po pierwszym merge: workflow run logs pokazują "Login Succeeded" przed push. Jeśli "Permission denied" — fix repo settings.
+- **H — Closure branch od fresh master** (Pułapka C, M1-D8 + M5-D27 + M6-D30 + M7-D35 + M8-D40 lekcja repeat 6. raz) — `git checkout master && git pull && git checkout -b docs/close-m9-dockerization` PRZED edycją PROGRESS.md. Wzorzec utrwala się.
+- **I — `gh api -X PATCH milestones/9`** — `9` to **number** milestone'a, nie title. Verify: `gh api repos/bgozlinski/tibiantis-scraper/milestones --jq '.[] | select(.title|startswith("M9")) | .number'` → `9`.
+- **J — Milestone exact title match** — `gh issue list --milestone "M9 — Dockeryzacja + prod-ready"` wymaga dokładnego tytułu (z em-dashem `—`, NIE myślnikiem `-`). Title z `gh api repos/.../milestones --jq '.[] | .title'`.
+
+### 🧪 Testing plan
+
+**Feature PR:**
+
+```bash
+# Local sanity (po PR push do ghcr.io)
+# Workflow runs auto na PR
+gh pr checks <PR-#>
+# expected: "Docker build" job → pass (build only, no push)
+
+# Post-merge sanity (master push)
+gh run list --workflow=docker.yml --limit 1
+# expected: status: completed, conclusion: success
+
+# Verify image w registry
+docker pull ghcr.io/bgozlinski/tibiantis-scraper:master
+docker image inspect ghcr.io/bgozlinski/tibiantis-scraper:master --format '{{.Created}}'
+```
+
+**Closure PR — Manual smoke (operator's laptop):**
+
+W closure PR body zacytuj wyniki (zrzut ekranu lub verbatim transcript):
+
+1. **Local build:**
+   ```bash
+   docker build -t tibiantis:dev .
+   docker image ls tibiantis:dev
+   ```
+   → exit 0, image ~150-200MB.
+
+2. **Full stack up:**
+   ```bash
+   cp .env.example .env
+   # fill DJANGO_SECRET_KEY, DISCORD_BOT_TOKEN, POSTGRES_PASSWORD
+   docker compose -f docker-compose.yml up -d
+   sleep 90
+   docker compose ps
+   ```
+   → wszystkie 7 services `Up healthy` (oprócz `migrate` `Exited (0)`).
+
+3. **Migration:**
+   ```bash
+   docker compose logs migrate
+   docker compose exec web python manage.py showmigrations --plan | grep '\[ \]' || echo "All applied"
+   ```
+   → exit 0 in logs, "All applied" w stdout.
+
+4. **Health endpoint:**
+   ```bash
+   curl -fsS http://localhost:8000/health/
+   ```
+   → `{"db": "ok", "redis": "ok"}` + HTTP 200.
+
+5. **Post-master-merge registry pull:**
+   ```bash
+   docker login ghcr.io -u bgozlinski   # z PAT z read:packages scope
+   docker pull ghcr.io/bgozlinski/tibiantis-scraper:master
+   docker image inspect ghcr.io/bgozlinski/tibiantis-scraper:master
+   ```
+   → success.
+
+### 📦 Definition of Done
+
+**Feature PR:**
+- [ ] AC spełnione (`docker.yml` workflow exists, PR build sanity, master push triggers ghcr.io push).
+- [ ] Feature PR zmergowany squash (`feat(ci): docker.yml workflow with ghcr.io build + push (M9-D44, #<#>)`).
+- [ ] CI lint + test zielone.
+- [ ] Image visible at `https://github.com/bgozlinski/tibiantis-scraper/pkgs/container/tibiantis-scraper`.
+
+**Closure PR:**
+- [ ] Closure PR zmergowany squash (`docs(progress): close M9 — Dockeryzacja + prod-ready COMPLETED + retro D41-D44`).
+- [ ] CI lint zielony.
+- [ ] PROGRESS.md sekcja M9 dorzucona.
+- [ ] Manual smoke description w closure PR body (5 punktów z testing plan).
+- [ ] Milestone M9 zamknięty na GitHub via `gh api -X PATCH .../milestones/9 -f state=closed`.
+- [ ] Wszystkie M9 issues CLOSED (`gh issue list --milestone "M9 — Dockeryzacja + prod-ready" --state open` → empty).
+
+---
+
+## Tech debt do flag'owania w M9 retro
+
+Te kandydaci mogą surface'ować podczas M9 implementacji (zaznacz w PROGRESS.md "Tech debt z M9"):
+
+- **Image size > 200MB** — jeśli D42 manual smoke pokaże > 200MB, audit warstw. Potencjalne wins: usuń curl (użyj Python httpx w HEALTHCHECK), explicit `apt-get clean`, multi-arch build slim.
+- **`celery_beat` pidfile race** — gdy beat restart'uje, pidfile może być stale. M-future: dorzucić `healthcheck` z `celery -A config status` (per-worker ping) zamiast pidfile check.
+- **`discord_bot` brak healthcheck** — `restart: unless-stopped` to band-aid. M-future: bot zapisuje heartbeat do Mongo co 60s, healthcheck script odczytuje recent timestamp.
+- **`.env` w prod jako single source of truth** — M-future: Docker secrets / Vault / SOPS gdy multi-host deploy.
+- **Static files broken w prod** — admin CSS/JS nie działa bez WhiteNoise / nginx. M10 kandydat.
+- **Image scanning** — Trivy w docker.yml workflow. M10 Hardening kandydat.
+- **Multi-arch builds** — `linux/amd64,linux/arm64` w `docker/build-push-action@v6 platforms:`. M-future jeśli deploy target ARM (Raspberry Pi, M-class Macs).
+- **`docker compose pull` strategy w prod runbook** — M-future docs/dev-runbook.md fragment "jak deploy update'u na VPS".
+- **`gunicorn --access-logfile - --error-logfile -`** — domyślnie gunicorn loguje do plików. W container chcemy stdout (Docker logs). Sanity post-D42: czy gunicorn writes do stdout out-of-the-box? Jeśli nie — explicit flags w CMD.
+
+---
+
+## Skill usage map
+
+| D | Skills wymagane | Skills opcjonalne |
+|---|---|---|
+| D41 | `test-driven-development` (TDD przy 4 testach health endpoint) | `using-git-worktrees` (jeśli paralelne taski) |
+| D42 | `verification-before-completion` (manual smoke przed PR ready) | — |
+| D43 | `verification-before-completion` (full stack smoke przed PR ready) | `systematic-debugging` (jeśli healthcheck flapuje) |
+| D44 | `verification-before-completion` (workflow run + registry pull verify) | `requesting-code-review` (multi-stage Dockerfile review) |
+
+---
+
+## Closing notes
+
+- **Strict chain:** D41 → D42 → D43 → D44 (każdy wymaga merge poprzedniego). Brak parallelism (Dockerfile zależy od healthcheck endpoint, compose zależy od Dockerfile, CI zależy od compose).
+- **4 PR-y feature + 1 PR closure** = 5 PRs total. Plus ewentualne hotfixy (M7/M8 wzorzec — 1-2 hotfixy per milestone).
+- **Manual smoke jest jedyną siecią dla full Docker stack** (M7 retro lekcja replicated). Nie testujemy real VPS deploy.
+- **Closure PR pattern od fresh master** to **6. raz pod rząd** (M1-D8 → M5-D27 → M6-D30 → M7-D35 → M8-D40 → M9-D44). Wzorzec utrwalony.

--- a/docs/superpowers/specs/2026-05-15-m9-dockerization-design.md
+++ b/docs/superpowers/specs/2026-05-15-m9-dockerization-design.md
@@ -1,0 +1,493 @@
+# M9 — Dockeryzacja + prod-ready — Design spec
+
+**Data:** 2026-05-15
+**Status:** ACCEPTED (decyzje §3.1-3.7 zaakceptowane przez developera 2026-05-15 w sesji M9 brainstorm)
+**Plan:** [`docs/superpowers/plans/2026-05-15-m9-implementation-plan.md`](../plans/2026-05-15-m9-implementation-plan.md) (next step po tym spec'u)
+**Milestone:** M9 — Dockeryzacja + prod-ready
+
+---
+
+## §1 Cel + scope
+
+Po M0-M8 mamy pełen backend (Django + Celery + Scrapy + py-cord) + Discord outbound + Mongo logging. Wszystko uruchamiane **lokalnie**: `poetry run python manage.py runserver`, `poetry run celery -A config worker`, `poetry run python manage.py run_discord_bot`, plus `docker-compose.dev.yml` z postgres/redis/mongo. **Brak deployable artefaktu** — nikt poza developerem nie umie tego uruchomić bez 30-min onboardingu.
+
+M9 zamyka pętlę "deployable artifact": każdy serwis backendowy (web/celery_worker/celery_beat/discord_bot + dependencies postgres/mongo/redis) startuje przez `docker compose up` z pre-built image; ten sam image jest publikowany do `ghcr.io/bgozlinski/tibiantis-scraper` po merge na master. Po M9 mamy gotowy `docker compose pull && docker compose up -d` flow dla VPS-a — wystarczy operator z dostępem do `.env` i jeden tag image'a.
+
+### W zakresie M9:
+- `apps/core/health/` — nowy Django app z `/health/` view (DB + Redis ping, 200 OK / 503 fail) i 4 unit tests.
+- `Dockerfile` multi-stage (builder + runtime), jeden image dla web/celery_worker/celery_beat/discord_bot — różnią się tylko `command`.
+- `.dockerignore` excluding `.git`, `.venv`, `__pycache__`, `tests/`, `docs/`, `.env*`, scratch files.
+- Production `docker-compose.yml` z 7 application services + 1 one-shot migrate service.
+- Healthchecki per service (zob. §3.3).
+- `.env.example` aktualizacja: Docker DNS hostnames (`postgres`/`redis`/`mongo`) zamiast `localhost`.
+- `.github/workflows/docker.yml` — build na PR + push do `ghcr.io/bgozlinski/tibiantis-scraper:<tag>` na push do `master` + tag `v*`.
+- PROGRESS.md retro M9 + manual smoke (5 punktów z §9) + milestone close.
+
+### Poza zakresem M9 (do M10 lub M-future):
+- **nginx + TLS** — YAGNI per execution plan §6.2. Dopiero przy real VPS deploy (M-future po wynajęciu hosta).
+- **Image security scanning** (Trivy/Snyk/Docker Scout) — kandydat na M10 Hardening.
+- **Static files w prod** (`collectstatic` + WhiteNoise) — admin może być za SSH tunelem; pełna obsługa w M10 (lub M-future jeśli admin nie potrzebny w prod).
+- **Multi-arch builds** (`linux/amd64,linux/arm64`) — YAGNI dopóki single deploy target (`amd64`).
+- **Docker secrets / Vault / SOPS** — env strategy zostaje `env_file: .env` (single-host prod, M-future jeśli multi-node).
+- **Auto-scaling, replicas, swarm/k8s** — out of scope, M-future jeśli będzie potrzeba.
+- **Semantic version tagging** (`v1.2.3`) w docker.yml — start z `:master` rolling tag, semver dorzucimy gdy będzie pierwsze realne deploy + release flow.
+- **Real production deploy** — out of scope, M-future po wynajęciu VPS-a.
+
+---
+
+## §2 Architektura
+
+### High-level diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                          Operator host                          │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │            docker compose stack (7 services + 1 OS)       │  │
+│  │                                                           │  │
+│  │   ┌───────────┐   ┌─────────┐   ┌─────────┐   ┌────────┐  │  │
+│  │   │ postgres  │   │  redis  │   │  mongo  │   │migrate │  │  │
+│  │   │  :5432    │   │  :6379  │   │ :27017  │   │one-shot│  │  │
+│  │   └─────┬─────┘   └────┬────┘   └────┬────┘   └────┬───┘  │  │
+│  │         │              │             │             │      │  │
+│  │         └──────────────┼─────────────┼─────────────┘      │  │
+│  │                        │             │                    │  │
+│  │   ┌────────────────────▼─────────────▼─────────────────┐  │  │
+│  │   │      Application services (shared image)           │  │  │
+│  │   │  ┌──────┐  ┌──────────────┐  ┌────────┐  ┌──────┐  │  │  │
+│  │   │  │ web  │  │celery_worker │  │ beat   │  │ bot  │  │  │  │
+│  │   │  │:8000 │  │   (worker)   │  │ (Beat) │  │      │  │  │  │
+│  │   │  └──────┘  └──────────────┘  └────────┘  └──────┘  │  │  │
+│  │   │  CMD: gunicorn  CMD: celery worker  CMD: beat      │  │  │
+│  │   │       CMD: run_discord_bot                         │  │  │
+│  │   └────────────────────────────────────────────────────┘  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  .env (DJANGO_SECRET_KEY, DISCORD_BOT_TOKEN, POSTGRES_PASSWORD) │
+└─────────────────────────────────────────────────────────────────┘
+
+                    ▲
+                    │ docker pull
+                    │
+        ┌───────────┴────────────┐
+        │  ghcr.io/bgozlinski/   │
+        │    tibiantis-scraper   │
+        │  :master :sha-acaa3c9  │
+        └───────────┬────────────┘
+                    │ docker push (GHA on master)
+                    │
+        ┌───────────┴────────────┐
+        │   GitHub Actions       │
+        │   docker.yml workflow  │
+        │   (build + push)       │
+        └────────────────────────┘
+```
+
+### Struktura plików (3 NEW Django + 4 NEW infra)
+
+**Nowe pliki (Django):**
+- `apps/core/__init__.py`
+- `apps/core/apps.py` (`CoreConfig`)
+- `apps/core/health.py` (view: `health_check(request) -> JsonResponse`)
+- `apps/core/urls.py` (path `/health/`)
+- `apps/core/tests/__init__.py`
+- `apps/core/tests/test_health.py` (4 tests)
+
+**Nowe pliki (infra):**
+- `Dockerfile`
+- `.dockerignore`
+- `docker-compose.yml` (prod)
+- `.github/workflows/docker.yml`
+
+**Modyfikowane pliki:**
+- `config/urls.py` — dorzucenie `path("health/", include("apps.core.urls"))`
+- `config/settings/base.py` — dorzucenie `"apps.core"` do `LOCAL_APPS`
+- `.env.example` — Docker hostnames (`postgres`/`redis`/`mongo`) + komentarze które wartości operator musi wypełnić
+- `pyproject.toml` — dorzucenie `gunicorn (>=23.0,<24.0)` jako prod dependency (aktualnie brak — `web` w Dockerfile używa). Plus opcjonalnie `types-redis` w dev deps gdy mypy zgłosi missing stubs dla `redis.Redis` w `health.py` (`redis` już jest direct dep z M5 → `redis (>=7.4.0,<8.0.0)`, nie trzeba dorzucać).
+
+---
+
+## §3 Decyzje designowe (zaakceptowane 2026-05-15)
+
+### §3.1 Dockerfile multi-stage (builder + runtime) z requirements.txt export
+
+```dockerfile
+FROM python:3.13-slim-bookworm AS builder
+ENV PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1 POETRY_VERSION=2.0.1
+RUN pip install --no-cache-dir "poetry==${POETRY_VERSION}" "poetry-plugin-export>=1.8"
+WORKDIR /build
+COPY pyproject.toml poetry.lock ./
+RUN poetry export --without-hashes --only=main -o requirements.txt
+RUN pip install --user --no-cache-dir -r requirements.txt
+
+FROM python:3.13-slim-bookworm AS runtime
+ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1 \
+    PATH="/home/app/.local/bin:$PATH" \
+    DJANGO_SETTINGS_MODULE=config.settings.prod
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+RUN useradd --create-home --shell /bin/bash --uid 1000 app
+USER app
+WORKDIR /app
+COPY --from=builder --chown=app:app /root/.local /home/app/.local
+COPY --chown=app:app . /app
+EXPOSE 8000
+HEALTHCHECK --interval=15s --timeout=5s --start-period=60s --retries=3 \
+  CMD curl -fsS http://localhost:8000/health/ || exit 1
+CMD ["gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "2", "--threads", "2", "--timeout", "60"]
+```
+
+**Dlaczego `poetry export → requirements.txt` w builder zamiast `poetry install` w runtime:**
+- Builder ma `poetry` (~60MB install). Runtime go nie potrzebuje — tylko `pip install -r requirements.txt`.
+- Mniejszy runtime image (~150-200MB vs ~350MB z poetry-in-runtime).
+- Lock file pozostaje source of truth (export wynik deterministyczny z lock'a).
+
+**Odstąpienie od CLAUDE.md §10** ("Nie eksportuj do `requirements.txt`"): kontekst tego zakazu to DEV workflow (developer nie powinien używać `requirements.txt` zamiast `poetry install`). W BUILD stage exportujemy wyłącznie jako transient hand-off do `pip` w runtime stage — lock file zostaje canonical. **Spec aktualizacja CLAUDE.md §10** (osobny PR w M9 lub follow-up): notka "no requirements.txt" dotyczy dev workflow; multi-stage Docker build może exportować dla image slimming.
+
+**Non-root user `app` (UID 1000)** — defense-in-depth. `chown -R app:app` w COPY → +50MB layer transient, akceptowalny trade-off.
+
+**Single image dla 4 application services:** `web`/`celery_worker`/`celery_beat`/`discord_bot` używają **tego samego obrazu**, różnią się tylko `command:` w docker-compose. Jeden Dockerfile, jeden build, jeden push do registry — zgodne z CLAUDE.md §10.
+
+### §3.2 `web` — gunicorn (WSGI), nie uvicorn (ASGI)
+
+Aktualnie 0 async views, 0 async resolvers. Gunicorn `--workers 2 --threads 2 --timeout 60` wystarcza dla single-host workload. Jeśli kiedyś dorzucimy async Strawberry resolvers — switch na `gunicorn -k uvicorn.workers.UvicornWorker` to 1-line zmiana w `CMD`. Per CLAUDE.md §2 "ASGI: uvicorn jeśli potrzebujemy async" — nie potrzebujemy teraz, więc YAGNI.
+
+### §3.3 Healthchecki per service
+
+| Service | Test | Interval | Timeout | Retries | Start period | Notes |
+|---|---|---|---|---|---|---|
+| `postgres` | `pg_isready -U $POSTGRES_USER -d $POSTGRES_DB` | 10s | 5s | 5 | 30s | (kontynuacja z dev compose) |
+| `redis` | `redis-cli ping` | 10s | 5s | 5 | - | (kontynuacja z dev compose) |
+| `mongo` | `mongosh --quiet --eval 'db.adminCommand("ping").ok'` | 10s | 5s | 5 | 30s | (kontynuacja z dev compose) |
+| `migrate` | **brak** — one-shot, `restart: 'no'` | - | - | - | - | Exit 0 sygnalizuje `service_completed_successfully` dla `web` |
+| `web` | `curl -fsS http://localhost:8000/health/` | 15s | 5s | 3 | 60s | Django + DB + Redis startup ≈ 30-45s, 60s start period dla bezpieczeństwa |
+| `celery_worker` | `celery -A config inspect ping -d celery@$HOSTNAME` | 30s | 10s | 3 | 60s | High overhead (~3s per call) → 30s interval |
+| `celery_beat` | `test -f /tmp/celerybeat.pid && ps -p $(cat /tmp/celerybeat.pid) > /dev/null` | 30s | 5s | 3 | 60s | Beat ma `--pidfile=/tmp/celerybeat.pid` w command |
+| `discord_bot` | **brak** | - | - | - | - | Long-running gateway connection bez exposed port. py-cord obsługuje heartbeat sam. `restart: unless-stopped` reboot przy crashu. M-future: dorzucić Mongo heartbeat write + custom healthcheck script. |
+
+### §3.4 Migration jako one-shot service z `service_completed_successfully` dependency
+
+```yaml
+services:
+  migrate:
+    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    command: python manage.py migrate --noinput
+    env_file: .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  web:
+    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    command: gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 2 --threads 2
+    env_file: .env
+    ports: ["8000:8000"]
+    depends_on:
+      postgres: { condition: service_healthy }
+      redis: { condition: service_healthy }
+      migrate: { condition: service_completed_successfully }
+```
+
+**Dlaczego separate service, nie inline `bash -c "migrate && gunicorn"`:**
+- **Idempotent** — `migrate` exit 0 czy migracja była no-op, czy applied. Recompose `docker compose up -d` po update'cie image'a → tylko `migrate` runs (`migrate` ma nową image SHA), reszta unchanged.
+- **No race condition** — jak `web` jest scaled na N replicas (M-future), wszystkie depends_on tego samego `migrate` exit code. Bez race na `migrate.lock` w PG.
+- **Czytelny `docker compose logs migrate`** — explicit migration log, nie zmieszany z gunicorn output.
+- **Trade-off:** dorzucamy 1 service do compose. Akceptowalny — czystszy lifecycle management.
+
+### §3.5 Image tagging strategy
+
+CLAUDE.md §13.2 spec'uje `docker/metadata-action@v5`:
+```yaml
+tags: |
+  type=ref,event=branch          # ghcr.io/.../tibiantis-scraper:master
+  type=semver,pattern={{version}}  # ghcr.io/.../tibiantis-scraper:1.2.3 (tylko gdy git tag v1.2.3)
+  type=sha,prefix=sha-,format=short  # ghcr.io/.../tibiantis-scraper:sha-acaa3c9
+```
+
+**Pull strategy w prod (compose) — hybrid `image:` + `build:` dla D43 dev iteration:**
+```yaml
+services:
+  web:
+    image: ghcr.io/bgozlinski/tibiantis-scraper:master   # rolling tag (pull w prod)
+    build: .                                              # fallback build z lokalnego Dockerfile
+```
+
+Docker Compose semantyka: gdy `image:` nie istnieje lokalnie ani w registry, użyje `build:` jako fallback. W D43 (przed D44 push):
+- `docker compose build` → buduje z lokalnego `Dockerfile`, taguje jako `ghcr.io/bgozlinski/tibiantis-scraper:master` lokalnie
+- `docker compose up -d` → używa lokalnie tagged image (registry NIE pull, bo lokal istnieje)
+
+W prod (po D44 merge):
+- `docker compose pull` → ściąga `:master` z registry (overrides lokalną wersję jeśli starsza)
+- `docker compose up -d` → uruchamia świeży pull
+
+Hybrid pattern działa dla obu workflow bez zmian w compose. M-future jeśli chcemy lock'ować prod na registry-only (no local build), usuwamy `build:` z compose.
+
+**Trade-off rolling vs explicit:**
+- `:master` rolling = każdy merge → `docker compose pull && docker compose up -d` daje fresh image. Niska ceremonia, zero release flow. **Decyzja M9.**
+- `:v1.2.3` explicit = wymaga `git tag v1.2.3 && git push --tags` flow + ręczna edycja compose. M-future gdy będzie pierwsze realne deploy + chcemy rollback flow.
+
+`:sha-<commit>` zostaje jako audit trail (gdy chce się sprawdzić "co obecnie chodzi w prod" przez `docker inspect`).
+
+### §3.6 `.env` strategy — `env_file`, nie Docker secrets
+
+Compose używa `env_file: .env` (jak w dev compose). Operator deploy'u przygotowuje `.env` ręcznie z secretami:
+- `DJANGO_SECRET_KEY` (generate'em z `get_random_secret_key()`)
+- `DISCORD_BOT_TOKEN` (Discord Developer Portal)
+- `POSTGRES_PASSWORD` (operator-generated)
+- `DJANGO_ALLOWED_HOSTS` (prod domain)
+
+`.env.example` aktualizowane:
+- Docker DNS hostnames: `DATABASE_URL=postgres://tibiantis:tibiantis@postgres:5432/tibiantis` (był `localhost:5435` dla dev)
+- `REDIS_URL=redis://redis:6379/0` (był `redis://localhost:6379/0`)
+- `MONGO_URL=mongodb://mongo:27017` (był `mongodb://localhost:27017`)
+- Komentarz nad każdą sekcją "Operator wypełnia: …" z listą wymaganych env varsach
+
+**Nie dorzucamy Docker secrets / Vault / SOPS** — YAGNI dla single-host prod. M-future jeśli multi-node deploy. **Bezpieczeństwo:** `.env` w `.gitignore` od M0, gitleaks w pre-commit blokuje accidental commit.
+
+### §3.7 Non-root user `app` (UID 1000) w runtime
+
+Runtime stage:
+```
+RUN useradd --create-home --shell /bin/bash --uid 1000 app
+USER app
+COPY --chown=app:app . /app
+```
+
+**Powód:** defense-in-depth — gdy ktoś przejmie container (np. RCE w Django view), nie ma root. Plus host-volume permissions cleaner (host user 1000 = container user 1000 → no `chown` dance po `docker run`).
+
+**Trade-off:** `chown -R app:app /app` w COPY → +~50MB transient layer (skopiowane pliki dostają attribute change). Akceptowalny.
+
+**Nie dorzucamy** dedykowanego non-root distroless image — `python:3.13-slim-bookworm` + custom user wystarcza. Distroless to `python:3.13-distroless`-style images, M-future jeśli chcemy minimal attack surface.
+
+---
+
+## §4 Healthcheck endpoint — sygnatura
+
+### §4.1 `apps/core/health.py`
+
+```python
+from __future__ import annotations
+import logging
+import redis
+from django.conf import settings
+from django.db import connection, OperationalError
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET
+
+logger = logging.getLogger(__name__)
+
+
+@require_GET
+def health_check(request) -> JsonResponse:
+    """Liveness + readiness check dla Docker HEALTHCHECK i load balancer'a.
+
+    Sprawdza:
+    - DB connectivity (cursor.execute("SELECT 1"))
+    - Redis connectivity (redis.Redis(...).ping())
+
+    Returns: 200 + {"db": "ok", "redis": "ok"} gdy oba OK.
+             503 + {"db": "fail|ok", "redis": "fail|ok", "error": "..."} gdy któryś fail.
+
+    Out of scope (M-future): Mongo check (nie blokuje krytycznego flow — logging
+    może gracefully degradować). Celery worker ping (osobny healthcheck per service).
+    """
+    status = {"db": "ok", "redis": "ok"}
+    status_code = 200
+
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+    except OperationalError as exc:
+        logger.exception("Health check: DB query failed")
+        status["db"] = "fail"
+        status["error"] = str(exc)
+        status_code = 503
+
+    try:
+        r = redis.Redis.from_url(settings.REDIS_URL, socket_timeout=2)
+        r.ping()
+    except (redis.ConnectionError, redis.TimeoutError) as exc:
+        logger.exception("Health check: Redis ping failed")
+        status["redis"] = "fail"
+        status["error"] = str(exc)
+        status_code = 503
+
+    return JsonResponse(status, status=status_code)
+```
+
+### §4.2 `apps/core/urls.py`
+
+```python
+from django.urls import path
+from apps.core.health import health_check
+
+urlpatterns = [
+    path("", health_check, name="health-check"),
+]
+```
+
+### §4.3 `config/urls.py` (modify)
+
+Dorzuca `path("health/", include("apps.core.urls"))` — pełny URL `/health/`.
+
+### §4.4 `redis-py` już jest direct dependency
+
+`redis (>=7.4.0,<8.0.0)` był dorzucony jako direct dependency w M5/M6 (Celery broker + Mongo logging — `apps/notifications/...` używa pośrednio przez `redis.Redis.from_url(REDIS_URL).ping()` można reuse). Sprawdzony `pyproject.toml:22`. **Nie trzeba dorzucać.**
+
+`types-redis` może być potrzebny w `[tool.poetry.group.dev.dependencies]` jeśli mypy zgłosi `Cannot find implementation or library stub for module redis.Redis`. Decyzja — dorzucamy reaktywnie w D41 jeśli `pre-commit run mypy --files apps/core/health.py` zgłosi.
+
+---
+
+## §5 D-task split (preview — szczegóły w implementation plan)
+
+| D | Tytuł | Czas | Branch | Zależy od |
+|---|---|---|---|---|
+| **D41** | `apps/core` healthcheck app + `/health/` endpoint + 4 tests | ~2-3h | `feat/<#>-health-endpoint` | (start of M9) |
+| **D42** | Multi-stage Dockerfile + .dockerignore + local container smoke | ~3-4h | `feat/<#>-dockerfile` | D41 merged |
+| **D43** | Production `docker-compose.yml` + 7 services + migrate one-shot + healthchecki + .env.example update | ~3-4h | `feat/<#>-prod-compose` | D42 merged |
+| **D44** | `docker.yml` CI workflow (build + push ghcr.io) + M9 e2e (full stack smoke) + closure PR | ~3-4h | `feat/<#>-docker-ci` + `docs/close-m9-dockerization` | D43 merged |
+
+**Sanity ratio:** 4 D-tasks × ~3.5h = ~14h, mieści się w 16h M9 budget (4 dni × 4h) z 2h buforem.
+
+---
+
+## §6 Error handling
+
+### §6.1 Healthcheck endpoint failure modes
+
+| Failure mode | Detection | Response | Recovery |
+|---|---|---|---|
+| DB unreachable | `connection.cursor().execute("SELECT 1")` raises `OperationalError` | 503 + `{"db": "fail"}` | Docker `HEALTHCHECK` → restart container po N retries |
+| Redis unreachable | `redis.Redis.from_url(...).ping()` raises `ConnectionError`/`TimeoutError` | 503 + `{"redis": "fail"}` | Same |
+| Endpoint timeout | curl `--max-time 5s` w HEALTHCHECK | Docker marks unhealthy | LB removes from rotation (M-future), restart on N retries |
+| 500 z Django view | (nie powinno) — wszystkie exceptions handled inline | 500 (Django default ErrorHandler) | Same as DB unreachable |
+
+### §6.2 Migration service failure
+
+`migrate` exit ≠ 0 → `web` nie startuje (`service_completed_successfully` not met). Operator widzi błąd w `docker compose logs migrate`, fix migration locally, rebuild image, retry. **Brak auto-rollback** — M-future jeśli chcemy zero-downtime migrations.
+
+### §6.3 Image pull failure (ghcr.io down)
+
+`docker compose pull` exit ≠ 0 → operator widzi error. Auto-fallback na lokalnie cached image (`docker compose up -d` bez `pull` używa local cache). Manual retry. **Brak retry loop w compose** — operator decyduje.
+
+### §6.4 Discord bot crash w container
+
+`restart: unless-stopped` policy → automatic restart po non-zero exit. py-cord obsługuje gateway reconnect po jego stronie (w-process retry). Crash zewnętrzny (OOM, SIGKILL) → Docker restart → bot reconnects, slash commands re-syncują przy startup.
+
+### §6.5 Celery worker / beat crash
+
+Same `restart: unless-stopped`. Beat schedule jest persistent w `django-celery-beat` (Postgres-backed) — restart nie traci jobs. Worker grabs unfinished tasks z Redis queue.
+
+### §6.6 Static files w prod (M9 NIE rozwiązuje)
+
+Django `STATIC_URL=/static/` ale bez `collectstatic` + WhiteNoise / nginx, admin CSS/JS będzie broken. **M9 świadomie pomija** — admin dostępny tylko przez SSH tunnel `ssh -L 8000:localhost:8000 prod.host` (dev workflow). M10 lub M-future dorzuci WhiteNoise + `collectstatic` w Dockerfile build stage.
+
+---
+
+## §7 Testing strategy
+
+### §7.1 Stack
+
+Docker M9 to **infra**, nie kod aplikacyjny — testing pattern się różni od M0-M8:
+
+| Layer | Test type | Mechanism |
+|---|---|---|
+| Healthcheck endpoint | Unit + integration | pytest-django |
+| Dockerfile | Smoke (local + CI) | `docker build` + `docker run` |
+| docker-compose.yml | Manual smoke (closure PR) | `docker compose up -d` |
+| CI workflow | GHA dry-run + post-merge push | PR triggers build, master triggers push |
+
+### §7.2 Test files (~4 tests total + 5 manual smoke punkty)
+
+**D41 — `apps/core/tests/test_health.py`** (4 tests):
+- `test_health_returns_200_when_db_and_redis_ok` — happy path, JSON shape `{"db": "ok", "redis": "ok"}`
+- `test_health_returns_503_when_db_fails` — mock `connection.cursor` → `OperationalError`, expects 503 + `"db": "fail"`
+- `test_health_returns_503_when_redis_fails` — mock `redis.Redis.from_url(...).ping()` → `ConnectionError`, expects 503 + `"redis": "fail"`
+- `test_health_response_shape_keys` — JSON keys pin (forward-compat dla M-future Mongo/Celery checks)
+
+**D42 — manual smoke w PR description:**
+- `docker build -t tibiantis:dev .` → exit 0
+- Image size raport (`docker image ls tibiantis:dev`) — target ~150-200MB
+- `docker run --rm -e DJANGO_SECRET_KEY=test -e DATABASE_URL=sqlite:///:memory: tibiantis:dev python manage.py check` → exit 0
+
+**D43 — manual smoke w PR description (5 punktów z §9 poniżej, podzbiór):**
+- `docker compose -f docker-compose.yml up -d` (z `.env` z dev secretami)
+- `docker compose ps` → 7/7 services `Up healthy` po ≤90s
+- `docker compose logs migrate` → exit 0, migration applied
+- `docker compose exec web curl -fsS http://localhost:8000/health/` → 200
+- `docker compose down -v` cleanup
+
+**D44 — CI verification:**
+- PR z dotknięciem `Dockerfile`/`docker-compose.yml`/`.github/workflows/docker.yml` triggers build job → zielony
+- Po merge do master: `docker.yml` push job → `docker pull ghcr.io/bgozlinski/tibiantis-scraper:master` z lokalu działa
+- M9 e2e smoke (closure PR): full stack via `docker compose pull && docker compose up -d` z pre-built image — potwierdzenie end-to-end push → pull → run flow
+
+### §7.3 Coverage cel
+
+- `apps/core/health/*` ≥ 95% — mały app, 4 tests powinny dać full coverage.
+- Cumulative `apps/*` ≥ 70% (CI threshold, M0 baseline) — niezmienne.
+
+### §7.4 NIE testujemy
+
+- **Real VPS deploy** — out of scope, M-future po wynajęciu hostingu.
+- **`docker compose up` na realnej maszynie zdalnej** — M-future.
+- **TLS / Let's Encrypt cert flow** — M-future.
+- **`ALLOWED_HOSTS=production-domain.com`** end-to-end — M-future.
+- **Image security scanning** — kandydat na M10 Hardening.
+
+---
+
+## §8 Definition of Done M9
+
+- [ ] **4 D-tasków zamkniętych** (#D41 + #D42 + #D43 + #D44) + closure PR
+- [ ] **`apps/core/health/`** — view (`health_check`), urls (`health/`), 4 tests, ≥95% coverage
+- [ ] **`config/urls.py`** dorzuca `path("health/", include("apps.core.urls"))`
+- [ ] **`config/settings/base.py`** dorzuca `"apps.core"` do `LOCAL_APPS`
+- [ ] **`pyproject.toml`** dorzuca `gunicorn (>=23.0,<24.0)` jako prod dependency (Dockerfile CMD używa). Plus `types-redis` w dev deps jeśli mypy zgłosi missing stubs.
+- [ ] **`Dockerfile`** multi-stage (builder + runtime), non-root user `app` (UID 1000), `python:3.13-slim-bookworm` base, HEALTHCHECK via curl `/health/`
+- [ ] **`.dockerignore`** excluding `.git`, `.venv`, `__pycache__`, `tests/`, `docs/`, `.env*`, `.idea/`, scratch files
+- [ ] **`docker-compose.yml`** (prod) z 7 services (postgres, redis, mongo, web, celery_worker, celery_beat, discord_bot) + 1 one-shot `migrate` + healthchecki + depends_on chain
+- [ ] **`.env.example`** zaktualizowane na Docker DNS hostnames (`postgres`/`redis`/`mongo`) + operator-wypełnia comments
+- [ ] **`.github/workflows/docker.yml`** — build na PR + push do `ghcr.io/bgozlinski/tibiantis-scraper` na master/tag, z `docker/metadata-action@v5` tags
+- [ ] **Pre-commit + CI lint + test zielone** dla wszystkich 4 PR-ów
+- [ ] **Coverage `apps/core/health/*` ≥ 95%** — osiągnięte
+- [ ] **PROGRESS.md** rozszerzony o sekcję M9 z retro per Issue (D41-D44) + Tech debt M9 + lekcje
+- [ ] **Manual smoke** udokumentowany w closure PR description (5 punktów z §9 poniżej)
+- [ ] **Milestone M9 zamknięty** na GitHub via `gh api -X PATCH .../milestones/9 -f state=closed`
+
+---
+
+## §9 Manual smoke checklist (operator's laptop + post-merge)
+
+W closure PR body (D44):
+
+1. **Local build:** `docker build -t tibiantis:dev .` → exit 0, image size ~150-200MB (`docker image ls tibiantis:dev`)
+2. **Full stack up:** `cp .env.example .env`, fill in `DJANGO_SECRET_KEY` + `DISCORD_BOT_TOKEN` + `POSTGRES_PASSWORD`, then `docker compose -f docker-compose.yml up -d` → wszystkie 7 services `Up healthy` po ≤90s (verify via `docker compose ps`)
+3. **Migrate one-shot:** `docker compose logs migrate` → exit 0, "Applying X..." lines, brak pending migrations po `docker compose exec web python manage.py showmigrations --plan | grep '\[ \]'` (powinno być empty)
+4. **Health endpoint:** `curl -fsS http://localhost:8000/health/` z hosta przez exposed `web:8000` → 200 + `{"db": "ok", "redis": "ok"}`
+5. **Post-master-merge:** `docker pull ghcr.io/bgozlinski/tibiantis-scraper:master` z lokalu (logged in to ghcr.io via `docker login ghcr.io -u bgozlinski`) → success, `docker image inspect` shows `:master` tag
+
+---
+
+## §10 References / precedensy
+
+- **CLAUDE.md §10** — Docker / docker-compose reguły (multi-stage, single image dla web/celery/bot, healthchecki, volumes, .env strategy). M9 odstępuje w jednym punkcie: `requirements.txt` export w builder stage (kontekst — multi-stage, nie dev workflow). Spec update kandydat.
+- **CLAUDE.md §13.2** — `docker.yml` workflow template z `docker/metadata-action@v5` i `docker/build-push-action@v6`. M9 reuses verbatim.
+- **`docker-compose.dev.yml`** — istniejące postgres+redis+mongo z healthcheckami. M9 prod compose extends pattern dla 4 app services.
+- **M2 — `config/urls.py`** routing setup. M9 dorzuca `path("health/", ...)`.
+- **M6 — `LOGGING` dict** — health endpoint loguje failures via M6 dispatcher do Mongo `app_logs`.
+- **M7-D32 lekcja** — `env(..., default="")` empty-env fallback (Pułapka H). M9 .env.example musi mieć komentarz że puste = operator wypełnia, nie default.
+- **M8-D37 lazy import lekcja** — w `health.py` import `redis` na top-level OK (redis to direct dependency po §4.4, nie lazy-load potrzebny).
+- **Execution plan §6.2 YAGNI** — nginx + TLS, dashboard, wykresy, multi-world — wszystko po-M9 osobne projekty.
+
+---
+
+## §11 Otwarte pytania dla M9 retro
+
+- **`STATIC_URL` / collectstatic** — czy admin musi działać w prod? Jeśli tak, dorzucamy WhiteNoise w M10. Aktualnie M9 zostawia broken (SSH tunnel workflow).
+- **Image size target** — 150-200MB to luźna estymata. Po pierwszym build mamy hard data; jeśli > 300MB, audit warstw (np. dorzucenie `--no-install-recommends` do `apt-get`, usuń `curl` z runtime jeśli HEALTHCHECK używa `wget` lub Python httpx).
+- **Image scanning** — Trivy w M10? Albo wystarczy GHA's CodeQL? Decyzja w M10 brainstorm.
+- **`web:8000` exposed port** — `ports: ["8000:8000"]` (development setup) czy `expose: 8000` (intended behind LB)? M9 daje `ports:` dla SSH-tunnel + local smoke. M-future + nginx zmienia na `expose:`.
+- **Celery beat scheduler choice** — `django-celery-beat` (DB-backed schedule, current setup) czy file-backed default? Aktualne setup `--scheduler django_celery_beat.schedulers:DatabaseScheduler` w `command` zostaje.


### PR DESCRIPTION
M9 brainstorm + planning artifacts. Następny milestone po M8 (Discord outbound notifications COMPLETED).

## Summary

- **Design spec** ([`docs/superpowers/specs/2026-05-15-m9-dockerization-design.md`](https://github.com/bgozlinski/tibiantis-scraper/blob/docs/m9-dockerization-spec/docs/superpowers/specs/2026-05-15-m9-dockerization-design.md)) — 7 decyzji designowych zaakceptowanych w brainstorm session 2026-05-15: multi-stage Dockerfile, gunicorn WSGI, per-service healthchecki, migrate one-shot service, rolling `:master` tag, `env_file: .env` strategy, non-root user.
- **Implementation plan** ([`docs/superpowers/plans/2026-05-15-m9-implementation-plan.md`](https://github.com/bgozlinski/tibiantis-scraper/blob/docs/m9-dockerization-spec/docs/superpowers/plans/2026-05-15-m9-implementation-plan.md)) — 4 D-tasks (D41-D44), strict chain bez parallelism, ~11-15h total (mieści się w 16h M9 budget).
- **4 issue bodies** w `.github/issue-bodies/m9-d{41,42,43,44}.md` — gotowe do `gh issue create --body-file`.

## D-task breakdown

| D | Cel | Czas | Branch | Deliverable |
|---|---|---|---|---|
| **D41** | `apps/core` health endpoint + 4 tests | 2-3h | `feat/<#>-health-endpoint` | `/health/` zwraca 200/503, ≥95% coverage |
| **D42** | Multi-stage Dockerfile + gunicorn dep | 3-4h | `feat/<#>-dockerfile` | `docker build` exit 0, image ~150-200MB, non-root |
| **D43** | Prod docker-compose.yml z 7 services + migrate one-shot | 3-4h | `feat/<#>-prod-compose` | Full stack `Up healthy` ≤90s |
| **D44** | docker.yml CI workflow (build + push ghcr.io) + closure | 3-4h | `feat/<#>-docker-ci` + `docs/close-m9-dockerization` | Image w ghcr.io po master merge, M9 milestone closed |

## Key design decisions (z spec §3)

1. **§3.1** Dockerfile multi-stage z `poetry export → requirements.txt` w builder (odstąpienie od CLAUDE.md §10 — kontekst BUILD stage, nie dev workflow)
2. **§3.2** Gunicorn WSGI dla `web` (uvicorn ASGI = YAGNI)
3. **§3.3** Per-service healthchecki; `discord_bot` świadomie BEZ healthcheck (restart policy wystarcza)
4. **§3.4** Migration jako osobny one-shot service z `service_completed_successfully` dependency
5. **§3.5** Rolling `:master` tag + `:sha-<commit>` audit (semver = M-future)
6. **§3.6** `env_file: .env` (Docker secrets = M-future jeśli multi-host)
7. **§3.7** Non-root user `app` (UID 1000) w runtime

## Poza scope M9 (M10 lub M-future)

- nginx + TLS (YAGNI dopóki brak realnego VPS deploy)
- Image security scanning (Trivy/Snyk) — kandydat na **M10 Hardening**
- Static files w prod (WhiteNoise + collectstatic) — admin SSH tunnel workflow, WhiteNoise w M10
- Multi-arch builds (amd64,arm64)
- Docker secrets / Vault / SOPS
- Auto-scaling, replicas, swarm/k8s
- Semantic version tagging
- Real production deploy

## Test plan

- [x] Spec brainstorm session z 7 decyzjami designowymi zaakceptowanymi
- [x] Plan + 4 issue bodies napisane w stylu M8 PR #127 (developer-as-implementer)
- [x] Self-review specu — naprawione 2 pomyłki (`redis` już direct dep z M5, `gunicorn` natomiast brakuje), doprecyzowane image tagging hybrid `image:` + `build:` dla D43 dev iteration
- [x] Self-review planu — spec coverage OK, brak placeholderów, type consistency OK
- [x] Pre-commit clean (end-of-file-fixer + mixed-line-ending auto-fixes applied)
- [ ] CI lint green
- [ ] Po merge: utworzyć 4 GitHub Issues z `gh issue create --body-file .github/issue-bodies/m9-d{41,42,43,44}.md --milestone "M9 — Dockeryzacja + prod-ready"`