### PR TITLE
feat(notifications): display bedmage DM last_login in Europe/Warsaw (#184)

### DIFF
--- a/apps/notifications/handlers.py
+++ b/apps/notifications/handlers.py
@@ -69,12 +69,27 @@ class DiscordDMHandler:
             )
 
     def _render(self, watch: BedmageWatch) -> str:
+        """Render bedmage notification DM body.
+
+        Per #184: `last_login` converted from UTC (DB storage) to Europe/Warsaw
+        before formatting, matching #180/#181's death-notification fix. The
+        literal `" UTC"` suffix was dropped — operators saw 1-2h offset vs
+        their local clock and the tibiantis.online "Last login" display.
+        """
         from django.conf import settings
 
+        # Invariant: services.check_bedmage_watches_for_character early-returns
+        # when character.last_login is None, so by the time the handler runs
+        # the field is non-None. Assert documents this + narrows the type
+        # (DateTimeField(null=True) → datetime | None in stubs).
+        assert watch.character.last_login is not None
+        last_login_local = watch.character.last_login.astimezone(
+            ZoneInfo("Europe/Warsaw")
+        )
         return (
             f"🛏️ Your bedmage **{watch.character.name}** has been logged out for "
             f"{settings.BEDMAGE_REGEN_MINUTES} minutes — mana fully regenerated.\n"
-            f"Last login: {watch.character.last_login:%Y-%m-%d %H:%M UTC}"
+            f"Last login: {last_login_local:%Y-%m-%d %H:%M}"
         )
 
 

--- a/tests/unit/notifications/test_discord_dm_handler.py
+++ b/tests/unit/notifications/test_discord_dm_handler.py
@@ -73,11 +73,17 @@ def test_handler_renders_message_with_character_name_regen_minutes_and_last_logi
     watch: MagicMock, mock_client: MagicMock, settings: pytest.FixtureRequest
 ) -> None:
     """Message template includes: 🛏️ emoji, character name (bolded), regen minutes
-    from settings (NOT hardcoded), and last_login formatted as `YYYY-MM-DD HH:MM UTC`.
+    from settings (NOT hardcoded), and last_login formatted in Europe/Warsaw
+    local time (no TZ suffix).
 
     Pułapka C from #129 — using `settings.BEDMAGE_REGEN_MINUTES` (current value,
     not hardcoded "100"). Test overrides the setting and verifies the rendered
     string reflects the override, locking the dynamic-read contract.
+
+    Post-#184: fixture's last_login = 2026-05-15 10:00 UTC; in CEST (UTC+2, May)
+    that's 12:00 Europe/Warsaw. The literal `" UTC"` suffix was dropped — the
+    displayed time is now in Polish local without a TZ marker (matches the
+    operator's mental model of "what tibiantis.online showed").
     """
     settings.BEDMAGE_REGEN_MINUTES = 90  # type: ignore[attr-defined]
 
@@ -87,7 +93,33 @@ def test_handler_renders_message_with_character_name_regen_minutes_and_last_logi
     assert "🛏️" in content
     assert "**Yhral**" in content
     assert "90" in content  # not 100 — proves the setting is read dynamically
-    assert "2026-05-15 10:00 UTC" in content
+    assert "Last login: 2026-05-15 12:00" in content  # CEST = UTC+2, May
+    assert "UTC" not in content  # post-#184: no TZ suffix in last_login display
+
+
+def test_handler_renders_last_login_in_europe_warsaw_during_winter(
+    watch: MagicMock, mock_client: MagicMock
+) -> None:
+    """Winter (CET = UTC+1) DST handling — bedmage DM time renders correctly
+    outside summer time.
+
+    Guards against a "fix" using hardcoded `+timedelta(hours=2)` instead of
+    `zoneinfo.ZoneInfo("Europe/Warsaw")`. A constant-offset fix would be wrong
+    half the year (Oct→Mar = CET, UTC+1) and at the two annual DST transition
+    Sundays. Mirrors test_handler_announce_renders_died_at_in_europe_warsaw_during_winter
+    in test_discord_channel_handler.py for the death-notification handler.
+
+    Fixture override: last_login = 2026-12-10 14:30 UTC → Europe/Warsaw 15:30 (CET).
+    """
+    from datetime import datetime, timezone
+
+    watch.character.last_login = datetime(2026, 12, 10, 14, 30, 0, tzinfo=timezone.utc)
+
+    DiscordDMHandler().notify(watch)
+
+    content = mock_client.send_dm.call_args.args[1]
+    assert "Last login: 2026-12-10 15:30" in content  # CET = UTC+1, December
+    assert "Last login: 2026-12-10 14:30" not in content  # raw UTC must NOT leak
 
 
 def test_handler_logs_error_and_skips_send_when_discord_id_is_none(


### PR DESCRIPTION
## Summary
Closes #184. Sibling fix to #180/#181 (death notification TZ) applied to `DiscordDMHandler._render`. Bedmage notification DMs now show `Last login` in Polish local time instead of raw UTC.

**Before:**
```
🛏️ Your bedmage Akrutki has been logged out for 100 minutes — mana fully regenerated.
Last login: 2026-05-16 22:37 UTC
```

**After:**
```
🛏️ Your bedmage Akrutki has been logged out for 100 minutes — mana fully regenerated.
Last login: 2026-05-17 00:37
```

## Changes
- **`apps/notifications/handlers.py`** — `_render` converts via `.astimezone(ZoneInfo("Europe/Warsaw"))` before formatting. Format string `%Y-%m-%d %H:%M UTC` → `%Y-%m-%d %H:%M` (drops literal `" UTC"` suffix). `ZoneInfo` import was already added in #181. Added `assert watch.character.last_login is not None` for mypy narrowing (service layer's `check_bedmage_watches_for_character` early-returns when `last_login` is None, so the handler never sees the null case).
- **`tests/unit/notifications/test_discord_dm_handler.py`** — updated existing happy-path assertion (UTC 10:00 → CEST 12:00, `"UTC" not in content`); added new `test_handler_renders_last_login_in_europe_warsaw_during_winter` guarding CET (UTC+1) DST. Mirrors the winter-DST guard pattern from `test_discord_channel_handler.py` introduced in #181.

## Verification
- 5/5 tests pass in `test_discord_dm_handler.py` (4 pre-existing + 1 new winter-DST guard)
- Pre-commit green
- Net diff: +50/-3 across the two files

## Test plan
- [x] Local pytest green
- [x] Pre-commit hooks green (incl. mypy)
- [ ] CI green
- [ ] Auto-deploy fires (#182/#183 pipeline) and bot picks up the new image; next bedmage notification cycle (any watched character logs in then logs out for ≥100 min) produces the new format

## Out of scope (already covered or deferred)
- Death notification TZ — done in #181
- Configurable env var for TZ — YAGNI per #180 brainstorm
- Explicit TZ name in display — operator's mockup doesn't include it

Refs #180 #181 (death-notification analog).