### PR TITLE
fix(discord_bot): canonicalize character_name in add wrapper (#164 follow-up)

### DIFF
--- a/discord_bot/services.py
+++ b/discord_bot/services.py
@@ -9,6 +9,7 @@ from discord_bot.models import DiscordChannel
 
 from apps.bedmages.models import BedmageWatch
 from apps.bedmages.services import add_bedmage_watch, remove_bedmage_watch
+from apps.characters.models import _canonicalize_name
 
 logger = logging.getLogger(__name__)
 
@@ -68,8 +69,15 @@ def add_bedmage_for_discord_user(
 
     Returns (watch, created). created=False when watch already on user's list
     (catches ValueError from apps service, idempotent ack).
+
+    Canonicalizes character_name at entry (same primitive as
+    apps.bedmages.services). Without this, the ValueError-recovery .get()
+    below would look up the raw user-typed casing (e.g. "akrutki") while the
+    Character row is stored under the canonical form ("Akrutki"), producing
+    BedmageWatch.DoesNotExist. Caught in prod on M10-D52 after #164 landed.
     """
     user, _ = get_or_create_user_by_discord_id(discord_id, discord_username)
+    character_name = _canonicalize_name(character_name)
     try:
         watch = add_bedmage_watch(user, character_name)
         return watch, True

--- a/tests/unit/discord_bot/test_services.py
+++ b/tests/unit/discord_bot/test_services.py
@@ -198,6 +198,42 @@ def test_add_bedmage_for_discord_user_returns_existing_on_duplicate() -> None:
     )
 
 
+@pytest.mark.django_db
+def test_add_bedmage_for_discord_user_returns_existing_on_duplicate_with_different_casing() -> (
+    None
+):
+    """Regression for M10-D52 prod bug — DoesNotExist surfaced as "Something
+    went wrong" when the second add used a different casing of the same name.
+
+    Post-#164 the apps service canonicalizes "akrutki" → "Akrutki" at entry,
+    creates the Character row under the canonical form, and raises ValueError
+    on duplicate. The bot wrapper's `except ValueError` recovery .get() must
+    also use the canonical form for the lookup — otherwise `character__name=
+    "akrutki"` 404s on a row stored as "Akrutki", BedmageWatch.DoesNotExist
+    escapes the wrapper, and the cog's catch-all renders "Something went
+    wrong" to the user.
+
+    The test that pinned the existing same-casing idempotency
+    (`..._returns_existing_on_duplicate`) didn't catch this because it used
+    "Yhral" → "Yhral" — pre-fix that works because canonicalize is a no-op
+    on already-canonical input. Mixed-casing exercises the bug.
+    """
+    first, first_created = add_bedmage_for_discord_user(
+        discord_id=42, discord_username="alice", character_name="Akrutki"
+    )
+    second, second_created = add_bedmage_for_discord_user(
+        discord_id=42, discord_username="alice", character_name="akrutki"
+    )
+
+    assert first_created is True
+    assert second_created is False
+    assert second.pk == first.pk
+    assert (
+        BedmageWatch.objects.filter(user=first.user, character=first.character).count()
+        == 1
+    )
+
+
 # === remove_bedmage_for_discord_user (D33) ===
 
 


### PR DESCRIPTION
## Summary
Hotfix for an M10-D52 prod bug surfaced after #170 + #173 deployed to Hetzner. `/bedmage add Akrutki` then `/bedmage add akrutki` in Discord produced "Something went wrong. The admins have been notified" instead of the friendly "already exists" ack. The bot's catch-all error handler was rendering a `BedmageWatch.DoesNotExist` exception that escaped the cog's normal `ValueError` recovery.

## Root cause
`apps.bedmages.services.add_bedmage_watch` (D49.6) canonicalizes `"akrutki"` → `"Akrutki"` at entry, so the Character row is stored under the canonical form. On duplicate add it raises `ValueError("already exists")`.

`discord_bot.services.add_bedmage_for_discord_user` catches that `ValueError` and recovers by doing `BedmageWatch.objects.get(user=user, character__name=character_name)` — but `character_name` is still the **raw user-typed casing**. `character__name="akrutki"` 404s on a row stored as `"Akrutki"`, raises `DoesNotExist`, which escapes the wrapper. The cog's catch-all renders the generic friendly message.

The D49.6 audit canonicalized at entry in `apps.bedmages.services` (USER/REMOVE) but missed this downstream `.get()` in the discord wrapper.

## Fix
- `discord_bot/services.py` — import `_canonicalize_name` from `apps.characters.models` and apply at entry of `add_bedmage_for_discord_user`, before both the inner service call AND the `.get()` recovery. Inline comment documents the prod incident.
- `remove_bedmage_for_discord_user` — unchanged. It delegates straight to `apps.bedmages.services.remove_bedmage_watch` which canonicalizes at entry per D49.6.

## Regression test
`test_add_bedmage_for_discord_user_returns_existing_on_duplicate_with_different_casing` — adds `"Akrutki"` then `"akrutki"` through the wrapper. Pre-fix raises `DoesNotExist`; post-fix returns `(existing, False)` identically to the same-casing path.

The existing `..._returns_existing_on_duplicate` test passed in CI because `_canonicalize_name` is a no-op on already-canonical input (`"Yhral"` → `"Yhral"`). Mixed casing exercises the bug — now covered.

## Verification
- 39 discord_bot tests pass locally (was 38, +1 = regression)
- Bug repro on Hetzner VM matches the M10-D52 prod incident exactly

## Test plan
- [x] Local pytest green (39/39 discord_bot)
- [x] Existing same-casing duplicate test still passes (no regression in the working path)
- [ ] Post-merge: redeploy Hetzner (`docker compose pull && up -d`), retry `/bedmage add Akrutki` + `/bedmage add akrutki` — second add should error with friendly "already exists", NOT generic "Something went wrong"

Refs #164