### PR TITLE
feat(deathwatch): services + types + cap setting (DW-2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,10 @@ BEDMAGE_REGEN_MINUTES=100
 BEDMAGE_NOTIFICATION_HANDLER=apps.notifications.handlers.DiscordDMHandler
 DEATH_NOTIFICATION_HANDLER=apps.notifications.handlers.DiscordChannelHandler
 
+# DeathWatch (M12) — global cap on UNIQUE characters watched across all users.
+# With DOWNLOAD_DELAY=2s, 20 chars = 40s cycle / 1-min Beat = 50% margin.
+DEATHWATCH_MAX_WATCHED_CHARACTERS=20
+
 # ─── Discord bot ─────────────────────────────────────────────────────
 # Operator MUSI wypełnić — Discord Developer Portal → Application → Bot → Token.
 # https://discord.com/developers/applications

--- a/apps/deathwatch/services.py
+++ b/apps/deathwatch/services.py
@@ -1,0 +1,163 @@
+"""DeathWatch services — business logic for per-character death blacklist.
+
+CLAUDE.md §7: logic lives here, not in views/resolvers/spiders. Pipeline route
+in `scrapers/.../pipelines.py` calls `record_watched_death(dict(item))` rather
+than touching ORM directly (CLAUDE.md §6).
+
+Spec: docs/superpowers/specs/2026-05-17-death-blacklist-design.md
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.conf import settings
+from django.db import transaction
+from django.db.models import QuerySet
+
+from apps.accounts.models import User
+from apps.characters.models import Character, _canonicalize_name
+from apps.deathwatch.models import DeathWatch, DeathWatchChannel, WatchedDeathEvent
+
+logger = logging.getLogger(__name__)
+
+
+def add_death_watch(user: User, character_name: str) -> DeathWatch:
+    """Create or reactivate a DeathWatch for user+character, with global cap check.
+
+    §3.2 / §3.8 — lazy Character fetch (auto-create), cap enforced atomically
+    via post-create count + rollback. Naive pre-check is TOCTOU between
+    concurrent /add calls.
+
+    Cap counts UNIQUE characters across all users (§3.2): 10 users watching
+    Yhral + Bubble = 2 unique chars, not 20 watches.
+
+    Raises ValueError when active duplicate exists for user, or when adding
+    this watch would push unique-character count past
+    `settings.DEATHWATCH_MAX_WATCHED_CHARACTERS`.
+    """
+    character_name = _canonicalize_name(character_name)
+
+    with transaction.atomic():
+        character, _ = Character.objects.get_or_create(name=character_name)
+        watch, created = DeathWatch.objects.get_or_create(
+            user=user, character=character, defaults={"active": True}
+        )
+
+        if not created and watch.active:
+            raise ValueError(
+                f"DeathWatch for {character_name!r} already active for user "
+                f"{user.username!r}"
+            )
+        if not created and not watch.active:
+            watch.active = True
+            watch.save(update_fields=["active"])
+
+        cap = settings.DEATHWATCH_MAX_WATCHED_CHARACTERS
+        unique_count = (
+            DeathWatch.objects.filter(active=True)
+            .values("character_id")
+            .distinct()
+            .count()
+        )
+        if unique_count > cap:
+            raise ValueError(
+                f"DeathWatch cap of {cap} unique characters exceeded "
+                f"(would be {unique_count})"
+            )
+
+    return watch
+
+
+def remove_death_watch(user: User, character_name: str) -> bool:
+    """Hard-delete DeathWatch for user+character. Idempotent.
+
+    §3.7 — hard delete consistent with bedmages `remove_bedmage_watch`.
+    Re-add resets the `created_at` floor used by `record_watched_death`,
+    so historical deaths between remove/add are correctly ignored.
+    """
+    character_name = _canonicalize_name(character_name)
+    deleted, _ = DeathWatch.objects.filter(
+        user=user, character__name=character_name
+    ).delete()
+    return deleted > 0
+
+
+def list_death_watches(user: User) -> QuerySet[DeathWatch]:
+    """List user's watches, newest first, with Character preloaded.
+
+    `select_related` to avoid N+1 when Discord cog / GraphQL renders names.
+    """
+    return (
+        DeathWatch.objects.filter(user=user)
+        .select_related("character")
+        .order_by("-created_at")
+    )
+
+
+def set_deathwatch_channel_for_guild(
+    guild_id: int, channel_id: int
+) -> DeathWatchChannel:
+    """Upsert announcement channel for a guild. Called by /deathwatch channel.
+
+    Per spec §2 / §3.1: one channel per guild (UniqueConstraint on guild_id).
+    Multiple guilds = multiple rows = announcements fan out to all (§3.9).
+    """
+    channel, _ = DeathWatchChannel.objects.update_or_create(
+        guild_id=guild_id, defaults={"channel_id": channel_id}
+    )
+    return channel
+
+
+def record_watched_death(item: dict[str, Any]) -> WatchedDeathEvent | None:
+    """Pipeline-side: persist event if it qualifies for any active watch.
+
+    §3.6 — filter "po dodaniu": event qualifies only when at least one
+    active DeathWatch for this character has `created_at < died_at`.
+    Tabela "Latest Deaths" on tibiantis.online shows ~10 historical entries
+    so the spider WILL emit deaths from before /add — service drops them.
+
+    Drops (returns None) when:
+    - Character missing (abnormal — spider shouldn't emit for unknown chars
+      in normal flow; defensive against state drift).
+    - No qualifying watch (no active watcher OR all watches added after died_at).
+    - Event already exists (unique constraint hit on character+died_at).
+    """
+    character_name = _canonicalize_name(item["character_name"])
+    try:
+        character = Character.objects.get(name=character_name)
+    except Character.DoesNotExist:
+        logger.warning(
+            "record_watched_death: Character %r missing, dropping item",
+            character_name,
+        )
+        return None
+
+    died_at = item["died_at"]
+    qualifies = DeathWatch.objects.filter(
+        character=character, active=True, created_at__lt=died_at
+    ).exists()
+    if not qualifies:
+        return None
+
+    event, created = WatchedDeathEvent.objects.get_or_create(
+        character=character,
+        died_at=died_at,
+        defaults={
+            "level_at_death": item["level_at_death"],
+            "killed_by": item.get("killed_by", ""),
+        },
+    )
+    return event if created else None
+
+
+def notify_watched_deaths_for_character(character: Character) -> int:
+    """Dispatch pending WatchedDeathEvents for character via configured handler.
+
+    DW-2 STUB: returns 0. DW-6 will plug in DeathWatchAnnouncementHandler
+    with multi-channel iteration and atomic flag-set-on-full-success.
+    Kept in DW-2 so DW-5 (Celery task) can import it without ImportError.
+    """
+    # TODO(DW-6): wire up DeathWatchAnnouncementHandler — see spec §3.9, §3.13.
+    return 0

--- a/apps/deathwatch/types.py
+++ b/apps/deathwatch/types.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from typing import TypedDict
+
+
+class DeathWatchPayload(TypedDict, total=False):
+    """Payload shape for DeathWatch service input/output.
+
+    Mirror of `apps/bedmages/types.py::BedmagePayload` pattern — types
+    separated from services for reusability and testability.
+    """
+
+    id: int
+    user_id: int
+    character_name: str
+    created_at: datetime
+    active: bool
+
+
+class WatchedDeathPayload(TypedDict, total=False):
+    """Pipeline-side payload — `CharacterDeathItem` shape from spider (DW-3).
+
+    `record_watched_death(item: dict)` accepts dict-like input matching this
+    shape. Plain dict (not TypedDict subclass) because Scrapy `Item` exposes
+    dict-access but isn't a TypedDict.
+    """
+
+    id: int
+    character_name: str
+    level_at_death: int
+    killed_by: str
+    died_at: datetime
+    announced_on_discord: bool

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -196,6 +196,14 @@ BEDMAGE_NOTIFICATION_HANDLER = env(
     default="apps.notifications.handlers.DiscordDMHandler",  # M5 LoggingHandler → M8 DiscordDMHandler
 )
 
+# DeathWatch (per-character death blacklist, M12).
+# Global cap on UNIQUE characters watched (not per-user). With DOWNLOAD_DELAY=2s
+# in scrapers/settings.py, 20 chars × 2s = 40s cycle fits the 1-min Beat interval
+# with 50% margin. See spec §3.2 and plan DW-5 Redis lock for overflow handling.
+DEATHWATCH_MAX_WATCHED_CHARACTERS = env.int(
+    "DEATHWATCH_MAX_WATCHED_CHARACTERS", default=20
+)
+
 # MongoDB — used ONLY for app_logs / scrape_logs (CLAUDE.md §4).
 # Empty MONGO_URL disables Mongo logging gracefully via NullHandler (spec §3.4).
 MONGO_URL = env("MONGO_URL", default="")

--- a/tests/unit/deathwatch/test_services.py
+++ b/tests/unit/deathwatch/test_services.py
@@ -1,0 +1,295 @@
+from datetime import timedelta
+
+import pytest
+from django.test import override_settings
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.characters.models import Character
+from apps.deathwatch.models import DeathWatch, DeathWatchChannel, WatchedDeathEvent
+from apps.deathwatch.services import (
+    add_death_watch,
+    list_death_watches,
+    record_watched_death,
+    remove_death_watch,
+    set_deathwatch_channel_for_guild,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# add_death_watch
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_add_death_watch_creates_character_lazy() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    watch = add_death_watch(user, "Yhral")
+
+    assert watch.character.name == "Yhral"
+    assert Character.objects.filter(name="Yhral").exists()
+
+
+@pytest.mark.django_db
+def test_add_death_watch_canonicalizes_name() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "  yhral  ")
+
+    assert Character.objects.filter(name="Yhral").exists()
+
+
+@pytest.mark.django_db
+def test_add_death_watch_raises_on_active_duplicate() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+
+    with pytest.raises(ValueError, match="already active"):
+        add_death_watch(user, "Yhral")
+
+
+@pytest.mark.django_db
+def test_add_death_watch_reactivates_inactive() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    watch = add_death_watch(user, "Yhral")
+    watch.active = False
+    watch.save(update_fields=["active"])
+
+    re_watch = add_death_watch(user, "Yhral")
+
+    assert re_watch.pk == watch.pk
+    assert re_watch.active is True
+
+
+@pytest.mark.django_db
+@override_settings(DEATHWATCH_MAX_WATCHED_CHARACTERS=2)
+def test_add_death_watch_cap_exceeded_raises() -> None:
+    u1 = User.objects.create(username="alice", discord_id="1")
+    u2 = User.objects.create(username="bob", discord_id="2")
+    add_death_watch(u1, "Yhral")
+    add_death_watch(u2, "Bubble")
+
+    with pytest.raises(ValueError, match="cap"):
+        add_death_watch(u1, "Eternal Oblivion")
+
+
+@pytest.mark.django_db
+@override_settings(DEATHWATCH_MAX_WATCHED_CHARACTERS=2)
+def test_add_death_watch_cap_counts_unique_characters_not_watches() -> None:
+    """Two users watching the same character = 1 unique, not 2."""
+    u1 = User.objects.create(username="alice", discord_id="1")
+    u2 = User.objects.create(username="bob", discord_id="2")
+    add_death_watch(u1, "Yhral")
+    add_death_watch(u2, "Yhral")  # same character — still 1 unique
+    add_death_watch(u1, "Bubble")  # 2 unique now
+
+    with pytest.raises(ValueError, match="cap"):
+        add_death_watch(u2, "Eternal Oblivion")  # would be 3rd unique
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# remove_death_watch
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_remove_death_watch_hard_deletes_existing() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+
+    assert remove_death_watch(user, "Yhral") is True
+    assert not DeathWatch.objects.filter(user=user).exists()
+
+
+@pytest.mark.django_db
+def test_remove_death_watch_idempotent_when_not_found() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+
+    assert remove_death_watch(user, "Yhral") is False
+
+
+@pytest.mark.django_db
+def test_remove_death_watch_canonicalizes_name() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+
+    assert remove_death_watch(user, "  YHRAL  ") is True
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# list_death_watches
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_list_death_watches_filters_by_user_and_orders_newest_first() -> None:
+    alice = User.objects.create(username="alice", discord_id="1")
+    bob = User.objects.create(username="bob", discord_id="2")
+    add_death_watch(alice, "Yhral")
+    add_death_watch(bob, "Bubble")
+    add_death_watch(alice, "Eternal Oblivion")
+
+    alice_watches = list(list_death_watches(alice))
+
+    # _canonicalize_name uppercases ONLY the first letter ("Eternal Oblivion"
+    # → "Eternal oblivion"). Match canonical form.
+    assert len(alice_watches) == 2
+    assert {w.character.name for w in alice_watches} == {"Yhral", "Eternal oblivion"}
+    assert alice_watches[0].character.name == "Eternal oblivion"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# set_deathwatch_channel_for_guild
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_set_deathwatch_channel_creates_when_missing() -> None:
+    channel = set_deathwatch_channel_for_guild(guild_id=111, channel_id=222)
+
+    assert channel.guild_id == 111
+    assert channel.channel_id == 222
+    assert DeathWatchChannel.objects.filter(guild_id=111).count() == 1
+
+
+@pytest.mark.django_db
+def test_set_deathwatch_channel_updates_when_exists() -> None:
+    set_deathwatch_channel_for_guild(guild_id=111, channel_id=222)
+    updated = set_deathwatch_channel_for_guild(guild_id=111, channel_id=999)
+
+    assert updated.channel_id == 999
+    assert DeathWatchChannel.objects.filter(guild_id=111).count() == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# record_watched_death
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _backdate_watch(watch: DeathWatch, delta: timedelta) -> None:
+    """Force watch.created_at backward, bypassing auto_now_add.
+
+    Workaround for `auto_now_add=True` — `.save()` with passed `created_at`
+    is ignored. Must use `.filter().update()` (M3-D17 retro #5 pattern).
+    """
+    DeathWatch.objects.filter(pk=watch.pk).update(created_at=timezone.now() - delta)
+
+
+@pytest.mark.django_db
+def test_record_watched_death_creates_event_when_died_after_watch_created() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    watch = add_death_watch(user, "Yhral")
+    _backdate_watch(watch, timedelta(hours=1))
+
+    item = {
+        "character_name": "Yhral",
+        "level_at_death": 128,
+        "killed_by": "a giant crayfish",
+        "died_at": timezone.now(),
+    }
+    event = record_watched_death(item)
+
+    assert event is not None
+    assert event.character.name == "Yhral"
+    assert event.level_at_death == 128
+    assert event.killed_by == "a giant crayfish"
+
+
+@pytest.mark.django_db
+def test_record_watched_death_drops_when_died_before_watch_created() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+
+    item = {
+        "character_name": "Yhral",
+        "level_at_death": 128,
+        "killed_by": "a dragon",
+        "died_at": timezone.now() - timedelta(hours=1),  # before watch.created_at
+    }
+
+    assert record_watched_death(item) is None
+    assert not WatchedDeathEvent.objects.exists()
+
+
+@pytest.mark.django_db
+def test_record_watched_death_drops_when_no_active_watch() -> None:
+    Character.objects.create(name="Yhral")  # exists but unwatched
+
+    item = {
+        "character_name": "Yhral",
+        "level_at_death": 128,
+        "killed_by": "a dragon",
+        "died_at": timezone.now(),
+    }
+
+    assert record_watched_death(item) is None
+    assert not WatchedDeathEvent.objects.exists()
+
+
+@pytest.mark.django_db
+def test_record_watched_death_drops_when_watch_inactive() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    watch = add_death_watch(user, "Yhral")
+    watch.active = False
+    watch.save(update_fields=["active"])
+    _backdate_watch(watch, timedelta(hours=1))
+
+    item = {
+        "character_name": "Yhral",
+        "level_at_death": 128,
+        "killed_by": "x",
+        "died_at": timezone.now(),
+    }
+
+    assert record_watched_death(item) is None
+
+
+@pytest.mark.django_db
+def test_record_watched_death_deduplicates_via_unique_constraint() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    watch = add_death_watch(user, "Yhral")
+    _backdate_watch(watch, timedelta(hours=1))
+
+    t = timezone.now()
+    item = {
+        "character_name": "Yhral",
+        "level_at_death": 128,
+        "killed_by": "x",
+        "died_at": t,
+    }
+
+    e1 = record_watched_death(item)
+    e2 = record_watched_death(item)
+
+    assert e1 is not None
+    assert e2 is None  # already exists — dedup
+    assert WatchedDeathEvent.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_record_watched_death_drops_when_character_missing() -> None:
+    item = {
+        "character_name": "Ghost",
+        "level_at_death": 1,
+        "killed_by": "x",
+        "died_at": timezone.now(),
+    }
+
+    assert record_watched_death(item) is None
+
+
+@pytest.mark.django_db
+def test_record_watched_death_canonicalizes_character_name() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    watch = add_death_watch(user, "Yhral")
+    _backdate_watch(watch, timedelta(hours=1))
+
+    item = {
+        "character_name": "  yhral  ",  # un-canonical input
+        "level_at_death": 128,
+        "killed_by": "x",
+        "died_at": timezone.now(),
+    }
+    event = record_watched_death(item)
+
+    assert event is not None
+    assert event.character.name == "Yhral"


### PR DESCRIPTION
## Summary

DW-2 (2 of 9) — business logic dla DeathWatch.

Closes #188.

## Changes

- **`apps/deathwatch/services.py`** — 6 funkcji:
  - `add_death_watch(user, name)` — lazy Character + cap check w `transaction.atomic` (post-create count + rollback, TOCTOU-safe), reactivate inactive.
  - `remove_death_watch(user, name)` — hard delete, idempotent.
  - `list_death_watches(user)` — filtered + `select_related` + ordered.
  - `set_deathwatch_channel_for_guild(guild_id, channel_id)` — upsert.
  - `record_watched_death(item: dict[str, Any])` — pipeline-side, filtr "po dodaniu" przez `created_at < died_at`, get_or_create dedup.
  - `notify_watched_deaths_for_character(character)` — **stub** (return 0). Real implementation w DW-6 (#192).
- **`apps/deathwatch/types.py`** — `DeathWatchPayload`, `WatchedDeathPayload` TypedDicts.
- **`config/settings/base.py`** — `DEATHWATCH_MAX_WATCHED_CHARACTERS=20` (cap counts unique characters, not watches).
- **`.env.example`** — nowa zmienna.
- **`tests/unit/deathwatch/test_services.py`** — 19 unit testów (happy paths + edge cases).

## Decisions

**Cap counts UNIQUE characters, nie watches:** 10 userów obserwujących Yhral + Bubble = 2 unique chars, nie 20 watches. Spec §3.2 design intent — chronimy tibiantis.online przed bombingiem niezależnie od liczby userów.

**Atomicity przez post-create + rollback:** zamiast pre-check (TOCTOU). Concurrent /add ostatecznie obejmie obie kontrole, ale tylko jeden commit wygrywa cap check.

**`_canonicalize_name` w każdej service func przyjmującej name** — memory `feedback_canonicalization_downstream_audit`. Downstream (Discord cog DW-7, GraphQL DW-8) idą przez services, NIE bezpośrednio do ORM.

## Test plan

- [x] 19/19 testów PASS lokalnie.
- [x] Mypy strict zielony.
- [x] Ruff format/check zielony.
- [x] Pre-commit zielony.

Next: DW-3 spider (#189) — może iść równolegle z DW-2 PR-em, oba zależą tylko od DW-1.