### PR TITLE
feat(docker): production compose with 7 services + migrate one-shot (M9-D43, #146)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,36 +1,54 @@
-# Django secret key. Generate: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+# ─── Django ──────────────────────────────────────────────────────────
+# Operator MUSI wypełnić — generate via:
+#   python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+#
+# UWAGA: jeśli wygenerowany klucz zawiera znak `$`, regeneruj — Compose v2
+# interpoluje `$VAR` w wartościach `.env` jako variable expansion ("$v4"
+# → "" → uszkodzony SECRET_KEY w compose context + spam warnings).
+# Alternatywa: alphanumeric-only z `python -c "import string, secrets; print(''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(50)))"`
 DJANGO_SECRET_KEY=
 
-# w docker-compose host będzie 'postgres', tu localhost dla lokalnego setupu
-POSTGRES_USER=tibiantis
-POSTGRES_PASSWORD=tibiantis
-POSTGRES_DB=tibiantis
-DATABASE_URL=postgres://tibiantis:tibiantis@localhost:5435/tibiantis
+
 # Set True only for local dev. Production must keep False.
 DJANGO_DEBUG=False
 
-# comma-separated list, np. example.com,api.example.com
+# Comma-separated list, np. example.com,api.example.com
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
 
-REDIS_URL=redis://localhost:6379/0
+# ─── PostgreSQL ──────────────────────────────────────────────────────
+# Operator MUSI ustawić POSTGRES_PASSWORD na real value przed prod deploy.
+POSTGRES_USER=tibiantis
+POSTGRES_PASSWORD=tibiantis
+POSTGRES_DB=tibiantis
 
-CELERY_BROKER_URL=redis://localhost:6379/1
-CELERY_RESULT_BACKEND=redis://localhost:6379/2
+# Docker DNS hostname `postgres` (compose service name).
+# Dla DEV (bez compose, `runserver` lokalnie): zmień `postgres:5432` na `localhost:5435`.
+DATABASE_URL=postgres://tibiantis:tibiantis@postgres:5432/tibiantis
 
-# Skip scrape if last_scraped_at is more recent than this many minutes)
+# ─── Redis ───────────────────────────────────────────────────────────
+# Docker DNS hostname `redis`. Dla DEV: `redis://localhost:6379/0`.
+REDIS_URL=redis://redis:6379/0
+CELERY_BROKER_URL=redis://redis:6379/1
+CELERY_RESULT_BACKEND=redis://redis:6379/2
+
+# ─── MongoDB ─────────────────────────────────────────────────────────
+# Docker DNS hostname `mongo`. Dla DEV: `mongodb://localhost:27017`.
+MONGO_URL=mongodb://mongo:27017
+MONGO_DB=tibiantis_logs
+
+# ─── Domain logic ────────────────────────────────────────────────────
 CELERY_SCRAPE_FRESHNESS_MINUTES=30
 
 DEATH_LEVEL_THRESHOLD=30
 
 BEDMAGE_REGEN_MINUTES=100
 BEDMAGE_NOTIFICATION_HANDLER=apps.notifications.handlers.DiscordDMHandler
-
-#  MongoDB
-MONGO_URL=mongodb://localhost:27017
-MONGO_DB=tibiantis_logs
-
-# Discord bot
-DISCORD_BOT_TOKEN=
-DISCORD_DEV_GUILD_ID=
-
 DEATH_NOTIFICATION_HANDLER=apps.notifications.handlers.DiscordChannelHandler
+
+# ─── Discord bot ─────────────────────────────────────────────────────
+# Operator MUSI wypełnić — Discord Developer Portal → Application → Bot → Token.
+# https://discord.com/developers/applications
+DISCORD_BOT_TOKEN=
+
+# Discord dev guild Server ID (Developer Mode → Copy ID). Empty dla prod.
+DISCORD_DEV_GUILD_ID=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,158 @@
+services:
+
+  # ─── Infrastructure ───────────────────────────────────────────────
+
+  postgres:
+    image: postgres:16-alpine
+    env_file: .env
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  mongo:
+    image: mongo:7
+    volumes:
+      - mongo_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  # ─── Migration (one-shot) ─────────────────────────────────────────
+
+  migrate:
+    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    build: .
+    env_file: .env
+    command: python manage.py migrate --noinput
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  # ─── Application services (shared image) ──────────────────────────
+
+  web:
+    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    build: .
+    env_file: .env
+    command:
+      - gunicorn
+      - config.wsgi:application
+      - --bind=0.0.0.0:8000
+      - --workers=2
+      - --threads=2
+      - --timeout=60
+      - --access-logfile=-
+      - --error-logfile=-
+    ports:
+      - "8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health/"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+
+  celery_worker:
+    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    build: .
+    env_file: .env
+    command:
+      - celery
+      - -A
+      - config
+      - worker
+      - -l
+      - info
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A config inspect ping -d celery@$$HOSTNAME"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+
+  celery_beat:
+    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    build: .
+    env_file: .env
+    command:
+      - celery
+      - -A
+      - config
+      - beat
+      - -l
+      - info
+      - --pidfile=/tmp/celerybeat.pid
+      - --schedule=/tmp/celerybeat-schedule
+      - --scheduler=django_celery_beat.schedulers:DatabaseScheduler
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /tmp/celerybeat.pid && kill -0 $$(cat /tmp/celerybeat.pid) 2>/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+
+  discord_bot:
+    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    build: .
+    env_file: .env
+    command: python manage.py run_discord_bot
+    depends_on:
+      postgres:
+        condition: service_healthy
+      mongo:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      disable: true
+    restart: unless-stopped
+
+
+
+volumes:
+  postgres_data:
+  mongo_data:


### PR DESCRIPTION
Closes #146 (third M9 task — full stack runnable lokalnie, gotowy do D44 CI workflow).

## Summary

Nowy `docker-compose.yml` (prod, **różny** od `docker-compose.dev.yml` — oba koegzystują: dev compose dla DB-only + `poetry run` workflow, prod compose dla full stack). 7 application services + 1 one-shot `migrate` service, hybrid `image: ghcr.io/...:master` + `build: .` (registry tag dopiero po D44 push), per-service healthchecki, depends_on chain z `service_healthy` + `service_completed_successfully`. `.env.example` zaktualizowany na Docker DNS hostnames + "Operator wypełnia" komentarze.

## Manual smoke results — wszystkie 4 punkty z spec §9 ✅

**Smoke flow** (po fix'ach z review):

```bash
cp .env.example .env
# fill DJANGO_SECRET_KEY (alphanumeric-only, no `$`)
# DISCORD_BOT_TOKEN zostawiony empty (discord_bot się restartuje, akceptowalne dla smoke)
# POSTGRES_PASSWORD default `tibiantis`

docker compose -f docker-compose.yml down -v
docker compose -f docker-compose.yml build       # SINGLE build (no race condition)
docker compose -f docker-compose.yml up -d --no-build
sleep 90
docker compose ps
```

**Result:** 7 services Up, 6 healthy + discord_bot Up (healthcheck disabled) + migrate Exited (0):

```
NAME                               STATUS
tibantis-scraper-celery_beat-1     Up About a minute (healthy)
tibantis-scraper-celery_worker-1   Up About a minute (healthy)
tibantis-scraper-discord_bot-1     Up About a minute
tibantis-scraper-mongo-1           Up About a minute (healthy)
tibantis-scraper-postgres-1        Up About a minute (healthy)
tibantis-scraper-redis-1           Up About a minute (healthy)
tibantis-scraper-web-1             Up About a minute (healthy)
```

**`docker compose logs migrate`:**
```
Operations to perform:
  Apply all migrations: accounts, admin, auth, bedmages, characters,
  contenttypes, deaths, discord_bot, django_celery_beat, sessions,
  token_blacklist
Running migrations:
  No migrations to apply.
```

**`curl http://localhost:8000/health/`:**
```json
{"db": "ok", "redis": "ok"}
```

**`docker compose exec web python manage.py showmigrations --plan | grep '[ ]'`** → empty (all applied).

## D43 retro lekcje (do PROGRESS.md / Tech debt M9)

5 empiryczne gotchas złapane podczas smoke (oryginalny issue body je przewidział tylko częściowo):

1. **`procps` NIE w `python:3.13-slim-bookworm`** — issue body Pułapka E spec'owała healthcheck `ps -p $(cat $PID)`, ale `ps` nie jest installed w slim image. Fix: `kill -0 $(cat $PID) 2>/dev/null` (POSIX, brak `procps` dependency). Cleaner, równoważny semantycznie.

2. **Inherited Dockerfile HEALTHCHECK propaguje do services bez explicit compose `healthcheck:`** — `discord_bot` świadomie bez healthcheck (spec §3.3) ale dziedziczył `curl /health/` z Dockerfile → zawsze "unhealthy". Fix: explicit `healthcheck: { disable: true }` w compose. To powinien być w specu §3.3.

3. **Compose v2 interpoluje `$VAR` w `.env` values** — SECRET_KEY wygenerowany przez `get_random_secret_key()` może zawierać `$` (np. `$v4`, `$zj6`), które Compose treats jako shell variable expansion → empty substitution + spam warnings + uszkodzony SECRET_KEY w compose context (choć env_file passthrough do containera jest OK). Fix: alphanumeric-only generator: `python -c "import string, secrets; print(''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(50)))"`. Dodane do `.env.example` jako "UWAGA" komentarz.

4. **MSYS path conversion na Windows Git Bash** — `docker compose exec celery_beat ls /tmp/` → MSYS translates `/tmp/` na `C:/Users/.../AppData/Local/Temp/` PRZED docker → container nie widzi. Fix dev: `MSYS_NO_PATHCONV=1` prefix lub `//tmp/` (double-slash escape). Tylko dev gotcha (`docker compose exec`), runtime container Linux path działa OK. Do `docs/dev-runbook.md` (M9 tech debt).

5. **D-task smoke command wymaga ALL env vars bez default'u** (kontynuacja D42 lesson #1) — `DJANGO_SECRET_KEY`, `DATABASE_URL`, `CELERY_BROKER_URL`, `CELERY_RESULT_BACKEND`, `REDIS_URL`. Bez nich `web` crashuje na `env("X")` raise.

## Compose layout zgodny ze spec'em §3 — sanity

- ✅ §3.1 Hybrid `image:` + `build:` (D43 dev iteration)
- ✅ §3.3 Per-service healthchecki (z `kill -0` fix dla celery_beat + `disable: true` dla discord_bot)
- ✅ §3.4 Migration jako one-shot z `service_completed_successfully` gate
- ✅ §3.5 `:master` rolling tag (image directive)
- ✅ §3.6 `env_file: .env`
- ✅ §3.7 Non-root user `app` (inherited z Dockerfile)

## Files

- **New:** `docker-compose.yml` (~120 lines, 8 service blocks + volumes top-level)
- **Modified:** `.env.example` (Docker DNS hostnames + "Operator wypełnia" komentarze + UWAGA o `$` w SECRET_KEY)
- **Unchanged:** `docker-compose.dev.yml` (dev workflow preserved)

## Test plan

- [x] `docker compose config --quiet` → no errors
- [x] `docker compose build` → all 5 app services share single image build
- [x] `docker compose up -d --no-build` → 7 Up healthy + migrate Exited (0) w ≤ 90s
- [x] `curl /health/` → 200 + JSON
- [x] `docker compose logs migrate` → "No migrations to apply" (clean state)
- [x] `docker compose down -v` → clean shutdown
- [ ] CI lint + test green

## Outstanding (do D44)

- Compose Pull `:master` z registry — czeka na D44 CI workflow push do ghcr.io. Manual smoke punkt #5 z spec §9 odroczony do D44 closure PR.