### PR TITLE
feat(ci): docker.yml workflow with ghcr.io build + push (M9-D44, #147)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Docker build
+
+on:
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "docker-compose.yml"
+      - "pyproject.toml"
+      - "poetry.lock"
+      - ".github/workflows/docker.yml"
+  push:
+    branches: [master]
+    tags: ["v*"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha-,format=short
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Feature PR dla #147 (M9-D44 — closure PR follows from fresh master after merge).

## Summary

`.github/workflows/docker.yml` — Docker build & push workflow zgodny ze spec §13.2 (CLAUDE.md verbatim) + issue body #147 AC. Verbatim implementacja, brak modyfikacji.

**Triggers:**
- `pull_request` z `paths:` filter — build-only verification gdy PR dotyka `Dockerfile`/`.dockerignore`/`docker-compose.yml`/`pyproject.toml`/`poetry.lock`/`docker.yml` (oszczędność CI minutes dla docs-only PR)
- `push: branches: [master]` — build + push do `ghcr.io/bgozlinski/tibiantis-scraper:master` + `:sha-<commit>` (rolling tag per spec §3.5)
- `push: tags: ["v*"]` — build + push z semver tag (M-future release flow)

**Permissions + auth:**
- Workflow-level `permissions: { contents: read, packages: write }` — minimal scope
- `docker/login-action@v3` z `${{ secrets.GITHUB_TOKEN }}` — auto-scoped, no custom PAT
- `if: github.event_name != 'pull_request'` na login — PR build nie próbuje auth (Pułapka B, security)
- Repo-level `default_workflow_permissions` przepięte na `"write"` przed merge (pre-flight check) — dwie warstwy guarantee

**Tags strategy (Pułapka F):**
- `type=ref,event=branch` → `:master` na push do master
- `type=semver,pattern={{version}}` → `:1.2.3` tylko z git tag `v1.2.3`
- `type=sha,prefix=sha-,format=short` → `:sha-<7-char>` na każdy build (audit trail)
- Wszystkie tags lowercase (ghcr.io lowercases username/repo)

**Cache + concurrency:**
- `cache-from: type=gha + cache-to: type=gha,mode=max` — GHA native cache, `mode=max` cache'uje wszystkie warstwy (nie tylko final, per Pułapka E)
- `concurrency: cancel-in-progress: true` — szybkie consecutive merges zabijają stare runy

## Manual smoke (do closure PR po master merge)

Ten feature PR triggeruje **build-only** workflow run (PR mode):
- `docker/build-push-action@v6` z `push: ${{ ... != 'pull_request' }}` → `push: false` na PR → build sanity bez registry push
- Tej iteracji nie widać w `ghcr.io` packages page

Po master merge:
- Workflow auto-triggers z `push: branches: [master]`
- `push: true` → image leci do `ghcr.io/bgozlinski/tibiantis-scraper:master` + `:sha-<commit>`
- Sanity (do closure PR description): `docker pull ghcr.io/bgozlinski/tibiantis-scraper:master` z lokalu z `docker login ghcr.io` (PAT z `read:packages` scope)

## Files

- **New:** `.github/workflows/docker.yml` (54 lines, verbatim z spec §13.2)

## Test plan

- [x] Workflow YAML verbatim z spec §13.2
- [x] Action versions current (`actions/checkout@v4`, `docker/setup-buildx-action@v3`, `docker/login-action@v3`, `docker/metadata-action@v5`, `docker/build-push-action@v6`)
- [x] Repo `default_workflow_permissions: "write"` confirmed (pre-flight via `gh api`)
- [x] `paths:` filter na PR (nie odpala dla docs-only PR)
- [x] `if: ... != 'pull_request'` na login (security)
- [x] `push: ${{ ... != 'pull_request' }}` na build-push (PR build-only, master/tag push)
- [ ] PR build job triggered i zielony (this PR — czekamy na CI)
- [ ] Post-merge: workflow run `push: true`, image visible w `https://github.com/bgozlinski/tibiantis-scraper/pkgs/container/tibiantis-scraper` (closure PR sanity)