### PR TITLE
fix(web): serve Django admin static via whitenoise + collectstatic in image (#162)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,10 @@ htmlcov/
 tests/
 docs/
 
+# Locally-collected staticfiles output (the Dockerfile runs collectstatic
+# fresh inside the image — don't ship dev's stale collected tree).
+staticfiles/
+
 # Local env (secrets!) — keep .env.example as template
 .env
 .env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,17 @@ WORKDIR /app
 COPY --from=builder --chown=app:app /opt/venv /opt/venv
 COPY --chown=app:app . /app
 
+# Collect static assets into STATIC_ROOT (/app/staticfiles) so whitenoise can
+# serve them at runtime. Build-time env vars are placeholders — collectstatic
+# only needs the settings module to import successfully, not real infra
+# credentials. None of these values are baked into the image (RUN-scoped).
+RUN DJANGO_SECRET_KEY=build-time-only-not-used \
+    DATABASE_URL=sqlite:///build.sqlite3 \
+    REDIS_URL=redis://localhost:6379/0 \
+    CELERY_BROKER_URL=redis://localhost:6379/1 \
+    CELERY_RESULT_BACKEND=redis://localhost:6379/2 \
+    python manage.py collectstatic --noinput
+
 EXPOSE 8000
 
 HEALTHCHECK --interval=15s --timeout=5s --start-period=60s --retries=3 \

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -64,6 +64,7 @@ INSTALLED_APPS: list[str] = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -133,6 +134,20 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/6.0/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
+# Django 6 settings shape (NOT legacy STATICFILES_STORAGE). Whitenoise's
+# CompressedManifestStaticFilesStorage gives us gzip/brotli pre-compression
+# at collectstatic time + manifest-based cache-busting for far-future
+# Cache-Control headers in prod.
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 
 
 AUTH_USER_MODEL = "accounts.User"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3490,6 +3490,21 @@ files = [
 ]
 
 [[package]]
+name = "whitenoise"
+version = "6.12.0"
+description = "Radically simplified static file serving for WSGI applications"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2"},
+    {file = "whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad"},
+]
+
+[package.extras]
+brotli = ["brotli"]
+
+[[package]]
 name = "wrapt"
 version = "2.1.2"
 description = "Module for decorators, wrappers and monkey patching."
@@ -3784,4 +3799,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<3.14"
-content-hash = "27925d738378e567591d97bd8d5c34655946bae98f92d280102935a626069bb3"
+content-hash = "24d3c888d360b3ecb5062f2246b6f773d2755bc23ec878e51835651cbdea7c61"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ requires-python = ">=3.13,<3.14"
       "httpx (>=0.28.1,<0.29.0)",
       "gunicorn (>=23.0,<24.0)",
       "cffi (>=2.0.0,<3.0.0)",
-      "charset-normalizer (>=3.0.0,<4.0.0)"
+      "charset-normalizer (>=3.0.0,<4.0.0)",
+      "whitenoise (>=6.7.0,<7.0.0)"
   ]
 
 

--- a/tests/unit/core/test_static_files.py
+++ b/tests/unit/core/test_static_files.py
@@ -1,0 +1,94 @@
+"""Tests for static-file serving config — #162 fix verification.
+
+Pre-#162, Django admin in prod (`DEBUG=False`, gunicorn, no nginx) renders
+unstyled because nothing serves `/static/`: `STATIC_URL` is set but `STATIC_ROOT`
+is missing, no `collectstatic` runs during image build, and `MIDDLEWARE` has no
+whitenoise to serve the collected tree at runtime.
+
+These tests assert the three-part contract that fixes the bug:
+  1. `STATIC_ROOT` points at a writable directory so `collectstatic --noinput`
+     has somewhere to write.
+  2. `STORAGES["staticfiles"]["BACKEND"]` uses whitenoise's compressed manifest
+     storage (Django 6 settings shape — NOT legacy `STATICFILES_STORAGE`).
+  3. `WhiteNoiseMiddleware` sits in `MIDDLEWARE` immediately after
+     `SecurityMiddleware` (per whitenoise docs — earlier or later breaks the
+     content-encoding / security-header interleaving).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.conf import settings
+
+
+def test_static_root_is_configured() -> None:
+    """STATIC_ROOT must be set so `collectstatic --noinput` has a target dir.
+
+    Pre-fix the setting is missing entirely; Django falls back to `None` which
+    makes `collectstatic` a no-op and gunicorn has nothing to serve.
+    """
+    assert settings.STATIC_ROOT, (
+        "STATIC_ROOT must be set (typically BASE_DIR / 'staticfiles') so "
+        "collectstatic has a destination"
+    )
+    assert Path(settings.STATIC_ROOT).name == "staticfiles", (
+        f"STATIC_ROOT should be named 'staticfiles' per project convention; "
+        f"got {settings.STATIC_ROOT}"
+    )
+
+
+def test_storages_staticfiles_uses_whitenoise_compressed_manifest() -> None:
+    """STORAGES['staticfiles']['BACKEND'] must point at whitenoise's
+    CompressedManifestStaticFilesStorage.
+
+    Django 6 deprecated the legacy `STATICFILES_STORAGE` flat setting in favour
+    of the `STORAGES` dict. This test pins the modern shape so a future
+    contributor doesn't accidentally use the legacy key (which Django 6 ignores).
+
+    Whitenoise's CompressedManifestStaticFilesStorage gives us:
+      - gzip/brotli pre-compression at collectstatic time → smaller wire
+      - manifest-based cache busting (hash in filename) → far-future Cache-Control
+    """
+    storages = getattr(settings, "STORAGES", None)
+    assert storages is not None, (
+        "settings.STORAGES dict must be defined (Django 6 shape, not legacy "
+        "STATICFILES_STORAGE)"
+    )
+    assert "staticfiles" in storages, "STORAGES must declare a 'staticfiles' key"
+    assert (
+        storages["staticfiles"]["BACKEND"]
+        == "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    ), (
+        f"STORAGES['staticfiles']['BACKEND'] must be whitenoise's "
+        f"CompressedManifestStaticFilesStorage; got "
+        f"{storages['staticfiles']['BACKEND']!r}"
+    )
+
+
+def test_whitenoise_middleware_directly_after_security() -> None:
+    """WhiteNoiseMiddleware must sit at index N+1 where N is SecurityMiddleware.
+
+    Per whitenoise docs (http://whitenoise.evans.io/en/stable/django.html#enable-whitenoise):
+    placement is strict — Security MUST come first (so security headers attach to
+    every response, including static files), and WhiteNoise MUST come second (so
+    it short-circuits `/static/*` before any heavier middleware runs).
+
+    Any other middleware between them is a misconfiguration.
+    """
+    middleware = list(settings.MIDDLEWARE)
+    security = "django.middleware.security.SecurityMiddleware"
+    whitenoise = "whitenoise.middleware.WhiteNoiseMiddleware"
+
+    assert security in middleware, "SecurityMiddleware missing — base config broken"
+    assert whitenoise in middleware, (
+        "WhiteNoiseMiddleware missing from MIDDLEWARE — /static/ won't be served "
+        "in prod (DEBUG=False)"
+    )
+
+    security_idx = middleware.index(security)
+    whitenoise_idx = middleware.index(whitenoise)
+    assert whitenoise_idx == security_idx + 1, (
+        f"WhiteNoiseMiddleware must be immediately after SecurityMiddleware "
+        f"(security at index {security_idx}, whitenoise at index {whitenoise_idx})"
+    )


### PR DESCRIPTION
## Summary
Closes #162. Django admin in prod (`DEBUG=False`, gunicorn, no nginx) rendered unstyled because nothing served `/static/*`. Adds whitenoise + `STATIC_ROOT` + `STORAGES` (Django 6 shape) + Dockerfile `collectstatic` step.

## Changes
- **`pyproject.toml` / `poetry.lock`** — `whitenoise ^6.7.0` runtime dep (resolves 6.12.0)
- **`config/settings/base.py`** — `WhiteNoiseMiddleware` immediately after `SecurityMiddleware`; `STATIC_ROOT = BASE_DIR / "staticfiles"`; `STORAGES["staticfiles"]["BACKEND"]` = `whitenoise.storage.CompressedManifestStaticFilesStorage`
- **`Dockerfile`** — `RUN python manage.py collectstatic --noinput` in final stage with 5 RUN-scoped placeholder env vars so `collectstatic` can import settings without real infra credentials
- **`.dockerignore`** — exclude `staticfiles/` so dev's stale local tree doesn't ship in the image (Dockerfile collects fresh)
- **`tests/unit/core/test_static_files.py`** — 3 RED-now-GREEN tests pinning the config contract

## Test plan
- [x] `pytest tests/unit/core/test_static_files.py` — 3 GREEN
- [x] Full suite — 240 pass + 1 xfailed, no regressions
- [ ] `docker build .` — verify the new `collectstatic` step works in the actual build (local image build)
- [ ] `runserver` (DEBUG=True) — admin renders fully styled via Django's `staticfiles` (whitenoise stays out of the way)
- [ ] After M10 close (D52) — re-deploy to Hetzner, SSH tunnel `/admin/` shows full Django theme

## Dev parity
- DEBUG=True: Django's `staticfiles` app serves via finders. Whitenoise defers (no `WHITENOISE_USE_FINDERS`, no `runserver_nostatic`).
- DEBUG=False (prod): whitenoise middleware intercepts `/static/*` and serves from `STATIC_ROOT`.

Refs M10 plan tasks D50.3-D50.8.