### PR TITLE
chore(m9_5): swap ghcr.io → Docker Hub registry (M9.5-D45, #154)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -31,14 +30,13 @@ jobs:
       - uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: bgozl/tibiantis-scraper
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
   # ─── Migration (one-shot) ─────────────────────────────────────────
 
   migrate:
-    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    image: bgozl/tibiantis-scraper:master
     build: .
     env_file: .env
     command: python manage.py migrate --noinput
@@ -51,7 +51,7 @@ services:
   # ─── Application services (shared image) ──────────────────────────
 
   web:
-    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    image: bgozl/tibiantis-scraper:master
     build: .
     env_file: .env
     command:
@@ -81,7 +81,7 @@ services:
     restart: unless-stopped
 
   celery_worker:
-    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    image: bgozl/tibiantis-scraper:master
     build: .
     env_file: .env
     command:
@@ -107,7 +107,7 @@ services:
     restart: unless-stopped
 
   celery_beat:
-    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    image: bgozl/tibiantis-scraper:master
     build: .
     env_file: .env
     command:
@@ -136,7 +136,7 @@ services:
     restart: unless-stopped
 
   discord_bot:
-    image: ghcr.io/bgozlinski/tibiantis-scraper:master
+    image: bgozl/tibiantis-scraper:master
     build: .
     env_file: .env
     command: python manage.py run_discord_bot


### PR DESCRIPTION
Closes #154 (first M9.5 task — Docker Hub registry as deployable artifact source).

## Summary

Swap container registry z `ghcr.io` na `docker.io` (Docker Hub) — workflow login + image name, plus `docker-compose.yml` 5× `image:` references. Po D45: każdy push do master triggeruje GHA workflow → push obrazu do `docker.io/bgozl/tibiantis-scraper:master` + `:sha-<commit>`. Anonymous pull z VM/laptopa działa (public Docker Hub repo).

## Changes

**`.github/workflows/docker.yml`** (3 changes):
- Removed `packages: write` permission (Docker Hub używa secrets, nie GITHUB_TOKEN)
- Removed `registry: ghcr.io` directive (Docker Hub default registry)
- Auth changed: `${{ secrets.GITHUB_TOKEN }}` / `${{ github.actor }}` → `${{ secrets.DOCKERHUB_TOKEN }}` / `${{ secrets.DOCKERHUB_USERNAME }}`
- Images directive: `ghcr.io/${{ github.repository }}` → `bgozl/tibiantis-scraper`

**`docker-compose.yml`** (5 services share image):
- `migrate`, `web`, `celery_worker`, `celery_beat`, `discord_bot` — `image:` swapped z `ghcr.io/bgozlinski/tibiantis-scraper:master` na `bgozl/tibiantis-scraper:master`
- `build: .` directive zostaje (hybrid pattern dla local iteration)

## Pre-PR ops (done by operator)

- [x] Docker Hub PAT generated z scope **Read + Write + Delete** dla `bgozl/tibiantis-scraper` only
- [x] `gh secret set DOCKERHUB_USERNAME --body "bgozl"`
- [x] `gh secret set DOCKERHUB_TOKEN --body "<PAT>"`
- [x] `docker login -u bgozl` test → "Login Succeeded"

## Pre-merge sanity

- [x] `docker compose -f docker-compose.yml config --quiet` → exit 0 (warnings o `$v4`/`$zj6` w `.env` SECRET_KEY — local M9-D43 known gotcha, NIE compose error)
- [x] Pre-commit lokalne clean
- [ ] CI lint + test + docker.yml workflow zielone (this PR — PR build mode, no push)

## Post-merge plan

1. **Master push triggers** `docker.yml` workflow w push mode:
   - `docker/login-action@v3` → "Logging in to docker.io" → "Login Succeeded"
   - `docker/build-push-action@v6` z `push: true` → push do `bgozl/tibiantis-scraper:master` + `:sha-<commit>`
2. **Operator verifies:**
   ```bash
   docker logout   # ensure no cached auth
   docker pull bgozl/tibiantis-scraper:master   # anonymous public pull
   ```
   → success
3. **Cleanup ghcr.io package:**
   ```bash
   gh api -X DELETE "user/packages/container/tibiantis-scraper"
   ```
   → 204 No Content. Sanity: https://github.com/bgozlinski?tab=packages → tibiantis-scraper gone.
4. **(Optional) Revert workflow permissions** z `"write"` na `"read"` — Docker Hub auth nie wymaga `packages: write`. Zostaw lub revert, zero risk.

## Test plan

- [x] Workflow YAML changes per AC (3 modifications)
- [x] Compose 5× image swap (migrate + web + celery_worker + celery_beat + discord_bot)
- [x] `docker compose config --quiet` exit 0
- [x] Pre-PR auth test `docker login -u bgozl` → success
- [ ] CI workflow zielony (PR build mode, no Docker Hub push)
- [ ] Post-merge: workflow run "Login Succeeded" + image visible at https://hub.docker.com/r/bgozl/tibiantis-scraper
- [ ] Post-merge: anonymous `docker pull bgozl/tibiantis-scraper:master` works
- [ ] Post-merge: ghcr.io package nuked