### PR TITLE
docs(m9_5): runbook sections 1-3 + bootstrap.sh hardening script (M9.5-D46, #155)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ ENV/
 [Ll]ib64
 [Ll]ocal
 [Ss]cripts
+!docs/scripts/
 pyvenv.cfg
 .venv
 pip-selfcheck.json

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -48,11 +48,15 @@ Estimated cost: **~6€/mc** (Hetzner CX22 + free Docker Hub public + free GHA p
    ssh root@<hetzner-ip>
    # Confirm SSH key auth works (no password prompt)
    ```
-3. Run bootstrap:
+3. Run bootstrap (~3-5 min on CX22; prints `[1/8]`..`[8/8]` step markers):
    ```bash
    bash /tmp/bootstrap.sh
    # Check output ends with "Bootstrap complete. SSH as deploy@<ip>..."
    ```
+   The script replaces the snap-installed Docker (pre-shipped on Hetzner Ubuntu 24.04
+   minimal — strict confinement + auto-refresh are production hazards) with docker-ce
+   via the official `get.docker.com` script, then asserts UFW + deploy + docker
+   state before declaring success.
 4. Verify hardening (from laptop, new terminal):
    ```bash
    ssh deploy@<hetzner-ip>           # should work

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -1,0 +1,67 @@
+# Tibiantis Monitor — Deploy runbook
+
+This runbook walks operator through first deploy of Tibiantis Monitor
+on Hetzner VM. Estimated time: ~1h end-to-end for someone with SSH + Docker
+familiarity. Updated after each milestone change.
+
+## §1 Prerequisites
+
+Before starting:
+- [ ] Hetzner Cloud account (https://console.hetzner.cloud) z payment method
+- [ ] Local SSH key pair: `~/.ssh/id_ed25519` (existing) or `ssh-keygen -t ed25519 -C "tibiantis-deploy"`
+- [ ] Discord bot token (Developer Portal, M7 setup) — paste later na VM
+- [ ] (Optional) Docker Hub account dla pull rate limit bypass z `docker login`
+
+Estimated cost: **~6€/mc** (Hetzner CX22 + free Docker Hub public + free GHA public)
+
+## §2 Provision VM
+
+1. Cloud Console → Projects → "Add Project" → `tibiantis-monitor`
+2. Sidebar → "Security" → "SSH Keys" → Add → paste `~/.ssh/id_ed25519.pub`
+3. Sidebar → "Servers" → "Add Server"
+   - Location: **Falkenstein DE-FSN** (~30ms z PL)
+   - Image: **Ubuntu 24.04**
+   - Type: **CX22** (~6€/mc, 2 vCPU shared, 4GB RAM, 40GB SSD)
+   - Networking: Public IPv4 + IPv6 (default)
+   - SSH Keys: select your uploaded key
+   - Firewall: leave empty for now (Firewall added next step)
+   - Cloud Config: none
+   - Volumes: none
+   - Backups: disabled
+   - Labels: `env=prod`, `project=tibiantis`
+   - Create & start server, **capture public IPv4 address**.
+4. Sidebar → "Firewalls" → "Create Firewall" → `tibiantis-firewall`
+   - Inbound rules:
+     - Allow TCP 22 from `<your-IPv4>/32` (check via `curl ipify.org`)
+     - Allow ICMP from `0.0.0.0/0` (ping/traceroute debug)
+   - Outbound rules: allow all (default)
+   - Apply to: server created step 3
+
+## §3 First SSH + bootstrap
+
+1. From laptop:
+   ```bash
+   scp docs/scripts/bootstrap.sh root@<hetzner-ip>:/tmp/
+   ```
+2. SSH as root:
+   ```bash
+   ssh root@<hetzner-ip>
+   # Confirm SSH key auth works (no password prompt)
+   ```
+3. Run bootstrap:
+   ```bash
+   bash /tmp/bootstrap.sh
+   # Check output ends with "Bootstrap complete. SSH as deploy@<ip>..."
+   ```
+4. Verify hardening (from laptop, new terminal):
+   ```bash
+   ssh deploy@<hetzner-ip>           # should work
+   ssh -o PreferredAuthentications=password root@<hetzner-ip>   # "Permission denied"
+   ```
+5. On VM as deploy:
+   ```bash
+   docker ps                          # empty list, no errors (Docker accessible via group membership)
+   sudo ufw status verbose            # 22/tcp ALLOW, default deny incoming
+   ```
+
+Next: §4 First deploy (covered in M9.5-D47).

--- a/docs/scripts/bootstrap.sh
+++ b/docs/scripts/bootstrap.sh
@@ -1,43 +1,78 @@
 #!/bin/bash
 set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
 
-# 1. Backup sshd_config (defensive — sed -i bez backup ryzykowne)
-cp /etc/ssh/sshd_config /etc/ssh/sshd_config.bak
+APT_OPTS=(-o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold)
 
-# 2. Create deploy user
-useradd -m -s /bin/bash -G sudo deploy
+# 1. apt update + upgrade FIRST — before sshd_config edits, so openssh-server
+#    upgrade can't trigger a dpkg merge prompt that silently aborts the script.
+echo "[1/8] apt update + upgrade"
+apt-get update -qq
+apt-get "${APT_OPTS[@]}" -y upgrade
+apt-get "${APT_OPTS[@]}" -y autoremove
+
+# 2. Backup sshd_config (defensive — sed -i bez backup ryzykowne)
+echo "[2/8] backup sshd_config"
+cp -f /etc/ssh/sshd_config /etc/ssh/sshd_config.bak
+
+# 3. Create deploy user (idempotent — re-run safe)
+echo "[3/8] create deploy user"
+id -u deploy >/dev/null 2>&1 || useradd -m -s /bin/bash -G sudo deploy
 mkdir -p /home/deploy/.ssh
-cp /root/.ssh/authorized_keys /home/deploy/.ssh/
+cp -f /root/.ssh/authorized_keys /home/deploy/.ssh/
 chown -R deploy:deploy /home/deploy/.ssh
 chmod 700 /home/deploy/.ssh
 chmod 600 /home/deploy/.ssh/authorized_keys
 
-# 3. Sudo bez hasła (single operator + key-only SSH = OK; M-future ograniczyć do docker)
+# 4. Sudo bez hasła (single operator + key-only SSH = OK; M-future ograniczyć do docker)
+echo "[4/8] sudo NOPASSWD for deploy"
 echo "deploy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/deploy
 chmod 440 /etc/sudoers.d/deploy
 
-# 4. SSH hardening
+# 5. SSH hardening
+echo "[5/8] SSH hardening"
 sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
 sed -i 's/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
 sed -i 's/^#*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
-systemctl reload sshd
+# Ubuntu/Debian: ssh.service. RHEL/CentOS: sshd.service. Try both for portability.
+systemctl reload ssh.service 2>/dev/null \
+    || systemctl reload sshd.service 2>/dev/null \
+    || { echo "ERROR: cannot reload SSH (tried ssh.service + sshd.service)"; exit 1; }
 
-# 5. UFW (layer 2 ponad Hetzner Cloud Firewall — defense-in-depth)
+# 6. UFW (layer 2 ponad Hetzner Cloud Firewall — defense-in-depth)
+#    `ufw allow 22/tcp` MUSI być przed `ufw --force enable` — preventowanie SSH lockout.
+echo "[6/8] UFW"
 ufw default deny incoming
 ufw default allow outgoing
 ufw allow 22/tcp comment 'SSH'
 # 8000/3001 NIE allow w UFW — dostęp przez SSH tunnel
 ufw --force enable
 
-# 6. Docker install (official script — convenience > apt-get docker.io which lags versions)
+# 7. Docker — Hetzner Ubuntu 24.04 minimal pre-installs Docker via snap.
+#    Snap docker has strict confinement (breaks bind mounts) and auto-refresh
+#    (restarts dockerd unannounced) — both production hazards. Replace with docker-ce.
+echo "[7/8] Docker (remove snap docker if present, install docker-ce)"
+if snap list docker >/dev/null 2>&1; then
+    echo "  detected snap docker, removing..."
+    snap remove docker
+fi
 curl -fsSL https://get.docker.com | sh
 usermod -aG docker deploy
 systemctl enable --now docker
 
-# 7. apt updates baseline
-apt-get update
-apt-get upgrade -y
-apt-get autoremove -y
+# 8. Final verification — assert critical post-conditions. If any fails, exit
+#    non-zero so the operator sees the failure instead of a fake "complete" line.
+echo "[8/8] verify"
+ufw status verbose | grep -q "Status: active" \
+    || { echo "ERROR: UFW not active"; exit 1; }
+ufw status | grep -qE "^22/tcp\s+ALLOW" \
+    || { echo "ERROR: UFW 22/tcp ALLOW missing"; exit 1; }
+id deploy | grep -qE '\bdocker\b' \
+    || { echo "ERROR: deploy not in docker group"; exit 1; }
+systemctl is-active --quiet docker \
+    || { echo "ERROR: docker.service not running"; exit 1; }
+grep -qE '^PasswordAuthentication no' /etc/ssh/sshd_config \
+    || { echo "ERROR: sshd PasswordAuthentication not disabled"; exit 1; }
 
 echo "Bootstrap complete. SSH as deploy@<ip> from now on."
 echo "Verify: ssh deploy@<ip>, then 'docker ps' should work."

--- a/docs/scripts/bootstrap.sh
+++ b/docs/scripts/bootstrap.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+# 1. Backup sshd_config (defensive — sed -i bez backup ryzykowne)
+cp /etc/ssh/sshd_config /etc/ssh/sshd_config.bak
+
+# 2. Create deploy user
+useradd -m -s /bin/bash -G sudo deploy
+mkdir -p /home/deploy/.ssh
+cp /root/.ssh/authorized_keys /home/deploy/.ssh/
+chown -R deploy:deploy /home/deploy/.ssh
+chmod 700 /home/deploy/.ssh
+chmod 600 /home/deploy/.ssh/authorized_keys
+
+# 3. Sudo bez hasła (single operator + key-only SSH = OK; M-future ograniczyć do docker)
+echo "deploy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/deploy
+chmod 440 /etc/sudoers.d/deploy
+
+# 4. SSH hardening
+sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+sed -i 's/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+sed -i 's/^#*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
+systemctl reload sshd
+
+# 5. UFW (layer 2 ponad Hetzner Cloud Firewall — defense-in-depth)
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow 22/tcp comment 'SSH'
+# 8000/3001 NIE allow w UFW — dostęp przez SSH tunnel
+ufw --force enable
+
+# 6. Docker install (official script — convenience > apt-get docker.io which lags versions)
+curl -fsSL https://get.docker.com | sh
+usermod -aG docker deploy
+systemctl enable --now docker
+
+# 7. apt updates baseline
+apt-get update
+apt-get upgrade -y
+apt-get autoremove -y
+
+echo "Bootstrap complete. SSH as deploy@<ip> from now on."
+echo "Verify: ssh deploy@<ip>, then 'docker ps' should work."


### PR DESCRIPTION
## Summary

- `docs/scripts/bootstrap.sh` — single-shot provisioning script: apt baseline, deploy user + SSH key, sudo NOPASSWD, SSH hardening (PasswordAuthentication no, PermitRootLogin prohibit-password, ChallengeResponseAuthentication no), UFW (default deny incoming, 22/tcp ALLOW), Docker via `get.docker.com` (after removing Hetzner's preinstalled snap docker), final 5-assertion verify block.
- `docs/deploy-runbook.md` — sections §1 Prerequisites, §2 Provision VM (Hetzner Cloud Console clicks: project, SSH key, CX22 Falkenstein, Cloud Firewall), §3 First SSH + bootstrap. §4 deferred to D47.
- `.gitignore` — `!docs/scripts/` exception (the virtualenv `[Ss]cripts` ignore pattern was swallowing `docs/scripts/bootstrap.sh`).

Three bugs in the originally-spec'd script were found via cold-start testing on a fresh CX22 and fixed in the follow-up commit (3f1a4b2):

1. **snap docker on Hetzner minimal image** — `curl get.docker.com | sh` silently skipped when snap docker was preinstalled. Added detect + `snap remove docker` first. Snap docker's strict confinement (breaks bind mounts) and auto-refresh (restarts dockerd unannounced) are production hazards.
2. **dpkg merge prompt** — original ordering ran `apt-get upgrade` *after* `sed -i` on sshd_config, which triggered dpkg's "your config has been modified, merge?" prompt that silently aborted the script (leaving UFW disabled and deploy without docker group, but with no error visible). Moved upgrade to step 1, added `DEBIAN_FRONTEND=noninteractive` + `--force-confold`.
3. **`systemctl reload sshd`** — that unit name is Red Hat convention. Ubuntu 24.04 uses `ssh.service`. Portable fallback added.

Also: `[X/8]` step markers (partial-failure visibility), idempotency guards, exit-on-postcondition-failure.

## Operator confirmation

VM: Hetzner CX22, Falkenstein DE-FSN, Ubuntu 24.04 minimal. IPv4 captured (not in repo).

**Bootstrap end-to-end (cold start on fresh VM):**
```
$ ssh root@<ip> "bash /tmp/bootstrap.sh"
[1/8] apt update + upgrade           # linux-tools-common 111 → 117, kernel held back (OK)
[2/8] backup sshd_config
[3/8] create deploy user
[4/8] sudo NOPASSWD for deploy
[5/8] SSH hardening                  # systemctl reload ssh.service: OK
[6/8] UFW                            # default deny incoming, 22/tcp ALLOW, --force enable: OK
[7/8] Docker (remove snap docker if present, install docker-ce)
                                     # docker-ce 29.5.0 installed, docker.service active
[8/8] verify                         # all 5 assertions passed
Bootstrap complete. SSH as deploy@<ip> from now on.
Verify: ssh deploy@<ip>, then 'docker ps' should work.
```

**Deploy-user verification (from laptop, new SSH session):**
```
$ ssh deploy@<ip> "whoami && groups && docker ps && sudo ufw status verbose"
deploy
deploy sudo docker
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
Status: active
Logging: on (low)
Default: deny (incoming), allow (outgoing), deny (routed)
New profiles: skip

To                         Action      From
--                         ------      ----
22/tcp                     ALLOW IN    Anywhere                   # SSH
22/tcp (v6)                ALLOW IN    Anywhere (v6)              # SSH
```

**Password-auth denied (from laptop):**
```
$ ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no root@<ip>
root@<ip>: Permission denied (publickey).
```

## Test plan

- [x] `bash -n docs/scripts/bootstrap.sh` — syntax OK
- [x] `poetry run pre-commit run --files docs/scripts/bootstrap.sh docs/deploy-runbook.md` — clean
- [x] Cold-start execution on fresh Hetzner CX22 — completed all 8 steps without manual intervention
- [x] AC verification as deploy user (groups, docker ps, ufw status verbose)
- [x] AC verification: password auth denied for root
- [x] CI `lint` job green (no Python tests impact)

Closes #155