### PR TITLE
refactor(settings): construct DATABASES from POSTGRES_* env vars, drop DATABASE_URL (#163)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,13 +17,18 @@ DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
 
 # ─── PostgreSQL ──────────────────────────────────────────────────────
 # Operator MUSI ustawić POSTGRES_PASSWORD na real value przed prod deploy.
+# Single source of truth: POSTGRES_PASSWORD lives in exactly one place
+# (per #163). Settings construct the connection string at runtime — no
+# DATABASE_URL line to keep in sync.
 POSTGRES_USER=tibiantis
 POSTGRES_PASSWORD=tibiantis
 POSTGRES_DB=tibiantis
 
 # Docker DNS hostname `postgres` (compose service name).
-# Dla DEV (bez compose, `runserver` lokalnie): zmień `postgres:5432` na `localhost:5435`.
-DATABASE_URL=postgres://tibiantis:tibiantis@postgres:5432/tibiantis
+# Dla DEV (bez compose, `runserver` lokalnie): zmień `postgres` na `localhost`
+# i `5432` na `5435` (host port w docker-compose.dev.yml).
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
 
 # ─── Redis ───────────────────────────────────────────────────────────
 # Docker DNS hostname `redis`. Dla DEV: `redis://localhost:6379/0`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,11 @@ jobs:
         image: mongo:7
         ports: ["27017:27017"]
     env:
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/tibiantis_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: tibiantis_test
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: "5432"
       REDIS_URL: redis://localhost:6379/0
       CELERY_BROKER_URL: redis://localhost:6379/1
       CELERY_RESULT_BACKEND: redis://localhost:6379/2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,11 @@ Użyj `djangorestframework-simplejwt` albo `djoser`. **Nie** twórz endpointów 
 DJANGO_SECRET_KEY=
 DJANGO_DEBUG=False
 DJANGO_ALLOWED_HOSTS=
-DATABASE_URL=postgres://user:pass@postgres:5432/tibiantis
+POSTGRES_USER=tibiantis
+POSTGRES_PASSWORD=tibiantis
+POSTGRES_DB=tibiantis
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
 MONGO_URL=mongodb://mongo:27017
 MONGO_DB=tibiantis_logs
 REDIS_URL=redis://redis:6379/0
@@ -458,7 +462,11 @@ jobs:
         image: mongo:7
         ports: ["27017:27017"]
     env:
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/tibiantis_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: tibiantis_test
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: "5432"
       REDIS_URL: redis://localhost:6379/0
       CELERY_BROKER_URL: redis://localhost:6379/1
       MONGO_URL: mongodb://localhost:27017

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,15 @@ COPY --chown=app:app . /app
 # Collect static assets into STATIC_ROOT (/app/staticfiles) so whitenoise can
 # serve them at runtime. Build-time env vars are placeholders — collectstatic
 # only needs the settings module to import successfully, not real infra
-# credentials. None of these values are baked into the image (RUN-scoped).
+# credentials. These values are RUN-scoped (not in container runtime env) but
+# remain visible in `docker history` layer metadata — only safe because none
+# are real secrets.
 RUN DJANGO_SECRET_KEY=build-time-only-not-used \
-    DATABASE_URL=sqlite:///build.sqlite3 \
+    POSTGRES_DB=build \
+    POSTGRES_USER=build \
+    POSTGRES_PASSWORD=build \
+    POSTGRES_HOST=localhost \
+    POSTGRES_PORT=5432 \
     REDIS_URL=redis://localhost:6379/0 \
     CELERY_BROKER_URL=redis://localhost:6379/1 \
     CELERY_RESULT_BACKEND=redis://localhost:6379/2 \

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -95,8 +95,25 @@ WSGI_APPLICATION = "config.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/6.0/ref/settings/#databases
+#
+# Constructed from individual POSTGRES_* env vars rather than parsing a
+# DATABASE_URL (per #163). The duplication of POSTGRES_PASSWORD inside a
+# URL-shaped DATABASE_URL was an operator footgun on M9.5-D47 first prod
+# deploy — operators generated a strong random password but forgot to also
+# update it inside DATABASE_URL, postgres initialised with the new value,
+# Django connected with the placeholder, migrate exited 1. Single source
+# of truth (POSTGRES_PASSWORD) eliminates the divergence path entirely.
 
-DATABASES = {"default": env.db()}
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": env("POSTGRES_DB"),
+        "USER": env("POSTGRES_USER"),
+        "PASSWORD": env("POSTGRES_PASSWORD"),
+        "HOST": env("POSTGRES_HOST", default="postgres"),
+        "PORT": env.int("POSTGRES_PORT", default=5432),
+    }
+}
 
 
 # Password validation

--- a/config/settings/stubs.py
+++ b/config/settings/stubs.py
@@ -46,3 +46,25 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     *LOCAL_APPS,
 ]
+
+# Override DATABASES for mypy's isolated env. Post-#163, base.py hardcodes
+# ENGINE=django.db.backends.postgresql, which triggers Django to import
+# psycopg/psycopg2 at app-loading time (mypy-django-plugin calls
+# apps.populate(INSTALLED_APPS), which builds Model._meta.db_table, which
+# touches connection.ops, which loads the backend). The mypy pre-commit hook
+# runs in an isolated venv with only the listed additional_dependencies — no
+# psycopg there — so the postgres backend fails to import with
+# ModuleNotFoundError.
+#
+# sqlite3 is in the Python stdlib (no extra dep needed) and is sufficient for
+# the django-stubs plugin to populate apps + resolve model relationships for
+# type checking. Same trick that pre-#163 stubs.py got for free by setting
+# DATABASE_URL=sqlite:///:memory: (env.db() inferred the engine from the URL
+# scheme); post-#163 we have to override DATABASES explicitly since base.py
+# no longer infers engine from a URL.
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    },
+}

--- a/config/settings/stubs.py
+++ b/config/settings/stubs.py
@@ -25,7 +25,11 @@ import os
 # values take precedence — these only kick in for isolated mypy runs that
 # have neither (e.g. pre-commit's isolated env on a fresh machine).
 os.environ.setdefault("DJANGO_SECRET_KEY", "stub-not-runtime")
-os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("POSTGRES_DB", "stub")
+os.environ.setdefault("POSTGRES_USER", "stub")
+os.environ.setdefault("POSTGRES_PASSWORD", "stub")
+os.environ.setdefault("POSTGRES_HOST", "stub")
+os.environ.setdefault("POSTGRES_PORT", "5432")
 os.environ.setdefault("CELERY_BROKER_URL", "memory://")
 os.environ.setdefault("CELERY_RESULT_BACKEND", "cache+memory://")
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -98,8 +98,7 @@ python3 -c "import string, secrets; print(''.join(secrets.choice(string.ascii_le
 
 Edit `.env`:
 - `DJANGO_SECRET_KEY=<generated 50-char alphanumeric>`
-- `POSTGRES_PASSWORD=<32-char alphanumeric>` (regenerate with the snippet above — alphanumeric avoids both compose `$VAR` interpolation AND URL-encoding inside `DATABASE_URL`)
-- **`DATABASE_URL=postgres://tibiantis:<same-as-POSTGRES_PASSWORD>@postgres:5432/tibiantis`** — the password appears twice; both must match exactly, or migrate exits 1 with `password authentication failed for user "tibiantis"`. Tech debt: should be DRY-constructed in `config/settings/prod.py` from individual `POSTGRES_*` vars (follow-up issue).
+- `POSTGRES_PASSWORD=<32-char alphanumeric>` (regenerate with the snippet above — alphanumeric avoids compose `$VAR` interpolation; #163 removed the duplicate password inside a `DATABASE_URL` URL, so this value only lives in one place now)
 - `DISCORD_BOT_TOKEN=<real token from Discord Developer Portal>`
 - `DJANGO_ALLOWED_HOSTS=<hetzner-ipv4>,localhost,web` — `web` is required so Uptime Kuma's internal-DNS monitor (`http://web:8000/health/`) doesn't get rejected by Django with `DisallowedHost`.
 
@@ -272,15 +271,15 @@ Option A leaves the rollback visible in the compose file (good for incident time
 ### 9.12 migrate exit 1: password authentication failed
 
 **Symptom:** `docker compose logs migrate` ends with `psycopg.OperationalError: ... password authentication failed for user "tibiantis"`. Web/celery/bot stay in `Created` state.
-**Cause:** `POSTGRES_PASSWORD` and the password embedded inside `DATABASE_URL` in `.env` don't match. Postgres initialized its data volume with the value of `POSTGRES_PASSWORD` on first boot; Django connects using `DATABASE_URL`.
+**Cause (post-#163):** `POSTGRES_PASSWORD` in `.env` doesn't match the password postgres was initialized with. The DRY refactor (#163) eliminated the historical "password in two places" footgun — `.env` now has a single `POSTGRES_PASSWORD` consumed by both the postgres container's `initdb` and Django's settings. If they mismatch, postgres initialised its data volume with one value (first-boot only) while `.env` was later edited to a different value.
 **Fix:**
 ```bash
 docker compose down
 docker volume rm tibiantis_postgres_data    # ONLY safe before any real data exists
-# Edit .env: make sure POSTGRES_PASSWORD and the password inside DATABASE_URL match exactly
+# Confirm .env has the password you want, then:
 docker compose up -d
 ```
-If postgres has real data, do NOT drop the volume — instead, edit `DATABASE_URL` in `.env` to match the password postgres was initialized with, and `docker compose up -d --force-recreate web migrate celery_worker celery_beat discord_bot`.
+If postgres has real data, do NOT drop the volume — instead, edit `.env`'s `POSTGRES_PASSWORD` back to whatever value postgres was originally initialized with, then `docker compose up -d --force-recreate web migrate celery_worker celery_beat discord_bot`. The password value is recoverable from the operator's password manager / first-deploy notes; there's no second value in `.env` to consult.
 
 ## §10 Cost tally
 

--- a/docs/dev-runbook.md
+++ b/docs/dev-runbook.md
@@ -24,7 +24,8 @@ cp .env.example .env
 # Edit:
 #   DJANGO_SECRET_KEY    — generate alphanumeric (see §6)
 #   DISCORD_BOT_TOKEN    — only if running the bot locally
-#   DATABASE_URL=postgres://tibiantis:tibiantis@localhost:5435/tibiantis
+#   POSTGRES_HOST=localhost
+#   POSTGRES_PORT=5435   — host port w docker-compose.dev.yml (NOT 5432)
 #   REDIS_URL=redis://localhost:6379/0
 #   MONGO_URL=mongodb://localhost:27017
 
@@ -190,7 +191,7 @@ python -c "import string, secrets; print(''.join(secrets.choice(string.ascii_let
 
 Use this for dev `.env` AND for production `.env` on the Hetzner VM. Same generator is documented in `deploy-runbook.md` §4.3 — single source of truth.
 
-The same constraint applies to `POSTGRES_PASSWORD` (especially in prod where it's embedded in `DATABASE_URL`): alphanumeric avoids both compose interpolation and URL-encoding inside `postgres://...`.
+The same constraint applies to `POSTGRES_PASSWORD`: alphanumeric avoids compose `$VAR` interpolation. Post-#163 the password lives in exactly one env var (no `DATABASE_URL` URL-encoding to also worry about), but the alphanumeric rule remains useful as a defence against compose interpolation.
 
 ---
 

--- a/tests/unit/core/test_settings.py
+++ b/tests/unit/core/test_settings.py
@@ -1,0 +1,103 @@
+"""Tests for settings shape — #163 fix verification.
+
+#163 surfaced an operator footgun: `.env.example` had `POSTGRES_PASSWORD` and the
+same password embedded inside `DATABASE_URL`. When operators generated a strong
+random `POSTGRES_PASSWORD` during first prod deploy but forgot to also update
+the password inside `DATABASE_URL`, postgres initialized its volume with the
+new password while Django connected with the placeholder one — silent until
+`migrate` exit 1. Cost ~30 min on M9.5-D47.
+
+The fix removes the duplication by constructing `DATABASES["default"]` from
+individual `POSTGRES_*` env vars (USER, PASSWORD, DB, HOST, PORT) in
+`config/settings/base.py`, deleting `DATABASE_URL` from `.env.example`, and
+mirroring the new shape across CI and Docker build-time placeholders (Option A
+per M10 spec §3.4 — unified env shape across dev/CI/prod).
+
+These tests pin the contract that no `DATABASE_URL` reference remains in
+settings, `.env.example`, or CI workflow, so future contributors can't
+re-introduce the duplication.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+
+
+def test_settings_base_has_no_database_url_or_env_db_references() -> None:
+    """`config/settings/base.py` constructs DATABASES from individual POSTGRES_*
+    env vars — no `env.db()` URL-parser call and no `DATABASE_URL` reference
+    remains anywhere in the file.
+
+    Pre-fix: `DATABASES = {"default": env.db()}` parses DATABASE_URL implicitly.
+    Post-fix: explicit `DATABASES = {"default": {"ENGINE": ..., "NAME": env(...),
+    "USER": env(...), ...}}` keyed off `POSTGRES_*` vars, removing the dual
+    source-of-truth that bit the M9.5-D47 deploy.
+    """
+    base_py = (BASE_DIR / "config" / "settings" / "base.py").read_text()
+    assert "DATABASE_URL" not in base_py, (
+        "DATABASE_URL reference found in config/settings/base.py — #163 "
+        "removes it. Construct DATABASES from POSTGRES_USER / "
+        "POSTGRES_PASSWORD / POSTGRES_DB / POSTGRES_HOST / POSTGRES_PORT "
+        "instead."
+    )
+    assert "env.db()" not in base_py, (
+        "env.db() call found in config/settings/base.py — #163 replaces the "
+        "URL parser with explicit POSTGRES_* construction so the password "
+        "lives in exactly one env var."
+    )
+
+
+def test_env_example_has_postgres_individual_vars_not_database_url() -> None:
+    """`.env.example` documents POSTGRES_HOST and POSTGRES_PORT as
+    operator-settable vars, and the duplicated `DATABASE_URL` line is gone.
+
+    Post-fix, the operator footgun (forgetting to update `DATABASE_URL`'s
+    password to match `POSTGRES_PASSWORD`) becomes structurally impossible —
+    there's only one place to set the password.
+    """
+    env_example = (BASE_DIR / ".env.example").read_text()
+    assert "DATABASE_URL" not in env_example, (
+        ".env.example still references DATABASE_URL — #163 removes it. "
+        "Operators set POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB / "
+        "POSTGRES_HOST / POSTGRES_PORT and settings build the connection."
+    )
+    for required in (
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_DB",
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+    ):
+        assert required in env_example, (
+            f".env.example must document {required} so operators know to "
+            f"set it explicitly (single source of truth, no URL embedding)"
+        )
+
+
+def test_ci_workflow_uses_postgres_env_vars_not_database_url() -> None:
+    """`.github/workflows/ci.yml` test job env block uses individual POSTGRES_*
+    vars — symmetric with the new dev + prod env shape.
+
+    The pre-fix workflow set `DATABASE_URL: postgres://postgres:postgres@...`
+    inside the `env:` block. Post-fix, the same five POSTGRES_* vars used in
+    dev/prod populate the test job env, keeping the env shape uniform across
+    all environments. Avoids env-shape drift that #163 is precisely fixing.
+    """
+    ci_yml = (BASE_DIR / ".github" / "workflows" / "ci.yml").read_text()
+    assert "DATABASE_URL" not in ci_yml, (
+        ".github/workflows/ci.yml still references DATABASE_URL — #163 swaps "
+        "it for individual POSTGRES_* env vars so test/dev/prod share one "
+        "env shape"
+    )
+    for required in (
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_DB",
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+    ):
+        assert (
+            required in ci_yml
+        ), f".github/workflows/ci.yml must set {required} for the test job"

--- a/tests/unit/core/test_settings.py
+++ b/tests/unit/core/test_settings.py
@@ -25,22 +25,39 @@ from pathlib import Path
 BASE_DIR = Path(__file__).resolve().parents[3]
 
 
+def _strip_hash_comments(text: str) -> str:
+    """Return text with `#`-comment lines removed.
+
+    Used by the no-DATABASE_URL checks so explanatory prose mentioning the
+    removed setting by name (e.g. "DATABASE_URL was an operator footgun")
+    doesn't false-fail the test. The contract is "no code USES DATABASE_URL",
+    not "the string literal never appears" — comments survive the strip.
+    """
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
 def test_settings_base_has_no_database_url_or_env_db_references() -> None:
     """`config/settings/base.py` constructs DATABASES from individual POSTGRES_*
     env vars — no `env.db()` URL-parser call and no `DATABASE_URL` reference
-    remains anywhere in the file.
+    remains in executable code in the file.
 
     Pre-fix: `DATABASES = {"default": env.db()}` parses DATABASE_URL implicitly.
     Post-fix: explicit `DATABASES = {"default": {"ENGINE": ..., "NAME": env(...),
     "USER": env(...), ...}}` keyed off `POSTGRES_*` vars, removing the dual
-    source-of-truth that bit the M9.5-D47 deploy.
+    source-of-truth that bit the M9.5-D47 deploy. Whole-line comments
+    explaining the rationale (which mention DATABASE_URL by name) are
+    permitted and excluded by `_strip_hash_comments`.
     """
-    base_py = (BASE_DIR / "config" / "settings" / "base.py").read_text()
+    base_py = _strip_hash_comments(
+        (BASE_DIR / "config" / "settings" / "base.py").read_text()
+    )
     assert "DATABASE_URL" not in base_py, (
-        "DATABASE_URL reference found in config/settings/base.py — #163 "
-        "removes it. Construct DATABASES from POSTGRES_USER / "
-        "POSTGRES_PASSWORD / POSTGRES_DB / POSTGRES_HOST / POSTGRES_PORT "
-        "instead."
+        "DATABASE_URL reference found in non-comment code in "
+        "config/settings/base.py — #163 removes it. Construct DATABASES "
+        "from POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB / "
+        "POSTGRES_HOST / POSTGRES_PORT instead."
     )
     assert "env.db()" not in base_py, (
         "env.db() call found in config/settings/base.py — #163 replaces the "
@@ -57,11 +74,12 @@ def test_env_example_has_postgres_individual_vars_not_database_url() -> None:
     password to match `POSTGRES_PASSWORD`) becomes structurally impossible —
     there's only one place to set the password.
     """
-    env_example = (BASE_DIR / ".env.example").read_text()
+    env_example = _strip_hash_comments((BASE_DIR / ".env.example").read_text())
     assert "DATABASE_URL" not in env_example, (
-        ".env.example still references DATABASE_URL — #163 removes it. "
-        "Operators set POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB / "
-        "POSTGRES_HOST / POSTGRES_PORT and settings build the connection."
+        ".env.example still references DATABASE_URL in non-comment lines — "
+        "#163 removes it. Operators set POSTGRES_USER / POSTGRES_PASSWORD / "
+        "POSTGRES_DB / POSTGRES_HOST / POSTGRES_PORT and settings build the "
+        "connection. Whole-line `#` comments mentioning the removal are fine."
     )
     for required in (
         "POSTGRES_USER",
@@ -85,11 +103,13 @@ def test_ci_workflow_uses_postgres_env_vars_not_database_url() -> None:
     dev/prod populate the test job env, keeping the env shape uniform across
     all environments. Avoids env-shape drift that #163 is precisely fixing.
     """
-    ci_yml = (BASE_DIR / ".github" / "workflows" / "ci.yml").read_text()
+    ci_yml = _strip_hash_comments(
+        (BASE_DIR / ".github" / "workflows" / "ci.yml").read_text()
+    )
     assert "DATABASE_URL" not in ci_yml, (
-        ".github/workflows/ci.yml still references DATABASE_URL — #163 swaps "
-        "it for individual POSTGRES_* env vars so test/dev/prod share one "
-        "env shape"
+        ".github/workflows/ci.yml still references DATABASE_URL in non-comment "
+        "lines — #163 swaps it for individual POSTGRES_* env vars so "
+        "test/dev/prod share one env shape"
     )
     for required in (
         "POSTGRES_USER",


### PR DESCRIPTION
## Summary
Closes #163. M9.5-D47 first prod deploy revealed that `.env.example` duplicated `POSTGRES_PASSWORD` inside `DATABASE_URL`. Operators who generated a strong random password but forgot to also update the URL form hit `migrate exit 1` with "password authentication failed". Cost ~30 min on first deploy.

Fix removes the duplication: settings construct the connection string from individual `POSTGRES_*` env vars. Single source of truth, divergence path eliminated.

Per M10 spec §3.4 — **Option A** (unify dev/CI/prod env shape).

## Code changes
- **`config/settings/base.py`** — `DATABASES["default"]` explicit dict; ENGINE pinned to `django.db.backends.postgresql`; HOST defaults to `postgres` (compose service name); PORT defaults to `5432`
- **`config/settings/stubs.py`** — mypy stub `setdefault` swapped from `DATABASE_URL` to the five `POSTGRES_*` vars
- **`Dockerfile`** — `collectstatic` RUN-scoped placeholders swapped from `DATABASE_URL=sqlite://...` to `POSTGRES_*=build`; comment tightened ("RUN-scoped" → also acknowledges layer history visibility, only safe because none are real secrets)
- **`.env.example`** — `DATABASE_URL` line removed; `POSTGRES_HOST` + `POSTGRES_PORT` added with dev hint comment
- **`.github/workflows/ci.yml`** — `env:` block in test job swaps `DATABASE_URL` line for the five `POSTGRES_*` vars

## Test changes
- **`tests/unit/core/test_settings.py`** (new) — 3 RED-now-GREEN tests pin the contract that no `DATABASE_URL` reference remains in non-comment code in `base.py`, `.env.example`, or `ci.yml`. Uses `_strip_hash_comments` helper so explanatory prose mentioning the removed setting by name (this PR has lots of it) doesn't false-fail.

## Docs changes
- **`CLAUDE.md` §10** — example `.env.example` snippet updated to `POSTGRES_*` shape
- **`CLAUDE.md` §13.1** — example `ci.yml` env block updated
- **`docs/deploy-runbook.md` §4.3** — removed the "DATABASE_URL must match POSTGRES_PASSWORD" warning (structurally impossible post-fix)
- **`docs/deploy-runbook.md` §9.12** — rewrote the password-auth-failed troubleshooting to reflect single-source-of-truth (no "second value in `.env` to consult")
- **`docs/dev-runbook.md` §1 + §6** — dev `.env` example updated; alphanumeric-password rule prose simplified

## Verification
Full suite locally: **243 pass + 1 xfailed**, no regressions. Baseline was 240 + 1 xfailed pre-PR; +3 = the new D51 tests moving RED → GREEN.

## Test plan
- [x] Local `pytest` green (243 pass, 0 fail)
- [x] Audit grep — no remaining `DATABASE_URL` / `env.db()` references in `config/`, `apps/`, `scrapers/`, `discord_bot/`, `.github/` (5 sites all changed)
- [ ] After M10 close (D52) — operator updates VM `.env` per new shape, `docker compose pull && up -d`, verify migrate exits 0
- [ ] After M10 close (D52) — Hetzner VM `grep DATABASE_URL /opt/tibiantis/.env` returns no matches

## Dev parity
- **Dev/CI/prod** all read the same five `POSTGRES_*` vars; no env-shape drift between environments
- Dev `.env` uses `POSTGRES_HOST=localhost POSTGRES_PORT=5435` (docker-compose.dev.yml host port); prod uses `POSTGRES_HOST=postgres POSTGRES_PORT=5432` (docker service DNS)

Refs M10 plan tasks D51.3-D51.7.