### PR TITLE
feat(notifications): display death time in Europe/Warsaw, not UTC (#180)

### DIFF
--- a/apps/notifications/handlers.py
+++ b/apps/notifications/handlers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import urllib.parse
 from typing import TYPE_CHECKING, Protocol, Any
+from zoneinfo import ZoneInfo
 
 if TYPE_CHECKING:
     from apps.bedmages.models import BedmageWatch
@@ -112,10 +113,17 @@ class DiscordChannelHandler:
         info lines (level / wall-clock time / killer). Empty `killed_by` renders
         as "unknown" (the model default for un-parsed kill messages).
 
+        Per #180: `died_at` is converted from UTC (DB storage) to Europe/Warsaw
+        before formatting, so the displayed time matches Polish operator
+        expectation and the tibiantis.info deaths-page time (server-local,
+        Europe/Berlin = same offset as Europe/Warsaw year-round). `zoneinfo`
+        handles DST correctly (CEST/CET transitions at the two annual Sundays).
+
         Embed `timestamp` field intentionally absent — wall-clock time lives in
         `description` now. Discord's footer timestamp would render in viewer's
         local TZ and disagree with the description, confusing operators.
         """
+        died_at_local = death_event.died_at.astimezone(ZoneInfo("Europe/Warsaw"))
         return {
             "title": death_event.character_name,
             "url": (
@@ -124,7 +132,7 @@ class DiscordChannelHandler:
             ),
             "description": (
                 f"Died at level {death_event.level_at_death}\n"
-                f"{death_event.died_at:%Y-%m-%d %H:%M:%S}\n"
+                f"{died_at_local:%Y-%m-%d %H:%M:%S}\n"
                 f"Killed by: {death_event.killed_by or 'unknown'}"
             ),
             "color": 0xDC143C,  # crimson

--- a/tests/unit/notifications/test_discord_channel_handler.py
+++ b/tests/unit/notifications/test_discord_channel_handler.py
@@ -107,8 +107,10 @@ def test_handler_announce_renders_embed_with_hyperlinked_title_and_info_descript
     embed = mock_client.send_channel_message.call_args.kwargs["embed"]
     assert embed["title"] == "Yhral"
     assert embed["url"] == "https://www.tibiantis.online/?page=character&name=Yhral"
+    # Fixture's died_at is 2026-05-15 14:30 UTC; in CEST (UTC+2, May) that's
+    # 16:30 Europe/Warsaw — the post-#180 expected display.
     assert embed["description"] == (
-        "Died at level 60\n" "2026-05-15 14:30:00\n" "Killed by: a dragon lord"
+        "Died at level 60\n2026-05-15 16:30:00\nKilled by: a dragon lord"
     )
     assert embed["color"] == 0xDC143C
     assert isinstance(embed["color"], int)  # Pułapka C — int, not "0xDC143C"
@@ -166,6 +168,34 @@ def test_handler_announce_urlencodes_space_in_character_name(
     assert (
         embed["title"] == "Im Bluee"
     )  # title text keeps the space; only URL encodes it
+
+
+def test_handler_announce_renders_died_at_in_europe_warsaw_during_winter(
+    death_event: MagicMock,
+    discord_channel: MagicMock,
+    mock_client: MagicMock,
+) -> None:
+    """Winter (CET = UTC+1) DST handling — death timestamps render correctly
+    outside summer time.
+
+    Guards against someone "fixing" #180 by hardcoding `+ timedelta(hours=2)`
+    instead of using `zoneinfo.ZoneInfo("Europe/Warsaw")`. A constant-offset
+    fix would be wrong half the year (Oct→Mar = CET, UTC+1) and at the two
+    annual DST transition Sundays.
+
+    UTC 14:30 on Dec 10 → Europe/Warsaw 15:30 (CET = UTC+1). Pre-#180 the
+    display showed 14:30 (raw UTC). The companion summer test
+    (..._hyperlinked_title_and_info_description) covers CEST (UTC+2).
+    """
+    death_event.died_at = datetime(2026, 12, 10, 14, 30, 0, tzinfo=timezone.utc)
+
+    DiscordChannelHandler().announce(death_event, discord_channel)
+
+    embed = mock_client.send_channel_message.call_args.kwargs["embed"]
+    assert "2026-12-10 15:30:00" in embed["description"]
+    assert (
+        "2026-12-10 14:30:00" not in embed["description"]
+    )  # the UTC value must NOT leak
 
 
 def test_handler_announce_returns_false_on_send_failure(


### PR DESCRIPTION
## Summary
Closes #180. Death notifications show wall-clock time in `Europe/Warsaw` (Polish local) instead of raw UTC. Operators previously saw notifications 1-2h behind their local clock, which also disagreed with `tibiantis.info`'s deaths page (server-local, Europe/Berlin = same offset as Europe/Warsaw year-round).

**Before:**
```
Marian the Great
Died at level 2
2026-05-16 23:58:17    ← UTC, but Polish local is 2026-05-17 01:58:17 (CEST = UTC+2)
Killed by: a bug
```

**After:**
```
Marian the Great
Died at level 2
2026-05-17 01:58:17    ← Europe/Warsaw, matches tibiantis.info display
Killed by: a bug
```

## Changes
- **`apps/notifications/handlers.py`** — `+1 import` + 1 line added in `_render_embed`:
  - `from zoneinfo import ZoneInfo` (stdlib, Python 3.9+, no external dep)
  - `died_at_local = death_event.died_at.astimezone(ZoneInfo("Europe/Warsaw"))` before the f-string format
  - `zoneinfo` handles DST automatically: CEST (UTC+2, Apr-Oct), CET (UTC+1, Oct-Mar), transitions on the two annual Sundays
- **`tests/unit/notifications/test_discord_channel_handler.py`** (earlier commit `bcbbcf5`):
  - **Updated** `test_handler_announce_renders_embed_with_hyperlinked_title_and_info_description` — fixture UTC 14:30 in May → expected `2026-05-15 16:30:00` (CEST)
  - **New** `test_handler_announce_renders_died_at_in_europe_warsaw_during_winter` — fixture UTC 14:30 in Dec → expected `2026-12-10 15:30:00` (CET). Guards against a hardcoded `+ timedelta(hours=2)` "fix" that would be wrong half the year.

## Verification
- 6/6 tests in `test_discord_channel_handler.py` pass locally (2 updated + 4 unchanged from #178)
- Pre-commit green (lint + format + mypy + gitleaks + Conventional Commit)

## Test plan
- [x] Local pytest green
- [x] Pre-commit hooks green
- [ ] CI green (full suite)
- [ ] Post-merge: redeploy on Hetzner, wait for next death scrape, verify Discord embed time matches the Polish operator's local clock (and `tibiantis.info` deaths page)

## Out of scope (defer)
- Bedmage DM `last_login` — currently formatted as `%Y-%m-%d %H:%M UTC` with explicit "UTC" suffix; same TZ issue but separate ticket if it bothers anyone.
- Configurable `DEATH_NOTIFICATION_TZ` env var — YAGNI for single-operator Polish project.
- Explicit TZ name in display (e.g. `... CEST`) — mockup didn't include it.

Refs M11.