### PR TITLE
feat(m9_5): Uptime Kuma + first prod deploy on Hetzner (M9.5-D47, #156)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,8 +151,19 @@ services:
       disable: true
     restart: unless-stopped
 
+  # ─── Monitoring ───────────────────────────────────────────────────
+
+  uptime-kuma:
+    image: louislam/uptime-kuma:1
+    volumes:
+      - uptime_kuma_data:/app/data
+    ports:
+      - "127.0.0.1:3001:3001"
+    restart: unless-stopped
+    # No healthcheck — Kuma monitors others, not itself.
 
 
 volumes:
   postgres_data:
   mongo_data:
+  uptime_kuma_data:

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -98,9 +98,10 @@ python3 -c "import string, secrets; print(''.join(secrets.choice(string.ascii_le
 
 Edit `.env`:
 - `DJANGO_SECRET_KEY=<generated 50-char alphanumeric>`
-- `POSTGRES_PASSWORD=<random>` (e.g. `openssl rand -base64 32` — but verify no `$` chars, regenerate if so)
+- `POSTGRES_PASSWORD=<32-char alphanumeric>` (regenerate with the snippet above — alphanumeric avoids both compose `$VAR` interpolation AND URL-encoding inside `DATABASE_URL`)
+- **`DATABASE_URL=postgres://tibiantis:<same-as-POSTGRES_PASSWORD>@postgres:5432/tibiantis`** — the password appears twice; both must match exactly, or migrate exits 1 with `password authentication failed for user "tibiantis"`. Tech debt: should be DRY-constructed in `config/settings/prod.py` from individual `POSTGRES_*` vars (follow-up issue).
 - `DISCORD_BOT_TOKEN=<real token from Discord Developer Portal>`
-- `DJANGO_ALLOWED_HOSTS=<hetzner-ipv4>,localhost`
+- `DJANGO_ALLOWED_HOSTS=<hetzner-ipv4>,localhost,web` — `web` is required so Uptime Kuma's internal-DNS monitor (`http://web:8000/health/`) doesn't get rejected by Django with `DisallowedHost`.
 
 ### 4.4 Pull + up
 
@@ -261,6 +262,25 @@ Option A leaves the rollback visible in the compose file (good for incident time
 
 **Symptom:** SSH works on VM console but external SSH connections fail.
 **Fix:** Cloud Console → Firewall → check inbound TCP 22 rule against your current ISP IP (`curl ipify.org`). Update CIDR if it changed.
+
+### 9.11 Kuma `web /health/` monitor red while curl from host works
+
+**Symptom:** All TCP monitors (postgres/redis/mongo) green, but the HTTP monitor `http://web:8000/health/` stays red.
+**Cause:** Django's `ALLOWED_HOSTS` rejects requests with `Host: web:8000` because `web` is the docker service name, not a host Django recognizes — Django returns HTTP 400 `DisallowedHost`, Kuma sees not-200.
+**Fix:** add `web` to `DJANGO_ALLOWED_HOSTS` in `.env`, then `docker compose up -d --force-recreate web`. The monitor recovers on the next 60s interval — no need to recreate it.
+
+### 9.12 migrate exit 1: password authentication failed
+
+**Symptom:** `docker compose logs migrate` ends with `psycopg.OperationalError: ... password authentication failed for user "tibiantis"`. Web/celery/bot stay in `Created` state.
+**Cause:** `POSTGRES_PASSWORD` and the password embedded inside `DATABASE_URL` in `.env` don't match. Postgres initialized its data volume with the value of `POSTGRES_PASSWORD` on first boot; Django connects using `DATABASE_URL`.
+**Fix:**
+```bash
+docker compose down
+docker volume rm tibiantis_postgres_data    # ONLY safe before any real data exists
+# Edit .env: make sure POSTGRES_PASSWORD and the password inside DATABASE_URL match exactly
+docker compose up -d
+```
+If postgres has real data, do NOT drop the volume — instead, edit `DATABASE_URL` in `.env` to match the password postgres was initialized with, and `docker compose up -d --force-recreate web migrate celery_worker celery_beat discord_bot`.
 
 ## §10 Cost tally
 

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -68,4 +68,212 @@ Estimated cost: **~6€/mc** (Hetzner CX22 + free Docker Hub public + free GHA p
    sudo ufw status verbose            # 22/tcp ALLOW, default deny incoming
    ```
 
-Next: §4 First deploy (covered in M9.5-D47).
+## §4 First deploy
+
+### 4.1 Prepare deploy directory
+
+```bash
+ssh deploy@<hetzner-ip>
+sudo mkdir -p /opt/tibiantis
+sudo chown deploy:deploy /opt/tibiantis
+cd /opt/tibiantis
+```
+
+### 4.2 Download compose + env template
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bgozlinski/tibiantis-scraper/master/docker-compose.yml -o docker-compose.yml
+curl -fsSL https://raw.githubusercontent.com/bgozlinski/tibiantis-scraper/master/.env.example -o .env.example
+cp .env.example .env
+chmod 600 .env
+```
+
+### 4.3 Fill secrets
+
+Generate `DJANGO_SECRET_KEY` (alphanumeric only — Compose v2 `$VAR` interpolation gotcha):
+
+```bash
+python3 -c "import string, secrets; print(''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(50)))"
+```
+
+Edit `.env`:
+- `DJANGO_SECRET_KEY=<generated 50-char alphanumeric>`
+- `POSTGRES_PASSWORD=<random>` (e.g. `openssl rand -base64 32` — but verify no `$` chars, regenerate if so)
+- `DISCORD_BOT_TOKEN=<real token from Discord Developer Portal>`
+- `DJANGO_ALLOWED_HOSTS=<hetzner-ipv4>,localhost`
+
+### 4.4 Pull + up
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Wait ~90 seconds for full stack health (postgres + redis + mongo first, then `migrate` one-shot completes, then web/celery_worker/celery_beat/discord_bot/uptime-kuma).
+
+### 4.5 Verify deploy
+
+```bash
+docker compose ps
+# Expected: 8 long-running services Up (postgres, redis, mongo, web, celery_worker,
+# celery_beat, discord_bot, uptime-kuma). migrate hidden by default (Exited 0).
+
+docker compose ps -a
+# Shows migrate Exited (0).
+
+docker compose logs migrate
+# Expected: "Apply all migrations" + "Running migrations" + exit 0
+
+docker compose exec web curl -fsS http://localhost:8000/health/
+# Expected: HTTP 200 + {"db":"ok","redis":"ok"}
+```
+
+## §5 Smoke verification
+
+From laptop, SSH tunnel with 2 forwarded ports:
+
+```bash
+ssh -L 8000:localhost:8000 -L 3001:localhost:3001 deploy@<hetzner-ip>
+```
+
+In another terminal on laptop:
+
+```bash
+curl -fsS http://localhost:8000/health/   # 200 + JSON
+```
+
+In browser: http://localhost:3001 → Uptime Kuma setup wizard.
+
+### 5.1 Kuma initial setup
+
+- Create admin account (save credentials in password manager).
+- Add 4 monitors:
+  1. **web /health/** — Type HTTP(s), URL `http://web:8000/health/`, interval 60s, expect 200
+  2. **postgres** — Type TCP Port, Hostname `postgres`, Port `5432`, interval 60s
+  3. **redis** — Type TCP Port, Hostname `redis`, Port `6379`, interval 60s
+  4. **mongo** — Type TCP Port, Hostname `mongo`, Port `27017`, interval 60s
+- Wait 2 min → all four monitors green on dashboard.
+
+> Kuma resolves service names via the Docker default network (`tibiantis_default`) because it shares the network with the other compose services. Using `http://localhost:8000/health/` inside Kuma would resolve to Kuma itself — see Pułapka B.
+
+## §6 Discord bot live test
+
+- In dev guild: `/bedmage add yhral`
+- Bot responds with an ephemeral success message (per M7-D33 contract).
+- Verify the DB row was actually created:
+
+  ```bash
+  docker compose exec web python manage.py shell -c \
+    "from apps.bedmages.models import BedmageWatch; \
+     print(BedmageWatch.objects.filter(character__name='yhral').exists())"
+  # → True
+  ```
+
+## §7 Rolling update
+
+After CI pushes to master (new `:master` tag in Docker Hub):
+
+```bash
+ssh deploy@<hetzner-ip>
+cd /opt/tibiantis
+docker compose pull
+docker compose up -d
+```
+
+Compose recreates containers with the new image. Healthchecks settle within ~30s. Migrations apply automatically because the `migrate` one-shot re-runs on every `up`.
+
+Sanity:
+
+```bash
+docker compose images   # shows :master tag created datetime
+docker compose ps       # all healthy
+```
+
+## §8 Rollback
+
+Option A — pin compose file to a specific commit SHA tag:
+
+```bash
+cd /opt/tibiantis
+sed -i 's|bgozl/tibiantis-scraper:master|bgozl/tibiantis-scraper:sha-<old-commit>|g' docker-compose.yml
+docker compose pull
+docker compose up -d
+```
+
+Option B — retag a local image as `:master`:
+
+```bash
+docker pull bgozl/tibiantis-scraper:sha-<old-commit>
+docker tag bgozl/tibiantis-scraper:sha-<old-commit> bgozl/tibiantis-scraper:master
+docker compose up -d
+```
+
+Option A leaves the rollback visible in the compose file (good for incident timeline). Option B is faster but invisible to `docker compose images`.
+
+## §9 Troubleshooting
+
+### 9.1 SECRET_KEY containing `$`
+
+**Symptom:** `The "<varname>" variable is not set. Defaulting to a blank string.` warnings on every `docker compose` command; web container starts with a partial SECRET_KEY.
+**Fix:** regenerate alphanumeric-only key (§4.3 generator), update `.env`, `docker compose up -d`.
+
+### 9.2 `.env` world-readable
+
+**Symptom:** `ls -la .env` shows `-rw-r--r--`.
+**Fix:** `chmod 600 .env`.
+
+### 9.3 Discord bot restart loop
+
+**Symptom:** `docker compose logs discord_bot` shows "Improper token has been passed" + container restarting every ~30s.
+**Fix:** regenerate token in Discord Developer Portal, edit `.env`, `docker compose up -d --no-deps discord_bot`.
+
+### 9.4 `migrate` exit code 1
+
+**Symptom:** `docker compose ps -a` shows migrate Exited (1); web doesn't start because `depends_on: service_completed_successfully` is unmet.
+**Fix:** `docker compose logs migrate` → read the migration error. Common cause: postgres not actually ready despite healthcheck — wait, then `docker compose up -d migrate` to retry only the migrate service.
+
+### 9.5 Port 8000 already in use
+
+**Symptom:** `docker compose up -d` fails with `Bind for 0.0.0.0:8000 failed: port is already allocated`.
+**Fix:** `sudo lsof -i :8000` → identify process → stop it, or change the host-side port in compose.
+
+### 9.6 UFW lockout
+
+**Symptom:** SSH disconnected mid-session, cannot reconnect.
+**Fix:** Hetzner Cloud Console → server → Console (web TTY) → `ufw allow 22/tcp && ufw reload`.
+
+### 9.7 Container DNS resolution failing
+
+**Symptom:** container can't pull images, can't connect to Discord/Postgres by service name.
+**Fix:** `docker network inspect tibiantis_default` → check internal DNS state. Fallback: `sudo systemctl restart docker` (will recreate networks; brief downtime).
+
+### 9.8 Disk full (40GB CX22 SSD)
+
+**Symptom:** `docker compose up` fails with `no space left on device`.
+**Fix:** `docker system prune -af && docker volume prune` (careful — drops unused volumes). M-future: attach Hetzner Volume for `/var/lib/docker`.
+
+### 9.9 Docker Hub anonymous rate limit (100 pulls / 6h)
+
+**Symptom:** `docker compose pull` fails with `toomanyrequests: Too Many Requests`.
+**Fix:** `docker login -u bgozl` with a Personal Access Token (200 pulls / 6h authenticated).
+
+### 9.10 Hetzner Cloud Firewall vs UFW desynced
+
+**Symptom:** SSH works on VM console but external SSH connections fail.
+**Fix:** Cloud Console → Firewall → check inbound TCP 22 rule against your current ISP IP (`curl ipify.org`). Update CIDR if it changed.
+
+## §10 Cost tally
+
+| Component | Cost |
+|---|---|
+| Hetzner CX22 VM | ~5.83€/mc |
+| Docker Hub public repo | 0€ (free tier) |
+| GitHub Actions on public repo | 0€ (unlimited) |
+| Discord bot | 0€ |
+| **Total** | **~6€/mc** |
+
+Optional add-ons (M-future):
+
+- Hetzner backups: +20% of server cost (~1.20€/mc)
+- Static IPv4 reservation: ~1€/mc
+- Off-site backup storage (Backblaze B2): ~$0.005/GB/mc


### PR DESCRIPTION
## Summary

- `docker-compose.yml` — new `uptime-kuma` service (louislam/uptime-kuma:1) bound to `127.0.0.1:3001` (localhost-only — UI exposed via SSH tunnel, not public internet). New named volume `uptime_kuma_data` persists admin user + monitor config across compose restarts. No healthcheck — Kuma monitors others, not itself.
- `docs/deploy-runbook.md` §4-§10 added end-to-end: first deploy flow, smoke verification with SSH tunnel + Kuma setup, Discord live test, rolling update, rollback, troubleshooting (12 scenarios), cost tally.
- Runbook updated mid-PR with two real bugs surfaced during the prod deploy smoke (`DATABASE_URL` password duplication, `ALLOWED_HOSTS` missing `web`). Both documented in §4.3 + §9.11 + §9.12.

## Operator confirmation

VM: Hetzner CX22, Falkenstein DE-FSN, Ubuntu 24.04 minimal. IPv4 `178.105.122.18` (here only — not committed).

**`docker compose ps` — 8 long-running services Up (healthy):**
```
NAME                        IMAGE                            SERVICE         STATUS
tibiantis-celery_beat-1     bgozl/tibiantis-scraper:master   celery_beat     Up 22 minutes (healthy)
tibiantis-celery_worker-1   bgozl/tibiantis-scraper:master   celery_worker   Up 22 minutes (healthy)
tibiantis-discord_bot-1     bgozl/tibiantis-scraper:master   discord_bot     Up 22 minutes
tibiantis-mongo-1           mongo:7                          mongo           Up 22 minutes (healthy)
tibiantis-postgres-1        postgres:16-alpine               postgres        Up  9 minutes (healthy)
tibiantis-redis-1           redis:7-alpine                   redis           Up 22 minutes (healthy)
tibiantis-uptime-kuma-1     louislam/uptime-kuma:1           uptime-kuma     Up 22 minutes (healthy)
tibiantis-web-1             bgozl/tibiantis-scraper:master   web             Up  9 minutes (healthy)
```

**`docker compose ps -a | grep migrate` — one-shot Exited 0:**
```
tibiantis-migrate-1   bgozl/tibiantis-scraper:master   migrate   Exited (0) 9 minutes ago
```

**Health endpoint, from inside VM via `docker compose exec`:**
```
$ docker compose exec web curl -fsS http://localhost:8000/health/
{"db": "ok", "redis": "ok"}
```

**Health endpoint, from laptop via 2-port SSH tunnel** (`ssh -L 8000:localhost:8000 -L 3001:localhost:3001 deploy@<ip>`):
```
$ curl -fsS http://localhost:8000/health/
{"db": "ok", "redis": "ok"}
```

**Uptime Kuma:** browser at `http://localhost:3001` (via the same tunnel). Admin account created, 4 monitors configured per spec:
- HTTP(s) `web /health/` → `http://web:8000/health/` — **green**
- TCP `postgres` → `postgres:5432` — **green**
- TCP `redis` → `redis:6379` — **green**
- TCP `mongo` → `mongo:27017` — **green**

**Discord live test** (dev guild): `/bedmage add Akrutki` → bot ephemeral success. DB verify:
```
$ docker compose exec web python manage.py shell -c \
    "from apps.bedmages.models import BedmageWatch; \
     print(BedmageWatch.objects.filter(character__name='Akrutki').exists())"
True
```

## Bugs surfaced during smoke (already fixed in this PR)

1. **`migrate` exited 1 with `password authentication failed for user "tibiantis"`** — `.env.example` duplicates the password (once standalone in `POSTGRES_PASSWORD`, once embedded in `DATABASE_URL`). Operator generated a strong `POSTGRES_PASSWORD` but the literal placeholder remained inside `DATABASE_URL`. Postgres baked the new pwd into the data volume on first boot; Django connected with the old placeholder. Fix: wipe `tibiantis_postgres_data` volume and re-issue both `.env` values matching. Documented in §4.3 + §9.12.
2. **Kuma `web /health/` monitor red while host curl worked** — Kuma sends `Host: web:8000`; Django's `DJANGO_ALLOWED_HOSTS` didn't include `web`, so it returned `400 DisallowedHost`. Fix: add `web` to `ALLOWED_HOSTS`, `docker compose up -d --force-recreate web`. Monitor recovers in next 60s interval, no recreation needed. Documented in §4.3 + §9.11.

## Follow-up issues to file post-merge

- **`.env.example` password DRY** — `DATABASE_URL` should be constructed at runtime in `config/settings/prod.py` from `POSTGRES_USER`/`POSTGRES_PASSWORD`/`POSTGRES_DB`, not duplicated in `.env`. This is a footgun guaranteed to trip up the next operator.
- **`/bedmage add` case sensitivity** — `BedmageWatch` lookups + `Character.name` saves should normalize to a canonical form (Tibia's `Title Case` first-letter convention). Currently `/bedmage add akrutki` and `/bedmage add Akrutki` create two distinct rows. Bug surfaced during D47 smoke.

## Test plan

- [x] `docker compose -f docker-compose.yml config --quiet` — exit 0
- [x] `poetry run pre-commit run --files docker-compose.yml docs/deploy-runbook.md` — clean
- [x] Real prod deploy on Hetzner CX22 — pulled compose from feat-branch URL, filled `.env`, `docker compose pull && up -d`
- [x] `docker compose exec web curl /health/` returns `{"db":"ok","redis":"ok"}`
- [x] SSH 2-port tunnel from laptop — `curl localhost:8000/health/` + browser at `localhost:3001`
- [x] Kuma 4 monitors green (HTTP web + TCP postgres/redis/mongo)
- [x] Discord `/bedmage add Akrutki` → bot ephemeral success + DB row verified
- [x] CI `lint` + `test` jobs green (no Python tests affected)

Closes #156