### PR TITLE
feat(notifications): hyperlink character name + line-by-line death embed (#178)

### DIFF
--- a/apps/notifications/handlers.py
+++ b/apps/notifications/handlers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import urllib.parse
 from typing import TYPE_CHECKING, Protocol, Any
 
 if TYPE_CHECKING:
@@ -103,10 +104,29 @@ class DiscordChannelHandler:
         )
 
     def _render_embed(self, death_event: DeathEvent) -> dict[str, Any]:
+        """Build Discord embed with hyperlinked character name + line-by-line info.
+
+        Per #178: `title` is the raw character name; `url` makes it a clickable
+        hyperlink to the Tibiantis online character page (quote_plus encoding —
+        Tibiantis uses `+` for spaces in URLs). `description` carries the three
+        info lines (level / wall-clock time / killer). Empty `killed_by` renders
+        as "unknown" (the model default for un-parsed kill messages).
+
+        Embed `timestamp` field intentionally absent — wall-clock time lives in
+        `description` now. Discord's footer timestamp would render in viewer's
+        local TZ and disagree with the description, confusing operators.
+        """
         return {
-            "title": f"💀 {death_event.character_name} (level {death_event.level_at_death})",
-            "description": death_event.killed_by or "Cause unknown",
-            "timestamp": death_event.died_at.isoformat(),
+            "title": death_event.character_name,
+            "url": (
+                "https://www.tibiantis.online/?page=character&name="
+                + urllib.parse.quote_plus(death_event.character_name)
+            ),
+            "description": (
+                f"Died at level {death_event.level_at_death}\n"
+                f"{death_event.died_at:%Y-%m-%d %H:%M:%S}\n"
+                f"Killed by: {death_event.killed_by or 'unknown'}"
+            ),
             "color": 0xDC143C,  # crimson
         }
 

--- a/tests/unit/notifications/test_discord_channel_handler.py
+++ b/tests/unit/notifications/test_discord_channel_handler.py
@@ -79,29 +79,93 @@ def test_handler_announce_calls_client_send_channel_message_with_embed(
     assert "content" not in call_kwargs or call_kwargs.get("content") is None
 
 
-def test_handler_announce_renders_embed_with_character_level_killed_by_color(
+def test_handler_announce_renders_embed_with_hyperlinked_title_and_info_description(
     death_event: MagicMock,
     discord_channel: MagicMock,
     mock_client: MagicMock,
 ) -> None:
-    """Embed shape contract — 4 keys with specific semantics:
+    """Embed shape contract post-#178 — character name as a clickable embed
+    title (via `url` field), info lines in `description`.
 
-    - `title`: 💀 + character name + level in parens (visible card heading)
-    - `description`: killed_by raw text (Discord renders body)
-    - `timestamp`: ISO 8601 with TZ (Discord parses + displays in user's TZ)
+    Pinned fields:
+    - `title`: raw character name (no emoji prefix, no level suffix)
+    - `url`: Tibiantis online character page, URL-encoded via quote_plus
+      so Discord renders the title as a clickable hyperlink
+    - `description`: three lines — `Died at level N` / `YYYY-MM-DD HH:MM:SS`
+      / `Killed by: <killed_by>`
     - `color`: integer `0xDC143C` (crimson) — Pułapka C, NOT hex string
+    - `timestamp`: removed (was: ISO 8601 string consumed by Discord as
+      a footer). The wall-clock time is in `description` now; the embed
+      footer rendered in viewer's local TZ would have shown a different
+      value, confusing operators.
 
-    Locks each field separately so a future refactor of one (e.g. localizing
-    "level" to "lvl") doesn't silently break the others.
+    Locks each field separately so a future refactor of one (e.g.
+    localizing "level" to "lvl") doesn't silently break the others.
     """
     DiscordChannelHandler().announce(death_event, discord_channel)
 
     embed = mock_client.send_channel_message.call_args.kwargs["embed"]
-    assert embed["title"] == "💀 Yhral (level 60)"
-    assert embed["description"] == "a dragon lord"
-    assert embed["timestamp"] == "2026-05-15T14:30:00+00:00"
+    assert embed["title"] == "Yhral"
+    assert embed["url"] == "https://www.tibiantis.online/?page=character&name=Yhral"
+    assert embed["description"] == (
+        "Died at level 60\n" "2026-05-15 14:30:00\n" "Killed by: a dragon lord"
+    )
     assert embed["color"] == 0xDC143C
     assert isinstance(embed["color"], int)  # Pułapka C — int, not "0xDC143C"
+    assert (
+        "timestamp" not in embed
+    )  # removed by #178; wall-clock now lives in description
+
+
+def test_handler_announce_renders_unknown_when_killed_by_is_empty(
+    death_event: MagicMock,
+    discord_channel: MagicMock,
+    mock_client: MagicMock,
+) -> None:
+    """Empty `killed_by` (the model default for un-parsed kill messages)
+    renders as `Killed by: unknown` in description.
+
+    The model has `killed_by = TextField(blank=True, default="")` so the
+    scraper can store "" when it can't parse the kill cause from the
+    Tibiantis deaths page. The notification should not say `Killed by: `
+    with an empty trailer — that would look like a parser bug to operators.
+    `"unknown"` is the post-#178 friendly fallback (shorter than the prior
+    `"Cause unknown"` which was a full standalone description).
+    """
+    death_event.killed_by = ""
+
+    DiscordChannelHandler().announce(death_event, discord_channel)
+
+    embed = mock_client.send_channel_message.call_args.kwargs["embed"]
+    assert "Killed by: unknown" in embed["description"]
+
+
+def test_handler_announce_urlencodes_space_in_character_name(
+    death_event: MagicMock,
+    discord_channel: MagicMock,
+    mock_client: MagicMock,
+) -> None:
+    """Character names with spaces produce `+`-encoded URLs.
+
+    Tibiantis's character-page URL uses `application/x-www-form-urlencoded`
+    style (`+` for space), and `urllib.parse.quote_plus` produces exactly
+    that. A name like `Im Bluee` must yield `name=Im+Bluee`, not
+    `name=Im%20Bluee` (which the Tibiantis page does also accept but isn't
+    the canonical form linked from the site itself) and not `name=Im Bluee`
+    (which Discord may render as a broken link).
+
+    Defensive against future names with other special chars — `quote_plus`
+    handles `%XX` encoding for those too.
+    """
+    death_event.character_name = "Im Bluee"
+
+    DiscordChannelHandler().announce(death_event, discord_channel)
+
+    embed = mock_client.send_channel_message.call_args.kwargs["embed"]
+    assert embed["url"] == "https://www.tibiantis.online/?page=character&name=Im+Bluee"
+    assert (
+        embed["title"] == "Im Bluee"
+    )  # title text keeps the space; only URL encodes it
 
 
 def test_handler_announce_returns_false_on_send_failure(


### PR DESCRIPTION
## Summary
Closes #178. Reworks the death-announcement Discord embed to make the character name a clickable link to the Tibiantis online page, with info on separate lines for readability.

**Before:**
```
💀 Im Bluee (level 49)
a ghoul
[footer timestamp in viewer's local TZ]
```

**After:**
```
Im Bluee                    ← bold, clickable link
Died at level 49
2026-05-06 19:49:29
Killed by: a ghoul
```

## Changes
- **`apps/notifications/handlers.py`** — `_render_embed` rewritten:
  - `title` = raw `character_name` (no emoji prefix, no level suffix)
  - `url` = `https://www.tibiantis.online/?page=character&name=<quote_plus(name)>` — Discord renders title+url as a heading-style hyperlink
  - `description` = 3 lines (`Died at level N` / `YYYY-MM-DD HH:MM:SS` / `Killed by: ...`). Empty `killed_by` → `"unknown"` (was `"Cause unknown"`)
  - `color` unchanged crimson `0xDC143C`
  - `timestamp` field removed — wall-clock is in description now; the embed footer would render in viewer's local TZ vs description's UTC value, confusing operators
- **`tests/unit/notifications/test_discord_channel_handler.py`** (in earlier commit `fc08a0f`) — 3 RED-now-GREEN tests pinning the new contract:
  - `test_handler_announce_renders_embed_with_hyperlinked_title_and_info_description` — title/url/description/color/no-timestamp
  - `test_handler_announce_renders_unknown_when_killed_by_is_empty` — empty `killed_by` → `"Killed by: unknown"`
  - `test_handler_announce_urlencodes_space_in_character_name` — `"Im Bluee"` → `name=Im+Bluee` (quote_plus, Tibiantis convention)
- 2 unchanged wiring tests (`calls_client_send_channel_message_with_embed`, `returns_false_on_send_failure`) still pass — they don't depend on embed shape.

## Verification
- 5/5 tests pass in `tests/unit/notifications/test_discord_channel_handler.py`
- Pre-commit (lint + format + mypy) green
- Net diff: +23/-3 in `handlers.py`, +75/-11 in the test file

## Test plan
- [x] Local pytest green on the notifications test module
- [x] Pre-commit hooks green
- [x] CI green (full suite)
- [x] Post-merge redeploy on Hetzner — next scraped death over the threshold produces the new embed format in the configured Discord channel
- [x] Click the character name in the Discord message — opens the Tibiantis online character page

## Out of scope (defer)
- TZ conversion for `died_at` — display whatever's in the DB (UTC). If the displayed time looks off by hours when verified in prod, separate ticket.
- Bedmage DM hyperlink — symmetric improvement for `DiscordDMHandler._render` but separate concern.
- `urlbuilder` helper for tibiantis.online links — extract once a 2nd or 3rd call site needs the same pattern.

Refs M11.