### PR TITLE
fix(docker): builder venv isolation + build-time SSL-stack import smoke (follow-up #167)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,32 @@ ENV PYTHONUNBUFFERED=1 \
 
 RUN pip install --no-cache-dir "poetry==${POETRY_VERSION}" "poetry-plugin-export>=1.8"
 
+# Isolated venv for app deps. Without this, `pip install --user` would see
+# transitive deps already installed in /usr/local site-packages by Poetry
+# itself (cffi, charset-normalizer, etc.) and silently no-op them with
+# "Requirement already satisfied" — they never get copied to runtime.
+# That regression (#167) caused scrape_deaths to fail every fire on prod
+# with ModuleNotFoundError: No module named '_cffi_backend'.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
 WORKDIR /build
 COPY pyproject.toml poetry.lock ./
 RUN poetry export --without-hashes --only=main -o requirements.txt
-RUN pip install --user --no-cache-dir -r requirements.txt
+RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
+
+# Build-time guardrail. Asserts the SSL-stack deps that scrapy/twisted need
+# at import time are actually importable. Fails the docker build if any
+# regresses — better than discovering it the next time someone tries to
+# scrape on prod and the silent failure mode amplifies for days.
+RUN /opt/venv/bin/python -c "import _cffi_backend, cryptography, OpenSSL._util, charset_normalizer; print('SSL-stack import OK')"
 
 
 FROM python:3.13-slim-bookworm AS runtime
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PATH="/home/app/.local/bin:$PATH" \
+    PATH="/opt/venv/bin:$PATH" \
     DJANGO_SETTINGS_MODULE=config.settings.prod
 
 RUN apt-get update \
@@ -29,7 +44,7 @@ RUN useradd --create-home --shell /bin/bash --uid 1000 app
 USER app
 WORKDIR /app
 
-COPY --from=builder --chown=app:app /root/.local /home/app/.local
+COPY --from=builder --chown=app:app /opt/venv /opt/venv
 COPY --chown=app:app . /app
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary

Follow-up to #167 which **did not actually fix** the prod scraper crash. The first hotfix added cffi + charset-normalizer to `[project.dependencies]` so they'd appear in `requirements.txt`, but the docker build still skipped installing them. This PR fixes the real underlying issue in the Dockerfile.

## Why #167 didn't work

CI build log of the merged #167 (docker.yml run on master @ d4bd470):

\`\`\`
#15 1.149 Requirement already satisfied: cffi==2.0.0 in /usr/local/lib/python3.13/site-packages (from -r requirements.txt (line 12)) (2.0.0)
#15 1.150 Requirement already satisfied: charset-normalizer==3.4.7 in /usr/local/lib/python3.13/site-packages (from -r requirements.txt (line 13)) (3.4.7)
\`\`\`

Mechanism:

1. Builder stage runs \`pip install poetry poetry-plugin-export\` → Poetry pulls cffi into \`/usr/local/lib/python3.13/site-packages\` as one of its own transitive deps.
2. Builder runs \`pip install --user -r requirements.txt\`.
3. pip sees cffi already exists in \`/usr/local/\`, treats as "already satisfied", **does not write to \`/root/.local\`**.
4. Runtime stage \`COPY --from=builder /root/.local /home/app/.local\` — nothing to copy for cffi.
5. Runtime container imports scrapy → twisted → pyOpenSSL → \`import _cffi_backend\` → **ModuleNotFoundError**.

Same mechanism dropped \`charset-normalizer\`.

Verified on prod VM after pulling the merged #167 image:
\`\`\`
$ docker compose exec celery_worker python -c "import _cffi_backend"
ModuleNotFoundError: No module named '_cffi_backend'
\`\`\`

## Fix

Two changes to \`Dockerfile\`:

1. **Builder creates an isolated \`/opt/venv\`** and installs app deps INTO that venv (\`/opt/venv/bin/pip install ...\`). Poetry's site-packages are in \`/usr/local/\` and stay separate. Runtime stage COPY's \`/opt/venv\` intact. Standard prod-Python multi-stage pattern.

2. **Build-time guardrail** — a \`RUN /opt/venv/bin/python -c "import _cffi_backend, cryptography, OpenSSL._util, charset_normalizer"\` step that fails the docker build if any future regression breaks the SSL-stack dep path. Catches the class of bug that #167 hit at build time rather than at next prod scrape failure.

## Expected verification post-merge

\`\`\`bash
# Wait for docker.yml to push new :master image
ssh deploy@<vm-ipv4>
cd /opt/tibiantis
docker compose pull
docker compose up -d
docker compose exec celery_worker python -c "import _cffi_backend; print('OK', _cffi_backend.__file__)"
# Expected: OK /opt/venv/lib/python3.13/site-packages/_cffi_backend.cpython-313-x86_64-linux-gnu.so

docker compose exec celery_worker python manage.py scrape_deaths
# Expected: {"yielded": <N>, "duplicates": <M>}

# After ~5min, beat fires and DeathEvent grows:
docker compose exec web python manage.py shell -c "from apps.deaths.models import DeathEvent; print('Total:', DeathEvent.objects.count())"
# Expected: Total > 0
\`\`\`

## Test plan

- [x] Pre-commit clean
- [ ] CI Docker build succeeds (the new RUN /opt/venv/bin/python -c "..." step fails the build if anything's broken — this is itself a test)
- [ ] CI lint + test green
- [ ] After merge: VM pull + recreate → cffi importable → scrape_deaths returns real yielded count

## Follow-up

Worth filing as M10 candidate: \`apps/deaths/tasks.py:43-47\` swallows subprocess returncode != 0 by returning a sentinel dict that Celery marks as \`succeeded\`. That's what masked this bug in prod for hours. Fix: re-raise or use \`self.retry()\` instead.