### PR TITLE
chore(compose): bind postgres to 127.0.0.1:5432 for SSH-tunnel ops access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,12 @@ services:
     env_file: .env
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    ports:
+      # Localhost-only binding (NOT 0.0.0.0) — reachable from VM's loopback
+      # for ops/SSH-tunnel access, never exposed to public internet.
+      # Pair with `ssh -L 5432:localhost:5432 deploy@<vm-ip>` for laptop-side
+      # GUI access (PyCharm, DBeaver, psql). Same pattern as uptime-kuma.
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s


### PR DESCRIPTION
## Summary

Add a localhost-only host port mapping for the `postgres` service so the operator can reach the DB via SSH tunnel for GUI / psql / ad-hoc query access. Same pattern already established by `uptime-kuma` (`127.0.0.1:3001:3001`).

```yaml
postgres:
  ...
  ports:
    - "127.0.0.1:5432:5432"
```

## Why

DB introspection is a routine ops need (debugging data state, verifying migration outcomes, manually fixing one-off rows). Currently the only path to query postgres is `docker compose exec postgres psql` — CLI only, no GUI client. Adding the host port lets PyCharm Database tool / DBeaver / `psql -h localhost` work via SSH tunnel.

## Security

- **Binding is `127.0.0.1`, NOT `0.0.0.0`.** Only processes on the VM's loopback can reach the port. UFW and Hetzner Cloud Firewall don't filter loopback — the binding never sees the public-net firewall path.
- **SSH key auth is the only access boundary.** To reach the port from outside, you must SSH to the VM (key required). Postgres user/password auth is the second gate.
- **No prod runtime impact.** Service-to-service traffic (web, celery, migrate → postgres) still goes over the docker bridge network using service-name DNS, unchanged.

## Operator usage post-merge

```bash
# On laptop, tunnel
ssh -L 5432:localhost:5432 deploy@<vm-ip>

# In another terminal on laptop
psql -h localhost -U tibiantis -d tibiantis
# Password: whatever's in .env's POSTGRES_PASSWORD on the VM

# PyCharm Database tool:
#   Host: localhost
#   Port: 5432
#   Database: tibiantis
#   User: tibiantis
#   Password: <from VM .env>
# OR use PyCharm's built-in SSH tunnel config pointing at deploy@<vm-ip>
# (same effect, no manual ssh -L terminal needed)
```

## Test plan

- [x] `docker compose -f docker-compose.yml config --quiet` exit 0
- [x] `poetry run pre-commit run --files docker-compose.yml` clean
- [ ] CI lint + test green
- [ ] After merge + VM `docker compose pull && up -d`: `docker compose ps` shows postgres with `127.0.0.1:5432->5432/tcp` PORTS column
- [ ] From laptop with SSH tunnel: `psql -h localhost -U tibiantis -d tibiantis` connects