### PR TITLE
feat(ci): auto-deploy to Hetzner on master push + Discord webhook notify (#182)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,3 +50,64 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy:
+    # Auto-deploy the newly-pushed :master image to Hetzner VM (#182). Fires
+    # only on push to master (not on PRs, not on tags) after the build job
+    # succeeds. SSH into the VM as the dedicated `deploy` user and run
+    # `docker compose pull && up -d`. Health-check polling at the end fails
+    # the job if the new stack doesn't return 200 on /health/ within 60s.
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - name: SSH + docker compose pull && up -d
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.HETZNER_HOST }}
+          username: ${{ secrets.HETZNER_USER }}
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            cd /opt/tibiantis
+            docker compose pull
+            docker compose up -d
+            # Wait for /health/ to return 200 — up to 60s total (12 × 5s).
+            # Covers the migrate one-shot + web boot. Failure here marks the
+            # deploy job as failed; the notify job below catches it.
+            for i in $(seq 1 12); do
+              if curl --max-time 5 -fsS http://localhost:8000/health/ >/dev/null; then
+                echo "Health check OK after ${i} attempts"
+                exit 0
+              fi
+              sleep 5
+            done
+            echo "Health check failed after 60s"
+            exit 1
+
+  notify:
+    # Post deploy outcome to Discord webhook. `if: always()` so failures are
+    # reported too — `needs.deploy.result` distinguishes success/failure.
+    # Gated by the same master-push condition as deploy so PR builds don't
+    # produce noise.
+    needs: deploy
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord
+        env:
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          WEBHOOK_URL: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
+        run: |
+          if [ "${DEPLOY_RESULT}" = "success" ]; then
+            STATUS="✅ Deployed"
+            COLOR=3066993
+          else
+            STATUS="❌ Deploy failed"
+            COLOR=15158332
+          fi
+          SHA_SHORT="${GITHUB_SHA:0:7}"
+          RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          curl -fsS -H "Content-Type: application/json" \
+            -d "{\"embeds\":[{\"title\":\"${STATUS} sha-${SHA_SHORT} to prod\",\"url\":\"${RUN_URL}\",\"color\":${COLOR}}]}" \
+            "${WEBHOOK_URL}"

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -171,7 +171,9 @@ In browser: http://localhost:3001 → Uptime Kuma setup wizard.
 
 ## §7 Rolling update
 
-After CI pushes to master (new `:master` tag in Docker Hub):
+**Post-#182, rolling update is automatic on master push.** The `deploy:` job in `.github/workflows/docker.yml` SSHes to the VM and runs `docker compose pull && up -d` after `build:` completes. Discord webhook (`DISCORD_DEPLOY_WEBHOOK_URL`) posts ✅/❌ to the dev guild. See §11.
+
+Manual update still works (use this if auto-deploy is disabled, or for ad-hoc redeploys):
 
 ```bash
 ssh deploy@<hetzner-ip>
@@ -296,3 +298,71 @@ Optional add-ons (M-future):
 - Hetzner backups: +20% of server cost (~1.20€/mc)
 - Static IPv4 reservation: ~1€/mc
 - Off-site backup storage (Backblaze B2): ~$0.005/GB/mc
+
+## §11 Auto-deploy via GitHub Actions (#182)
+
+After PR #182, every push to `master` triggers an automatic deploy. The flow:
+
+1. `build` job in `.github/workflows/docker.yml` builds + pushes the new image to Docker Hub (`bgozl/tibiantis-scraper:master` + `:sha-<short>`)
+2. `deploy` job SSHes to the Hetzner VM as the `deploy` user and runs `docker compose pull && docker compose up -d`
+3. Post-deploy, the `deploy` job polls `http://localhost:8000/health/` for up to 60s (12 × 5s). Failure exits non-zero → job marked failed
+4. `notify` job (runs `if: always()`) posts the outcome to the Discord webhook: ✅ on success, ❌ on failure with a link to the GHA run
+
+### Required secrets
+
+| Secret | Value |
+|---|---|
+| `HETZNER_HOST` | VM IPv4 (currently `178.105.122.18`) |
+| `HETZNER_USER` | `deploy` |
+| `HETZNER_SSH_KEY` | Dedicated ed25519 private key (NOT the operator's daily-driver key). Pubkey appended to `/home/deploy/.ssh/authorized_keys` on the VM |
+| `DISCORD_DEPLOY_WEBHOOK_URL` | Webhook URL for the dev guild `#ci` (or chosen) channel |
+
+Set via `gh secret set <NAME>` (interactive for the webhook URL to avoid shell history).
+
+### Disable temporarily
+
+Two options:
+
+**Option A (surgical):** delete the secrets the deploy job depends on — the workflow will fail at the SSH step and the notify step will fire ❌, but no actual deploy attempt happens because the SSH action can't authenticate.
+
+```bash
+gh secret delete HETZNER_SSH_KEY
+# Re-set later when ready to resume auto-deploy
+```
+
+**Option B (clean):** comment out the `deploy:` and `notify:` jobs in `.github/workflows/docker.yml` on a quick PR. The `build:` job continues pushing images to Docker Hub but nothing happens on the VM until you `docker compose pull && up -d` manually (see §7).
+
+### Rotate the deploy SSH key
+
+If the key is suspected compromised:
+
+```bash
+# On laptop — generate new key
+ssh-keygen -t ed25519 -C "github-actions-deploy" -f ~/.ssh/tibiantis_deploy_ed25519_new -N ""
+
+# Append new pubkey to VM
+cat ~/.ssh/tibiantis_deploy_ed25519_new.pub | ssh deploy@<vm-ip> 'cat >> ~/.ssh/authorized_keys'
+
+# Remove old pubkey from VM authorized_keys (edit manually)
+ssh deploy@<vm-ip>
+nano ~/.ssh/authorized_keys
+# Delete the line ending in "github-actions-deploy" (old key)
+# Save + exit
+
+# Update GHA secret with new private key
+gh secret set HETZNER_SSH_KEY < ~/.ssh/tibiantis_deploy_ed25519_new
+
+# Verify next deploy works
+git commit --allow-empty -m "chore: trigger deploy after key rotation"
+git push origin master
+# Watch the run in GHA UI + Discord channel
+```
+
+### Rotate the Discord webhook URL
+
+If the URL leaked (it's a bearer-token-style credential):
+
+1. Discord → channel settings → Integrations → Webhooks → delete the leaked webhook
+2. Create a new one in the same channel, copy URL
+3. `gh secret set DISCORD_DEPLOY_WEBHOOK_URL` (interactive paste)
+4. Next deploy uses the new URL automatically


### PR DESCRIPTION
## Summary
Closes #182. Adds two new jobs to `.github/workflows/docker.yml` so every push to master automatically deploys the new image to the Hetzner VM and posts the outcome to Discord. No more manual `ssh deploy@... && docker compose pull && up -d` per PR merge.

```
push to master
      │
      ▼
build (existing) — push :master + :sha-<short> to Docker Hub
      │ (success-only)
      ▼
deploy (new) — SSH to Hetzner, `docker compose pull && up -d`, poll /health/ 60s
      │
      ▼
notify (new, if: always()) — POST to Discord webhook: ✅/❌ + sha + run URL
```

## Changes
- **`.github/workflows/docker.yml`**:
  - `deploy:` job (depends on `build:`, gated to `push` + `refs/heads/master`) — `appleboy/ssh-action@v1.2.2`, runs `docker compose pull && up -d`, polls `/health/` 12×5s. Job fails if health check times out.
  - `notify:` job (`if: always()` + same master-push gate) — `curl` to `DISCORD_DEPLOY_WEBHOOK_URL` with embed payload. Green ✅ on success, red ❌ on failure, links to GHA run.
  - Existing `build:` job unchanged.

- **`docs/deploy-runbook.md`**:
  - §7 (Rolling update) — leads with "automatic on master push" reference to new §11. Manual command preserved as a fallback.
  - New §11 — full flow, required-secrets table, disable-temporarily playbook (delete secret OR comment out the job), SSH key rotation procedure, webhook rotation procedure.

## Operator setup (done before this PR)
All 4 GitHub secrets already set:
- `HETZNER_HOST` = `178.105.122.18`
- `HETZNER_USER` = `deploy`
- `HETZNER_SSH_KEY` = dedicated ed25519 passphraseless key (NOT operator's daily-driver key)
- `DISCORD_DEPLOY_WEBHOOK_URL` = dev guild `#ci` channel webhook (initial leak-and-rotate done out-of-band)

Verified via `gh secret list` — all 4 timestamps "less than a minute ago" at setup time.

## Test plan
- [x] YAML syntax OK locally (pre-commit accepted; gh push succeeded)
- [x] All 4 secrets set
- [x] Deploy SSH key verified to authenticate (manual `ssh -i ~/.ssh/tibiantis_deploy_ed25519 deploy@<vm-ip> hostname` worked)
- [x] Webhook URL verified via curl smoke test (test message landed in `#ci`)
- [ ] **After merge: first deploy is the end-to-end smoke** — watch GHA UI + Discord `#ci` for ✅
- [ ] Force a failure once (e.g. break the health-check URL in a test branch or `workflow_dispatch`) to verify the ❌ path shows up with a working run-URL link

## Out of scope (defer)
Per #182 §"Out of scope":
- Pre-deploy `pg_dump` backup — operator does this manually before risky migrations
- Rollback automation — manual: `sed` the compose file to a `sha-<old>` image per §8
- `workflow_run` split (separate `deploy.yml`) — single workflow keeps dep chain explicit
- `authorized_keys command="..."` restriction on deploy key — defense-in-depth hardening, separate ticket
- Multi-environment (staging) — single VM stays as-is

## No unit-test surface
This is a CI workflow YAML change — no RED-test-first applies. The acceptance gate is end-to-end: merge the PR, watch the next master push automatically deploy and notify Discord. If anything breaks, the disable-temporarily playbook in §11 recovers quickly.

Refs M11.