### PR TITLE
docs(m9_5): fix Docker Hub username bgozlinski → bgozl in M9.5 spec/plan/issue bodies

### DIFF
--- a/.github/issue-bodies/m9_5-d45.md
+++ b/.github/issue-bodies/m9_5-d45.md
@@ -10,14 +10,14 @@
 
 ## 🎯 Cel
 
-Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + image name, plus `docker-compose.yml` 5× `image:` references. Dorzucić `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` jako GitHub Secrets (manual pre-PR). Cleanup ghcr.io package post-merge. Po D45: każdy push do master triggeruje GHA workflow → push obrazu do `docker.io/bgozlinski/tibiantis-scraper:master` + `:sha-<commit>`. Anonymous pull z VM/laptopa działa (public Docker Hub repo).
+Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + image name, plus `docker-compose.yml` 5× `image:` references. Dorzucić `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` jako GitHub Secrets (manual pre-PR). Cleanup ghcr.io package post-merge. Po D45: każdy push do master triggeruje GHA workflow → push obrazu do `docker.io/bgozl/tibiantis-scraper:master` + `:sha-<commit>`. Anonymous pull z VM/laptopa działa (public Docker Hub repo).
 
 ## 🧠 Czego się nauczysz
 
 - **Docker Hub public repos** — anonymous pull works bez auth (default). Rate limit 100/6h anonymous, 200/6h authenticated.
 - **Docker Hub PAT scoping** — least privilege per repo, Read/Write/Delete scopes osobno.
 - **`docker/login-action@v3` default registry** — bez `registry:` directive, defaults to `index.docker.io`.
-- **`docker/metadata-action@v5` image naming** — `images: bgozlinski/tibiantis-scraper` (bez `docker.io/` prefix).
+- **`docker/metadata-action@v5` image naming** — `images: bgozl/tibiantis-scraper` (bez `docker.io/` prefix).
 - **GitHub package deletion** — `gh api -X DELETE user/packages/container/<name>` nuke entire package.
 
 ## ✅ Acceptance criteria
@@ -28,12 +28,12 @@ Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + i
   - Click "New Access Token"
   - Description: `tibiantis-monitor-ci`
   - Permissions: **Read, Write, Delete** (NIE Read-only)
-  - Repository access: dla `bgozlinski/tibiantis-scraper` only (NIE account-wide)
+  - Repository access: dla `bgozl/tibiantis-scraper` only (NIE account-wide)
   - Generated value — copy now (visible once)
 
 - [ ] **Add GitHub Secrets:**
   ```bash
-  gh secret set DOCKERHUB_USERNAME --body "bgozlinski"
+  gh secret set DOCKERHUB_USERNAME --body "bgozl"
   gh secret set DOCKERHUB_TOKEN --body "<paste-PAT>"
   gh secret list
   ```
@@ -41,15 +41,15 @@ Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + i
 
 - [ ] **Verify PAT works (sanity):**
   ```bash
-  docker login -u bgozlinski -p <PAT>
+  docker login -u bgozl -p <PAT>
   # → Login Succeeded
   docker pull busybox
-  docker tag busybox bgozlinski/tibiantis-scraper:smoke-test
-  docker push bgozlinski/tibiantis-scraper:smoke-test
+  docker tag busybox bgozl/tibiantis-scraper:smoke-test
+  docker push bgozl/tibiantis-scraper:smoke-test
   # → success
-  docker rmi bgozlinski/tibiantis-scraper:smoke-test
+  docker rmi bgozl/tibiantis-scraper:smoke-test
   # → cleanup local
-  # Delete smoke-test tag via UI: https://hub.docker.com/r/bgozlinski/tibiantis-scraper/tags
+  # Delete smoke-test tag via UI: https://hub.docker.com/r/bgozl/tibiantis-scraper/tags
   ```
 
 ### `.github/workflows/docker.yml` changes
@@ -96,7 +96,7 @@ Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + i
         - uses: docker/metadata-action@v5
           id: meta
           with:
-            images: bgozlinski/tibiantis-scraper   # ← BEZ "ghcr.io/" prefix
+            images: bgozl/tibiantis-scraper   # ← BEZ "ghcr.io/" prefix
             tags: |
               type=ref,event=branch
               type=semver,pattern={{version}}
@@ -117,10 +117,10 @@ Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + i
 - [ ] 5× `image:` swap (`migrate`, `web`, `celery_worker`, `celery_beat`, `discord_bot`):
   ```yaml
   # PRZED:
-  image: ghcr.io/bgozlinski/tibiantis-scraper:master
+  image: ghcr.io/bgozl/tibiantis-scraper:master
 
   # PO:
-  image: bgozlinski/tibiantis-scraper:master
+  image: bgozl/tibiantis-scraper:master
   ```
 
 - [ ] `build: .` directive ZOSTAJE (hybrid pattern for local iteration).
@@ -130,15 +130,15 @@ Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + i
 - [ ] Workflow run zielony:
   ```bash
   gh run watch <run-id>
-  # → "Login Succeeded" + push to bgozlinski/tibiantis-scraper:master + :sha-<commit>
+  # → "Login Succeeded" + push to bgozl/tibiantis-scraper:master + :sha-<commit>
   ```
 
-- [ ] Image visible w Docker Hub UI: `https://hub.docker.com/r/bgozlinski/tibiantis-scraper` → public + tags `:master` + `:sha-<commit>`.
+- [ ] Image visible w Docker Hub UI: `https://hub.docker.com/r/bgozl/tibiantis-scraper` → public + tags `:master` + `:sha-<commit>`.
 
 - [ ] Anonymous pull z laptopa:
   ```bash
   docker logout   # ensure no cached auth
-  docker pull bgozlinski/tibiantis-scraper:master
+  docker pull bgozl/tibiantis-scraper:master
   # → success
   ```
 
@@ -162,8 +162,8 @@ Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + i
 
 - **A — PAT scope MUSI być Read + Write + Delete.** Read-only nie pozwala na push z CI. Sanity: pre-PR `docker push` smoke test.
 - **B — Secrets names case-sensitive.** `DOCKERHUB_USERNAME` (NIE `dockerhub_username` ani `DOCKER_HUB_USERNAME`). Workflow YAML match exact.
-- **C — `images: bgozlinski/tibiantis-scraper`** lowercase. Docker Hub case-insensitive ale convention lowercase.
-- **D — Image name uniqueness check** — pre-PR: `curl -fsS https://hub.docker.com/v2/repositories/bgozlinski/tibiantis-scraper/` — jeśli 200 returned (existing repo), to nie ours. Jeśli 404, available. Po pierwszym push → 200.
+- **C — `images: bgozl/tibiantis-scraper`** lowercase. Docker Hub case-insensitive ale convention lowercase.
+- **D — Image name uniqueness check** — pre-PR: `curl -fsS https://hub.docker.com/v2/repositories/bgozl/tibiantis-scraper/` — jeśli 200 returned (existing repo), to nie ours. Jeśli 404, available. Po pierwszym push → 200.
 - **E — Workflow `paths:` filter** triggers na PR D45 (changed `.github/workflows/docker.yml` w `paths:` list). PR build → "Login Succeeded" but `push: false` → no Docker Hub push. Master merge → `push: true` triggers actual push.
 - **F — Conventional commit scope `m9.5` rejected** — use `m9_5` (underscore). Example: `chore(m9_5): swap ghcr.io → Docker Hub registry (M9.5-D45, #<#>)`.
 - **G — ghcr.io cleanup async** — `gh api -X DELETE` returns 204. UI may show package for ~1 min after.
@@ -176,7 +176,7 @@ Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + i
 ```bash
 # Pre-PR sanity
 gh secret list   # → DOCKERHUB_USERNAME + DOCKERHUB_TOKEN
-docker login -u bgozlinski -p <PAT>   # → Login Succeeded
+docker login -u bgozl -p <PAT>   # → Login Succeeded
 # Optional smoke push test (z busybox tag), delete tag w UI po
 
 # Workflow YAML sanity
@@ -190,8 +190,8 @@ docker compose -f docker-compose.yml config --quiet
 # Post-PR (po master merge)
 gh run watch <workflow-run-id>
 docker logout   # ensure no cached ghcr.io auth
-docker pull bgozlinski/tibiantis-scraper:master   # anonymous
-docker image inspect bgozlinski/tibiantis-scraper:master --format '{{.Created}}'
+docker pull bgozl/tibiantis-scraper:master   # anonymous
+docker image inspect bgozl/tibiantis-scraper:master --format '{{.Created}}'
 
 # Cleanup ghcr.io
 gh api "user/packages/container/tibiantis-scraper/versions" --jq '.[].name'
@@ -205,7 +205,7 @@ gh api -X DELETE "user/packages/container/tibiantis-scraper"
 - [ ] AC spełnione (workflow + compose updated, secrets w GitHub, ghcr.io package usunięty, anonymous pull works).
 - [ ] PR zmergowany squash (`chore(m9_5): swap ghcr.io → Docker Hub registry (M9.5-D45, #<#>)`).
 - [ ] CI lint + test + docker.yml workflow zielone.
-- [ ] Docker Hub repo public + visible at `https://hub.docker.com/r/bgozlinski/tibiantis-scraper`.
-- [ ] `docker pull bgozlinski/tibiantis-scraper:master` z laptopa anonymous = success.
+- [ ] Docker Hub repo public + visible at `https://hub.docker.com/r/bgozl/tibiantis-scraper`.
+- [ ] `docker pull bgozl/tibiantis-scraper:master` z laptopa anonymous = success.
 - [ ] ghcr.io package wiped (`gh api -X DELETE`).
 - [ ] PR description ma post-merge sanity output (workflow log "Login Succeeded" + pull confirmation).

--- a/.github/issue-bodies/m9_5-d47.md
+++ b/.github/issue-bodies/m9_5-d47.md
@@ -247,15 +247,15 @@ Dorzucić `uptime-kuma` jako 9. service do `docker-compose.yml` (port 3001 local
 
   ```bash
   cd /opt/tibiantis
-  sed -i 's|bgozlinski/tibiantis-scraper:master|bgozlinski/tibiantis-scraper:sha-<old-commit>|g' docker-compose.yml
+  sed -i 's|bgozl/tibiantis-scraper:master|bgozl/tibiantis-scraper:sha-<old-commit>|g' docker-compose.yml
   docker compose pull
   docker compose up -d
   ```
 
   Alternative: revert via `docker tag`:
   ```bash
-  docker pull bgozlinski/tibiantis-scraper:sha-<old-commit>
-  docker tag bgozlinski/tibiantis-scraper:sha-<old-commit> bgozlinski/tibiantis-scraper:master
+  docker pull bgozl/tibiantis-scraper:sha-<old-commit>
+  docker tag bgozl/tibiantis-scraper:sha-<old-commit> bgozl/tibiantis-scraper:master
   docker compose up -d
   ```
 
@@ -304,7 +304,7 @@ Dorzucić `uptime-kuma` jako 9. service do `docker-compose.yml` (port 3001 local
   ### 9.9 Docker Hub anonymous rate limit (100/6h)
 
   Symptom: `docker compose pull` fails "toomanyrequests: Too Many Requests".
-  Fix: `docker login -u bgozlinski` with PAT (200/6h authenticated).
+  Fix: `docker login -u bgozl` with PAT (200/6h authenticated).
 
   ### 9.10 Hetzner Cloud Firewall niezsynchronizowany z UFW
 

--- a/.github/issue-bodies/m9_5-d48.md
+++ b/.github/issue-bodies/m9_5-d48.md
@@ -123,10 +123,10 @@ D48 ma **2 PR-y w 1 issue** (M5-D27 + M6-D30 + M7-D35 + M8-D40 + M9-D44 pattern)
 
   **Symptom:** `docker compose up -d` z hybrid `image:` + `build:` (5+ services share same image) fails:
   ```
-  target celery_beat: failed to solve: image "bgozlinski/tibiantis-scraper:master": already exists
+  target celery_beat: failed to solve: image "bgozl/tibiantis-scraper:master": already exists
   ```
 
-  **Reason:** Compose builds 5 services parallel via buildx. Wszystkie tagują się jako same `bgozlinski/tibiantis-scraper:master`. Race condition — pierwszy success, drugi → "already exists".
+  **Reason:** Compose builds 5 services parallel via buildx. Wszystkie tagują się jako same `bgozl/tibiantis-scraper:master`. Race condition — pierwszy success, drugi → "already exists".
 
   **Workaround — split na 2 commands:**
   ```bash
@@ -207,10 +207,10 @@ D48 ma **2 PR-y w 1 issue** (M5-D27 + M6-D30 + M7-D35 + M8-D40 + M9-D44 pattern)
   1. **Registry swap verify:**
      ```
      $ docker logout
-     $ docker pull bgozlinski/tibiantis-scraper:master
-     master: Pulling from bgozlinski/tibiantis-scraper
+     $ docker pull bgozl/tibiantis-scraper:master
+     master: Pulling from bgozl/tibiantis-scraper
      ...
-     Status: Downloaded newer image for bgozlinski/tibiantis-scraper:master
+     Status: Downloaded newer image for bgozl/tibiantis-scraper:master
      ```
 
   2. **VM hardening verify:**

--- a/docs/superpowers/plans/2026-05-16-m9.5-implementation-plan.md
+++ b/docs/superpowers/plans/2026-05-16-m9.5-implementation-plan.md
@@ -28,7 +28,7 @@
 ## Pre-flight checklist (przed startem D45)
 
 - [ ] **Docker Hub account** — `https://hub.docker.com` registered + payment NOT required (free public repos)
-- [ ] **Docker Hub PAT** — generated z `https://hub.docker.com/settings/security` z scope **Read + Write + Delete** dla `bgozlinski/tibiantis-scraper` only (NIE account-wide). Zapisany w password manager lub w GitHub Secrets bezpośrednio.
+- [ ] **Docker Hub PAT** — generated z `https://hub.docker.com/settings/security` z scope **Read + Write + Delete** dla `bgozl/tibiantis-scraper` only (NIE account-wide). Zapisany w password manager lub w GitHub Secrets bezpośrednio.
 - [ ] **GitHub Secrets** — `gh secret list` confirm `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` przed D45 PR (alternatively, dorzuca w D45 PR sequence)
 - [ ] **Hetzner Cloud account** — `https://console.hetzner.cloud` registered + credit card / IBAN setup (CX22 = ~6€/mc billing)
 - [ ] **Local SSH key** — `~/.ssh/id_ed25519` existing OR generate: `ssh-keygen -t ed25519 -C "tibiantis-deploy"`. Pubkey ready do upload do Hetzner Cloud Console.
@@ -44,7 +44,7 @@
 
 Wszystkie 7 decyzji designowych ze spec'a §3 zaakceptowane bez modyfikacji:
 
-1. ✅ **§3.1** Registry swap ghcr.io → Docker Hub (PUBLIC repo `bgozlinski/tibiantis-scraper`, anonymous pull, secrets-based auth).
+1. ✅ **§3.1** Registry swap ghcr.io → Docker Hub (PUBLIC repo `bgozl/tibiantis-scraper`, anonymous pull, secrets-based auth).
 2. ✅ **§3.2** Manual Hetzner Cloud Console provisioning (CX22 Falkenstein, Ubuntu 24.04). NIE Terraform.
 3. ✅ **§3.3** Hardening minimal must-haves (deploy user + SSH key-only + UFW + Docker). NIE comprehensive (fail2ban/unattended-upgrades to M-future).
 4. ✅ **§3.4** First deploy `/opt/tibiantis` z manual `curl + .env edit + docker compose pull/up`. NIE git clone full source.
@@ -70,10 +70,10 @@ Wszystkie 7 decyzji designowych ze spec'a §3 zaakceptowane bez modyfikacji:
 |---|---|---|---|
 | **Docker Hub PAT scope insufficient** (np. Read-only zamiast Read+Write+Delete) | Średnie (operator UI mistake) | D45 workflow `push: true` fail "denied" | Issue body D45 explicit "Read + Write + Delete scope" + verify pre-PR z `docker login` test |
 | **GitHub Secrets typo (`DOCKERHUB_TOKEN` vs `DOCKER_HUB_TOKEN`)** | Niskie | Workflow "Username and password required" | `gh secret list` sanity pre-PR + workflow YAML match exact names |
-| **Image name conflict** (`bgozlinski/tibiantis-scraper` zajęty przez kogoś) | Bardzo niskie (matching GitHub username) | Push fails, push fallback name | Pre-check: `curl https://hub.docker.com/v2/repositories/bgozlinski/tibiantis-scraper/` (404 = available) |
+| **Image name conflict** (`bgozl/tibiantis-scraper` zajęty przez kogoś) | Niskie (krótki ale unique username) | Push fails, push fallback name | Pre-check: `curl https://hub.docker.com/v2/repositories/bgozl/tibiantis-scraper/` (404 = available) |
 | **Hetzner CX22 RAM insufficient pod load** | Niskie (~1.5-2GB idle, 4GB total) | OOM kill któregoś service'a | Monitoring via Kuma + `docker stats` po deploy. Upgrade na CCX13 (4GB → 8GB, ~14€/mc) gdy się okaże |
 | **SSH lockout w D46** (operator `ufw deny` przed `ufw allow 22`) | Średnie (bootstrap script ordering) | Lost SSH access do VM | Hetzner Cloud Console → server → Console (web TTY rescue) → `ufw allow 22 + reload`. Bootstrap script ma `ufw allow 22` PRZED `ufw enable` (sanity check w issue body) |
-| **`docker compose pull` rate limit anonymous (100/6h)** | Niskie (single VM, dev iteration rare) | 429 toomanyrequests | `docker login -u bgozlinski` z PAT bypassuje (200/6h authenticated). Issue body D47 §troubleshooting |
+| **`docker compose pull` rate limit anonymous (100/6h)** | Niskie (single VM, dev iteration rare) | 429 toomanyrequests | `docker login -u bgozl` z PAT bypassuje (200/6h authenticated). Issue body D47 §troubleshooting |
 | **Discord bot token nieprawidłowy w `.env`** | Średnie (operator copy-paste mistake) | `discord_bot` restart loop | `docker compose logs discord_bot` shows "Improper token". Regenerate token w Developer Portal, edit `.env`, `docker compose up -d --no-deps discord_bot` |
 | **Kuma initial setup race** (web form skip) | Niskie | UI shows login bez admin creation | `docker compose restart uptime-kuma` re-renders setup form (DB w `uptime_kuma_data` empty → setup mode) |
 | **First `docker compose pull` slow (480MB image)** | Wysokie (one-time) | ~30-60s w Falkenstein z Docker Hub | Acceptable, operator informed w runbook §4 "first pull ~1min, subsequent rolling pulls only diff layers" |
@@ -106,14 +106,14 @@ Wszystkie 7 decyzji designowych ze spec'a §3 zaakceptowane bez modyfikacji:
 
 ### 🎯 Cel
 
-Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + image name, plus `docker-compose.yml` 5× `image:` references. Dorzucić `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` jako GitHub Secrets (manual pre-PR via `gh secret set`). Cleanup ghcr.io package post-merge (`gh api -X DELETE`). Po D45: każdy push do master triggeruje GHA workflow → push obrazu do `docker.io/bgozlinski/tibiantis-scraper:master` + `:sha-<commit>`. Lokalny `docker pull bgozlinski/tibiantis-scraper:master` z laptopa działa **anonymous** (no `docker login` needed for public repo).
+Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + image name, plus `docker-compose.yml` 5× `image:` references. Dorzucić `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` jako GitHub Secrets (manual pre-PR via `gh secret set`). Cleanup ghcr.io package post-merge (`gh api -X DELETE`). Po D45: każdy push do master triggeruje GHA workflow → push obrazu do `docker.io/bgozl/tibiantis-scraper:master` + `:sha-<commit>`. Lokalny `docker pull bgozl/tibiantis-scraper:master` z laptopa działa **anonymous** (no `docker login` needed for public repo).
 
 ### 🧠 Czego się nauczysz
 
 - **Docker Hub public repos** — anonymous pull works bez auth (default), idealny dla VPS deploy gdy nie chcesz `docker login` na każdej VM. Rate limit 100/6h anonymous, 200/6h authenticated.
 - **Docker Hub PAT scoping** — Personal Access Tokens w Docker Hub mogą być scoped do specific repos (Read, Write, Delete) zamiast account-wide. Best practice: least privilege per service.
 - **`docker/login-action@v3` default registry** — bez `registry:` directive, action defaults to `index.docker.io` (Docker Hub). Wystarczy podać `username` + `password` (PAT).
-- **`docker/metadata-action@v5` image naming** — `images: bgozlinski/tibiantis-scraper` (bez `docker.io/` prefix, choć też działa). Auto-resolves jako `index.docker.io/bgozlinski/tibiantis-scraper`.
+- **`docker/metadata-action@v5` image naming** — `images: bgozl/tibiantis-scraper` (bez `docker.io/` prefix, choć też działa). Auto-resolves jako `index.docker.io/bgozl/tibiantis-scraper`.
 - **GitHub package deletion via `gh api`** — `gh api -X DELETE user/packages/container/<name>` nuke całego package + wszystkich versions. Alternative: per-version delete `gh api -X DELETE user/packages/container/<name>/versions/<id>`.
 
 ### ✅ Acceptance criteria
@@ -123,8 +123,8 @@ Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + i
 **Kluczowe punkty:**
 
 - **Pre-PR manual ops:**
-  - Generate Docker Hub PAT (https://hub.docker.com/settings/security) z scope **Read + Write + Delete** dla `bgozlinski/tibiantis-scraper` only
-  - `gh secret set DOCKERHUB_USERNAME --body "bgozlinski"`
+  - Generate Docker Hub PAT (https://hub.docker.com/settings/security) z scope **Read + Write + Delete** dla `bgozl/tibiantis-scraper` only
+  - `gh secret set DOCKERHUB_USERNAME --body "bgozl"`
   - `gh secret set DOCKERHUB_TOKEN --body "<paste-PAT>"`
   - Verify: `gh secret list` → shows both
 
@@ -133,29 +133,29 @@ Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + i
   - Usuń `registry: ghcr.io` z login-action
   - Replace `${{ secrets.GITHUB_TOKEN }}` z `${{ secrets.DOCKERHUB_TOKEN }}`
   - Replace `username: ${{ github.actor }}` z `username: ${{ secrets.DOCKERHUB_USERNAME }}`
-  - Replace `images: ghcr.io/${{ github.repository }}` z `images: bgozlinski/tibiantis-scraper`
+  - Replace `images: ghcr.io/${{ github.repository }}` z `images: bgozl/tibiantis-scraper`
 
 - **`docker-compose.yml`** 5× swap:
-  - `migrate.image`, `web.image`, `celery_worker.image`, `celery_beat.image`, `discord_bot.image`: `ghcr.io/bgozlinski/tibiantis-scraper:master` → `bgozlinski/tibiantis-scraper:master`
+  - `migrate.image`, `web.image`, `celery_worker.image`, `celery_beat.image`, `discord_bot.image`: `ghcr.io/bgozl/tibiantis-scraper:master` → `bgozl/tibiantis-scraper:master`
 
 - **Post-PR cleanup:**
   - `gh api -X DELETE user/packages/container/tibiantis-scraper` (nuke ghcr.io)
-  - Sanity: `curl -fsS https://hub.docker.com/v2/repositories/bgozlinski/tibiantis-scraper/` → 200 + JSON with `pull_count > 0` (po pierwszym push)
+  - Sanity: `curl -fsS https://hub.docker.com/v2/repositories/bgozl/tibiantis-scraper/` → 200 + JSON with `pull_count > 0` (po pierwszym push)
 
 - **Optional cleanup:** revert workflow permissions `gh api -X PUT repos/.../actions/permissions/workflow -f default_workflow_permissions=read` (M9-D44 flipped na "write" dla ghcr.io; Docker Hub nie wymaga)
 
 - **Manual smoke (post-master-merge):**
   - GHA workflow log → "Logging in to docker.io" → "Login Succeeded"
-  - GHA workflow log → `bgozlinski/tibiantis-scraper:master` + `bgozlinski/tibiantis-scraper:sha-<commit>` w tags
-  - `docker pull bgozlinski/tibiantis-scraper:master` z laptopa **bez `docker login`** → success
-  - Verify w UI: `https://hub.docker.com/r/bgozlinski/tibiantis-scraper` → public + tags visible
+  - GHA workflow log → `bgozl/tibiantis-scraper:master` + `bgozl/tibiantis-scraper:sha-<commit>` w tags
+  - `docker pull bgozl/tibiantis-scraper:master` z laptopa **bez `docker login`** → success
+  - Verify w UI: `https://hub.docker.com/r/bgozl/tibiantis-scraper` → public + tags visible
 
 ### ⚠️ Pułapki do uwagi
 
 - **A — PAT scope MUSI być Read + Write + Delete.** Read-only NIE pozwala na push z CI. Issue body D45 explicit czeck w pre-PR steps.
 - **B — Secrets names case-sensitive.** `DOCKERHUB_USERNAME` (NIE `dockerhub_username` ani `DOCKER_HUB_USERNAME`). Workflow YAML match exact.
-- **C — `images: bgozlinski/tibiantis-scraper`** bez `docker.io/` prefix (choć działa też z prefix). Lowercase username (Docker Hub case-insensitive ale convention lowercase).
-- **D — Image name już wzięty?** Pre-check: `curl -fsS https://hub.docker.com/v2/repositories/bgozlinski/tibiantis-scraper/` — jeśli 200 returned (existing repo), to nie ours (lub our previous attempt). Jeśli 404, available. Po pierwszym push → 200 z tags.
+- **C — `images: bgozl/tibiantis-scraper`** bez `docker.io/` prefix (choć działa też z prefix). Lowercase username (Docker Hub case-insensitive ale convention lowercase).
+- **D — Image name już wzięty?** Pre-check: `curl -fsS https://hub.docker.com/v2/repositories/bgozl/tibiantis-scraper/` — jeśli 200 returned (existing repo), to nie ours (lub our previous attempt). Jeśli 404, available. Po pierwszym push → 200 z tags.
 - **E — `default_workflow_permissions: "read"` post-revert** — Docker Hub workflow nie potrzebuje `packages: write`, ale ci.yml też nic z tym nie robi (tylko `contents: read`). Revert harmless. Można zostawić "write" — zero risk dla M9.5+M10.
 - **F — ghcr.io cleanup async** — `gh api -X DELETE` zwraca 204 No Content. Verify w UI: `https://github.com/bgozlinski?tab=packages` → tibiantis-scraper package gone (może chwilę).
 - **G — Workflow uses `paths:` filter na PR.** Zmiana `.github/workflows/docker.yml` triggers workflow na PR (file w `paths:` list). Sanity: workflow odpala się na PR D45 + zielony.
@@ -166,10 +166,10 @@ Zmienić registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + i
 ```bash
 # Pre-PR sanity
 gh secret list   # → DOCKERHUB_USERNAME + DOCKERHUB_TOKEN visible
-docker login -u bgozlinski -p <PAT>   # test PAT scope works
-docker pull busybox && docker tag busybox bgozlinski/tibiantis-scraper:smoke
-docker push bgozlinski/tibiantis-scraper:smoke   # smoke push przez PAT (delete tag after)
-docker rmi bgozlinski/tibiantis-scraper:smoke   # cleanup
+docker login -u bgozl -p <PAT>   # test PAT scope works
+docker pull busybox && docker tag busybox bgozl/tibiantis-scraper:smoke
+docker push bgozl/tibiantis-scraper:smoke   # smoke push przez PAT (delete tag after)
+docker rmi bgozl/tibiantis-scraper:smoke   # cleanup
 
 # Workflow YAML sanity
 yamllint .github/workflows/docker.yml
@@ -177,8 +177,8 @@ poetry run pre-commit run --files .github/workflows/docker.yml docker-compose.ym
 
 # Post-PR (po master merge)
 gh run watch <workflow-run-id>
-docker pull bgozlinski/tibiantis-scraper:master   # bez docker login
-docker image inspect bgozlinski/tibiantis-scraper:master --format '{{.Created}}'
+docker pull bgozl/tibiantis-scraper:master   # bez docker login
+docker image inspect bgozl/tibiantis-scraper:master --format '{{.Created}}'
 
 # Cleanup ghcr.io
 gh api "user/packages/container/tibiantis-scraper/versions" --jq '.[].name'   # list before delete
@@ -190,8 +190,8 @@ gh api -X DELETE "user/packages/container/tibiantis-scraper"
 - [ ] AC spełnione (workflow + compose updated, secrets w GitHub, ghcr.io package usunięty).
 - [ ] PR zmergowany squash (`chore(m9_5): swap ghcr.io → Docker Hub registry (M9.5-D45, #<#>)`).
 - [ ] CI lint + test + docker.yml workflow zielone.
-- [ ] Docker Hub repo public + visible at `https://hub.docker.com/r/bgozlinski/tibiantis-scraper`.
-- [ ] `docker pull bgozlinski/tibiantis-scraper:master` z laptopa anonymous = success.
+- [ ] Docker Hub repo public + visible at `https://hub.docker.com/r/bgozl/tibiantis-scraper`.
+- [ ] `docker pull bgozl/tibiantis-scraper:master` z laptopa anonymous = success.
 - [ ] ghcr.io package wiped.
 
 ---
@@ -542,7 +542,7 @@ D48 ma **2 PR-y w 1 issue** (M5-D27 + M6-D30 + M7-D35 + M8-D40 + M9-D44 pattern)
 5. **`docker compose build` przed `up -d --no-build` (M9-D43 lesson)**
    - Hybrid `image:` + `build:` pattern (5 services share image)
    - `docker compose up -d` z auto-build = parallel buildx → race na shared tag `:master`
-   - Symptom: `target X: failed to solve: image "bgozlinski/...:master": already exists`
+   - Symptom: `target X: failed to solve: image "bgozl/tibiantis-scraper:master": already exists`
    - Fix: split na 2 commands:
      1. `docker compose build` (single-shot, no race)
      2. `docker compose up -d --no-build` (uses cached image)

--- a/docs/superpowers/specs/2026-05-16-m9.5-hetzner-deploy-design.md
+++ b/docs/superpowers/specs/2026-05-16-m9.5-hetzner-deploy-design.md
@@ -11,10 +11,10 @@
 
 Po M9 mamy deployable artifact (pre-built Docker image w registry) i `docker-compose.yml` z 7 services + migrate one-shot. **Brak realnego deploy'u** — nikt nie uruchomił tego stack'a na production VM. M9.5 zamyka pętlę "działa w prod": aplikacja Tibiantis Monitor chodzi na realnej Hetzner VM (CX22 Falkenstein), Discord bot odbiera commands z dev guild, Celery beat scrapuje co X minut, `/health/` odpowiada 200 via SSH tunnel. Operator (Ty) ma dokumentowany runbook żeby powtórzyć deploy (lub rebuild VM) za miesiąc bez session-context.
 
-Plus M9.5 robi **registry swap ghcr.io → Docker Hub**: aktualnie M9 deployable artifact jest w `ghcr.io/bgozlinski/tibiantis-scraper:master`, ale user preferuje Docker Hub (anonymous pull z VM bez `docker login`, industry standard, prostszy auth flow).
+Plus M9.5 robi **registry swap ghcr.io → Docker Hub**: aktualnie M9 deployable artifact jest w `ghcr.io/bgozl/tibiantis-scraper:master`, ale user preferuje Docker Hub (anonymous pull z VM bez `docker login`, industry standard, prostszy auth flow).
 
 ### W zakresie M9.5:
-- **D45 Registry swap:** `.github/workflows/docker.yml` push do `docker.io/bgozlinski/tibiantis-scraper` (public repo, anonymous pull). `docker-compose.yml` 5× `image:` swap. GitHub Secrets `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (scoped PAT). Cleanup ghcr.io versions.
+- **D45 Registry swap:** `.github/workflows/docker.yml` push do `docker.io/bgozl/tibiantis-scraper` (public repo, anonymous pull). `docker-compose.yml` 5× `image:` swap. GitHub Secrets `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (scoped PAT). Cleanup ghcr.io versions.
 - **D46 VM provisioning + hardening:** Manual Hetzner Cloud Console setup (CX22 Falkenstein, Ubuntu 24.04, SSH key, Hetzner Cloud Firewall). `docs/scripts/bootstrap.sh` (deploy user + sudo + SSH hardening + UFW + Docker install). `docs/deploy-runbook.md` sections 1-3.
 - **D47 First deploy + monitoring:** Dorzucenie `uptime-kuma` jako 9. service w `docker-compose.yml` (port 3001 lokalny, SSH tunnel access). First manual deploy na VM (`docker compose pull && up -d`). 4 Kuma monitors (web /health/, postgres/redis/mongo TCP). Discord bot live test w dev guild. `docs/deploy-runbook.md` sections 4-10.
 - **D48 Closure:** `docs/dev-runbook.md` carry-over consolidation z M3-M9 (Windows gotchas, MSYS path, `docker compose build` race fix, Compose `$VAR` interpolation, `pre-commit clean` workflow, Celery `-P solo`). PROGRESS.md M9.5 retro section + milestone close.
@@ -57,7 +57,7 @@ Plus M9.5 robi **registry swap ghcr.io → Docker Hub**: aktualnie M9 deployable
                    │ (2) docker push :master + :sha-<commit>
                    ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│ Docker Hub: docker.io/bgozlinski/tibiantis-scraper (PUBLIC)     │
+│ Docker Hub: docker.io/bgozl/tibiantis-scraper (PUBLIC)     │
 │  Tags: :master (rolling) + :sha-c26d2f1 (audit)                 │
 │  Anonymous pull (no auth needed on VM)                          │
 └──────────────────┬──────────────────────────────────────────────┘
@@ -117,8 +117,8 @@ Plus M9.5 robi **registry swap ghcr.io → Docker Hub**: aktualnie M9 deployable
 - `PROGRESS.md` — M9.5 retro section (D48)
 
 **GitHub repo settings (manual via UI / `gh secret set`):**
-- Add secret `DOCKERHUB_USERNAME=bgozlinski`
-- Add secret `DOCKERHUB_TOKEN=<PAT scoped do bgozlinski/tibiantis-scraper z Read+Write+Delete>`
+- Add secret `DOCKERHUB_USERNAME=bgozl`
+- Add secret `DOCKERHUB_TOKEN=<PAT scoped do bgozl/tibiantis-scraper z Read+Write+Delete>`
 - (Optional post-D45) revert `default_workflow_permissions: "read"` — Docker Hub auth nie wymaga `packages: write`
 
 **Manual cleanup (post-D45 merge):**
@@ -152,15 +152,15 @@ jobs:
 
       - uses: docker/metadata-action@v5
         with:
-          images: bgozlinski/tibiantis-scraper   # ← BEZ "ghcr.io/" prefix
+          images: bgozl/tibiantis-scraper   # ← BEZ "ghcr.io/" prefix
           # tags pattern bez zmian (branch/semver/sha-short)
 ```
 
-**Compose `docker-compose.yml`** — 5× `image: bgozlinski/tibiantis-scraper:master` (zamiast `ghcr.io/bgozlinski/tibiantis-scraper:master`).
+**Compose `docker-compose.yml`** — 5× `image: bgozl/tibiantis-scraper:master` (zamiast `ghcr.io/bgozl/tibiantis-scraper:master`).
 
 **GitHub Secrets (manual pre-PR):**
-- `DOCKERHUB_USERNAME=bgozlinski`
-- `DOCKERHUB_TOKEN=<PAT>` z scope **Read + Write + Delete** dla `bgozlinski/tibiantis-scraper` only (NIE account-wide PAT — least privilege per Docker Hub access token UI)
+- `DOCKERHUB_USERNAME=bgozl`
+- `DOCKERHUB_TOKEN=<PAT>` z scope **Read + Write + Delete** dla `bgozl/tibiantis-scraper` only (NIE account-wide PAT — least privilege per Docker Hub access token UI)
 
 **Cleanup ghcr.io (post-merge):** `gh api -X DELETE user/packages/container/tibiantis-scraper` — nuke whole package + all versions.
 
@@ -336,7 +336,7 @@ volumes:
 5. **Smoke verification** — SSH tunnel + `curl /health/` + Uptime Kuma initial setup (4 monitors)
 6. **Discord bot live test** — `/bedmage add yhral` w dev guild + DB verify
 7. **Rolling update** — `cd /opt/tibiantis && docker compose pull && docker compose up -d` (po każdy nowy `:master` push z CI)
-8. **Rollback** — manual edit `docker-compose.yml` na `image: bgozlinski/tibiantis-scraper:sha-<old-commit>` + `docker compose up -d`. Lub `docker tag` workaround.
+8. **Rollback** — manual edit `docker-compose.yml` na `image: bgozl/tibiantis-scraper:sha-<old-commit>` + `docker compose up -d`. Lub `docker tag` workaround.
 9. **Troubleshooting** — top 10 typowych issues:
    - SECRET_KEY z `$` (M9-D43 lesson)
    - Operator zapomniał `chmod 600 .env`
@@ -384,10 +384,10 @@ volumes:
 
 | Failure | Detection | Recovery |
 |---|---|---|
-| PAT expired / wrong scope | Workflow log "Login Failed" | Regenerate PAT z Read+Write+Delete scope dla `bgozlinski/tibiantis-scraper`, `gh secret set DOCKERHUB_TOKEN` |
+| PAT expired / wrong scope | Workflow log "Login Failed" | Regenerate PAT z Read+Write+Delete scope dla `bgozl/tibiantis-scraper`, `gh secret set DOCKERHUB_TOKEN` |
 | Secret missing | Workflow log "Username and password required" | `gh secret list` confirm + re-set |
 | Rate limit (push) | Docker Hub 429 | Authenticated push limit jest hojny (1000/6h), nie powinno trafić w M9.5 |
-| Image name collision | `bgozlinski/tibiantis-scraper` ktoś inny ma | Free name lub change to `bgozlinski-tib/tibiantis-scraper` (verified available przez Docker Hub UI) |
+| Image name collision | `bgozl/tibiantis-scraper` ktoś inny ma | Free name lub change to `bgozl-tib/tibiantis-scraper` (verified available przez Docker Hub UI) |
 
 ### §5.2 D46 — VM provisioning issues
 
@@ -403,7 +403,7 @@ volumes:
 
 | Failure | Detection | Recovery |
 |---|---|---|
-| `docker compose pull` rate limit (Docker Hub anonymous) | 429 / "toomanyrequests" | `docker login -u bgozlinski -p <PAT>` na VM bypassuje (200/6h) |
+| `docker compose pull` rate limit (Docker Hub anonymous) | 429 / "toomanyrequests" | `docker login -u bgozl -p <PAT>` na VM bypassuje (200/6h) |
 | `.env` SECRET_KEY z `$` | Compose warnings + Django ImproperlyConfigured | Regenerate alphanumeric per §3.7 |
 | `.env` brakuje wymaganego var (np. `DJANGO_SECRET_KEY`) | Container `ImproperlyConfigured: Set the X environment variable` | Edit `.env`, `docker compose down + up -d` |
 | Postgres data corruption (rare) | Migrate fails / web crashes | `docker compose down -v` + restart (data loss — fresh DB) lub manual `pg_dump` restore |
@@ -414,7 +414,7 @@ volumes:
 
 | Failure | Detection | Recovery |
 |---|---|---|
-| New image broken (pull works, container crashes) | `docker compose ps` shows web Restarting | Pinned rollback: edit `docker-compose.yml` `image: bgozlinski/tibiantis-scraper:sha-<previous>` + `docker compose up -d` |
+| New image broken (pull works, container crashes) | `docker compose ps` shows web Restarting | Pinned rollback: edit `docker-compose.yml` `image: bgozl/tibiantis-scraper:sha-<previous>` + `docker compose up -d` |
 | Migration fail (new schema breaks rollback) | `migrate` exit 1 in logs | Operator decides: fix forward (CI new build z fix) lub manual `docker compose exec web python manage.py migrate <app> <prev-migration>` (risky, data implications) |
 | `docker compose pull` slow / hang | Network issue Hetzner ↔ Docker Hub | Retry, check status.docker.com |
 
@@ -469,7 +469,7 @@ Po M9.5 closure: optional "from-zero rebuild test" — operator wykonuje runbook
 **D45:**
 - [ ] PR zmergowany (`chore(ci): swap ghcr.io → Docker Hub registry (M9.5-D45, #<#>)`)
 - [ ] CI lint + test + docker.yml workflow zielone
-- [ ] `docker pull bgozlinski/tibiantis-scraper:master` z laptopa anonymous = success
+- [ ] `docker pull bgozl/tibiantis-scraper:master` z laptopa anonymous = success
 - [ ] ghcr.io package usunięty (`gh api -X DELETE ...`)
 
 **D46:**
@@ -511,10 +511,10 @@ W closure PR body (D48), zacytuj wyniki (verbatim transcript lub screenshots):
 
 1. **Registry swap verify:**
    ```bash
-   docker pull bgozlinski/tibiantis-scraper:master   # bez docker login
-   docker image inspect bgozlinski/tibiantis-scraper:master --format '{{.Created}}'
+   docker pull bgozl/tibiantis-scraper:master   # bez docker login
+   docker image inspect bgozl/tibiantis-scraper:master --format '{{.Created}}'
    ```
-   → success, image visible at https://hub.docker.com/r/bgozlinski/tibiantis-scraper
+   → success, image visible at https://hub.docker.com/r/bgozl/tibiantis-scraper
 
 2. **VM hardening verify:**
    ```bash


### PR DESCRIPTION
Pre-D45 chore: poprawia Docker Hub username w M9.5 planning artifacts. User's Docker Hub username to **bgozl** (5 chars), różny od GitHub username **bgozlinski** (10 chars).

## Summary

5 files updated z `bgozlinski/tibiantis-scraper` → `bgozl/tibiantis-scraper` (Docker Hub context only):

- `docs/superpowers/specs/2026-05-16-m9.5-hetzner-deploy-design.md`
- `docs/superpowers/plans/2026-05-16-m9.5-implementation-plan.md`
- `.github/issue-bodies/m9_5-d45.md`
- `.github/issue-bodies/m9_5-d47.md`
- `.github/issue-bodies/m9_5-d48.md`

D46 issue body bez zmian (no Docker Hub refs — tylko hardening + bootstrap.sh).

## Co dokładnie zmienione

- `image: bgozlinski/tibiantis-scraper` → `image: bgozl/tibiantis-scraper` (compose YAML examples w spec/plan/issues)
- `DOCKERHUB_USERNAME=bgozlinski` → `DOCKERHUB_USERNAME=bgozl` (secret value)
- `docker.io/bgozlinski/tibiantis-scraper` → `docker.io/bgozl/tibiantis-scraper`
- `hub.docker.com/r/bgozlinski/tibiantis-scraper` → `hub.docker.com/r/bgozl/tibiantis-scraper`
- `docker login -u bgozlinski` → `docker login -u bgozl`
- `docker pull bgozlinski/...` / `docker push bgozlinski/...` / `docker tag bgozlinski/...` etc.
- PAT scope text (`dla bgozlinski/tibiantis-scraper only` → `dla bgozl/tibiantis-scraper only`)
- sed substitution patterns w rollback section (D47 + D48)
- Error message quote w plan §5 (Docker compose build race)

## Co NIE zmienione (GitHub URLs zostają)

- `https://github.com/bgozlinski/tibiantis-scraper.git` (D48 git clone reference)
- `https://raw.githubusercontent.com/bgozlinski/tibiantis-scraper/...` (D47 + spec + plan, 8 occurrences total)
- `gh api repos/bgozlinski/tibiantis-scraper/...` GitHub API paths (spec, plan, D45, D48)
- `https://github.com/bgozlinski?tab=packages` (D45 + plan, ghcr.io cleanup UI link)
- ASCII diagram `Repo bgozlinski/tibiantis-scraper (public)` w spec §2 GitHub block

## Co NIE w scope tego PR (do D45)

- `.github/workflows/docker.yml` — registry swap (`registry: ghcr.io` removed + secrets-based auth + images directive change) → D45 actual work
- `docker-compose.yml` — 5× `image:` swap → D45 actual work

Te dwie zmiany NIE należą do dokumentacji-only chore — są code changes D45 scope.

## Test plan

- [x] Wszystkie Docker Hub references w M9.5 docs zaktualizowane na `bgozl`
- [x] Wszystkie GitHub URLs intact (verified via final `grep bgozlinski`)
- [x] Pre-commit clean (mixed-line-ending auto-fix + reszta passed)
- [x] D46 untouched (no Docker Hub refs)
- [x] Workflow + compose untouched (D45 scope, NIE ten PR)
- [ ] CI lint green
- [ ] Po merge: D45 może startować, operator generuje PAT dla `bgozl/tibiantis-scraper` repo + sets secrets z `bgozl` username