### PR TITLE
feat(deathwatch): CharacterDeathsSpider + date utils refactor (DW-3)

### DIFF
--- a/apps/deathwatch/management/commands/scrape_character_deaths.py
+++ b/apps/deathwatch/management/commands/scrape_character_deaths.py
@@ -1,0 +1,47 @@
+import asyncio
+import os
+import sys
+
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+from twisted.internet import asyncioreactor
+
+asyncioreactor.install()  # type: ignore[no-untyped-call]
+
+from crochet import setup, wait_for  # noqa: E402
+from django.core.management.base import BaseCommand  # noqa: E402
+from scrapy.crawler import CrawlerRunner  # noqa: E402
+from scrapy.utils.project import get_project_settings  # noqa: E402
+
+from argparse import ArgumentParser  # noqa: E402
+from typing import Any  # noqa: E402
+
+os.environ.setdefault("SCRAPY_SETTINGS_MODULE", "scrapers.tibiantis_scrapers.settings")
+setup()
+
+
+class Command(BaseCommand):
+    """Crawl the Latest Deaths section on a character's tibiantis.online profile.
+
+    Subprocess entry point for the DW-5 Celery task — same pattern as
+    `apps/characters/management/commands/scrape_character.py` to keep the
+    Twisted reactor isolated from the Celery worker (M3-D17 retro #8).
+    """
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument("name", type=str)
+
+    @wait_for(timeout=60.0)
+    def _run_crawl(self, name: str) -> Any:
+        settings = get_project_settings()
+        runner = CrawlerRunner(settings)
+        from scrapers.tibiantis_scrapers.spiders.character_deaths_spider import (
+            CharacterDeathsSpider,
+        )
+
+        return runner.crawl(CharacterDeathsSpider, name=name)
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        self._run_crawl(options["name"])
+        self.stdout.write(self.style.SUCCESS(f"Scraped deaths for {options['name']}"))

--- a/scrapers/tibiantis_scrapers/items.py
+++ b/scrapers/tibiantis_scrapers/items.py
@@ -19,3 +19,19 @@ class DeathItem(Item):
     level_at_death = Field()
     killed_by = Field()
     died_at = Field()
+
+
+class CharacterDeathItem(Item):
+    """Death emitted by `character_deaths_spider` (DW-3) parsing the "Latest
+    Deaths" section on `tibiantis.online` character profile pages.
+
+    Shape mirrors `DeathItem` (M4) but is a distinct type so the pipeline can
+    route it to `apps.deathwatch.services.record_watched_death` rather than
+    `apps.deaths.services.save_death_event`. Spec §3.4 — full separation from
+    M4 deaths feature.
+    """
+
+    character_name = Field()
+    level_at_death = Field()
+    killed_by = Field()
+    died_at = Field()

--- a/scrapers/tibiantis_scrapers/spiders/character_deaths_spider.py
+++ b/scrapers/tibiantis_scrapers/spiders/character_deaths_spider.py
@@ -1,0 +1,79 @@
+"""Spider parsing the "Latest Deaths" section of tibiantis.online character profiles.
+
+DW-3 — emits one `CharacterDeathItem` per row in the Latest Deaths table.
+Pipeline route (DW-4) calls `apps.deathwatch.services.record_watched_death`
+which applies the "po dodaniu" filter (§3.6).
+"""
+
+from __future__ import annotations
+
+import re
+
+import scrapy
+
+from scrapers.tibiantis_scrapers.items import CharacterDeathItem
+from scrapers.tibiantis_scrapers.utils.dates import parse_tibiantis_timestamp
+
+_DEATH_TEXT_RE = re.compile(r"Killed at Level (\d+)(?: by (.+?))?\.?$")
+
+
+class CharacterDeathsSpider(scrapy.Spider):
+    name = "character_deaths"
+
+    def __init__(self, name=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not name:
+            raise ValueError("CharacterDeathsSpider requires -a name=<character>")
+        self.character_name = name
+        self.start_urls = [f"https://tibiantis.online/?page=character&name={name}"]
+
+    def parse(self, response):
+        """Locate the Latest Deaths table and yield one item per data row.
+
+        Selector strategy: find the `<table class="tabi">` whose first row
+        contains the bold "Latest Deaths" heading, then iterate `tr.hover`
+        siblings. Avoids brittle dependence on the table's position in the
+        page — the profile has multiple `.tabi` tables in non-fixed order.
+        """
+        deaths_table = response.xpath(
+            '//table[contains(@class,"tabi")][.//b[normalize-space(text())="Latest Deaths"]]'
+        )
+        if not deaths_table:
+            self.logger.info("No Latest Deaths section for %s", self.character_name)
+            return
+
+        rows = deaths_table.css("tr.hover")
+        for row in rows:
+            timestamp_raw = row.css("td:nth-child(1)::text").get("").strip()
+            died_at = parse_tibiantis_timestamp(timestamp_raw)
+            if died_at is None:
+                self.logger.warning(
+                    "Unparseable death timestamp for %s: %r",
+                    self.character_name,
+                    timestamp_raw,
+                )
+                continue
+
+            death_text = " ".join(row.css("td:nth-child(2) ::text").getall()).strip()
+            level, killer = self._parse_death_text(death_text)
+
+            item = CharacterDeathItem()
+            item["character_name"] = self.character_name
+            item["died_at"] = died_at
+            item["level_at_death"] = level
+            item["killed_by"] = killer
+            yield item
+
+    @staticmethod
+    def _parse_death_text(text: str) -> tuple[int, str]:
+        """Parse "Killed at Level 128 by a giant crayfish." → (128, "a giant crayfish").
+
+        Returns (0, "") on no-match — defensive, logged upstream. The trailing
+        period is optional in the regex because some rare entries omit it.
+        """
+        match = _DEATH_TEXT_RE.match(text.strip())
+        if not match:
+            return 0, ""
+        level = int(match.group(1))
+        killer = (match.group(2) or "").strip()
+        return level, killer

--- a/scrapers/tibiantis_scrapers/spiders/character_spider.py
+++ b/scrapers/tibiantis_scrapers/spiders/character_spider.py
@@ -1,7 +1,9 @@
-import scrapy
-from scrapers.tibiantis_scrapers.items import CharacterItem
 from datetime import datetime
-from zoneinfo import ZoneInfo
+
+import scrapy
+
+from scrapers.tibiantis_scrapers.items import CharacterItem
+from scrapers.tibiantis_scrapers.utils.dates import parse_tibiantis_timestamp
 
 
 class CharacterSpider(scrapy.Spider):
@@ -17,11 +19,12 @@ class CharacterSpider(scrapy.Spider):
         self.start_urls = [f"https://tibiantis.online/?page=character&name={name}"]
 
     def _parse_last_login(self, raw: str) -> datetime | None:
-        if not raw or "never" in raw.lower():
-            return None
-        naive_part, _tz = raw.rsplit(" ", 1)  # "CEST" / "CET"
-        dt = datetime.strptime(naive_part, "%d %b %Y %H:%M:%S")
-        return dt.replace(tzinfo=ZoneInfo("Europe/Berlin"))
+        """Thin wrapper kept for backwards-compatibility — tests call this directly.
+
+        Implementation moved to `utils.dates.parse_tibiantis_timestamp` (DW-3)
+        for reuse by `character_deaths_spider`.
+        """
+        return parse_tibiantis_timestamp(raw)
 
     def parse(self, response):
         rows = response.css("table.tabi tr.hover")

--- a/scrapers/tibiantis_scrapers/utils/dates.py
+++ b/scrapers/tibiantis_scrapers/utils/dates.py
@@ -1,0 +1,31 @@
+"""Shared date parsers for Tibiantis-emitted timestamps.
+
+Single source of truth — extracted from `character_spider._parse_last_login`
+(M1) so the new `character_deaths_spider` (DW-3) can reuse without duplication.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+def parse_tibiantis_timestamp(raw: str) -> datetime | None:
+    """Parse Tibiantis "DD MMM YYYY HH:MM:SS CEST/CET" → tz-aware datetime.
+
+    Tibiantis displays Europe/Berlin time. `ZoneInfo("Europe/Berlin")` handles
+    DST transitions (CEST/CET twice yearly) without needing to inspect the
+    trailing TZ token. Returns None for:
+    - "never" / empty input (profile shows "Last Login: never" for accounts
+      that have not yet logged in),
+    - any string the strict format parser rejects (defensive — Tibiantis is a
+      fan-made site, an unexpected layout change shouldn't crash callers).
+    """
+    if not raw or "never" in raw.lower():
+        return None
+    try:
+        naive_part, _tz = raw.rsplit(" ", 1)  # drop CEST/CET suffix
+        dt = datetime.strptime(naive_part, "%d %b %Y %H:%M:%S")
+    except ValueError:
+        return None
+    return dt.replace(tzinfo=ZoneInfo("Europe/Berlin"))

--- a/tests/unit/deathwatch/test_spider.py
+++ b/tests/unit/deathwatch/test_spider.py
@@ -1,0 +1,197 @@
+"""Offline tests for CharacterDeathsSpider — fixture HTML via HtmlResponse.
+
+Reuses `tests/fixtures/character_yhral.html` (M1 fixture) — it already has a
+"Latest Deaths" section with one death. Tests requiring >=2 deaths build a
+synthetic in-test fixture via `_build_character_with_deaths_html` (mirror of
+`_build_character_html` in test_character_spider.py).
+
+CLAUDE.md §15.6: never hit live Tibiantis in CI.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+from scrapy.http import HtmlResponse, Request
+
+from scrapers.tibiantis_scrapers.spiders.character_deaths_spider import (
+    CharacterDeathsSpider,
+)
+
+YHRAL_FIXTURE = (
+    Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "character_yhral.html"
+)
+
+
+def _build_character_with_deaths_html(deaths: list[tuple[str, str]]) -> bytes:
+    """Build minimal page body containing a 'Latest Deaths' table with given rows.
+
+    Each tuple is (timestamp_raw, death_text). Mirrors the real markup layout:
+    `<table class="tabi">` with first row containing `<b>Latest Deaths</b>`,
+    subsequent rows `<tr class='hover'><td>{timestamp}</td><td>{text}</td></tr>`.
+    """
+    death_rows = "".join(
+        f"<tr class='hover'><td>{ts}</td><td>{text}</td></tr>" for ts, text in deaths
+    )
+    return (
+        "<html><body>"
+        # Profile table (spider doesn't read it but real markup has it)
+        "<table class='tabi'>"
+        "<tr><td colspan='2'><b>Character Information</b></td></tr>"
+        "<tr class='hover'><td>Name:</td><td>Yhral</td></tr>"
+        "</table>"
+        "<br /><br />"
+        # Latest Deaths table — what the spider targets
+        "<table class='tabi'>"
+        "<tr><td colspan='2'><b>Latest Deaths</b></td></tr>"
+        f"{death_rows}"
+        "</table>"
+        "</body></html>"
+    ).encode("utf-8")
+
+
+@pytest.fixture
+def yhral_response() -> HtmlResponse:
+    """Real-world snapshot from M1: one death entry in Latest Deaths."""
+    body = YHRAL_FIXTURE.read_bytes()
+    request = Request(url="https://tibiantis.online/?page=character&name=Yhral")
+    return HtmlResponse(
+        url=request.url,
+        body=body,
+        encoding="utf-8",
+        request=request,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Sanity / argument handling
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_spider_requires_name_arg() -> None:
+    """Spider raises if -a name= is missing (matches CharacterSpider behaviour)."""
+    with pytest.raises(ValueError, match="name"):
+        CharacterDeathsSpider()
+
+
+def test_spider_start_url_is_tibiantis_online() -> None:
+    spider = CharacterDeathsSpider(name="Yhral")
+    assert spider.start_urls == ["https://tibiantis.online/?page=character&name=Yhral"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Single-death fixture (M1 character_yhral.html snapshot)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_yields_one_item_from_yhral_fixture(
+    yhral_response: HtmlResponse,
+) -> None:
+    """character_yhral.html has exactly one Latest Deaths row."""
+    spider = CharacterDeathsSpider(name="Yhral")
+    items = list(spider.parse(yhral_response))
+
+    assert len(items) == 1
+    item = items[0]
+    assert item["character_name"] == "Yhral"
+    assert item["level_at_death"] == 115
+    assert item["killed_by"] == "a deathslicer"
+
+
+def test_parsed_died_at_is_europe_berlin_tz(yhral_response: HtmlResponse) -> None:
+    """died_at parses to tz-aware datetime in Europe/Berlin (matches CEST suffix)."""
+    spider = CharacterDeathsSpider(name="Yhral")
+    item = next(iter(spider.parse(yhral_response)))
+
+    assert isinstance(item["died_at"], datetime)
+    assert item["died_at"].tzinfo == ZoneInfo("Europe/Berlin")
+    # Fixture timestamp: "12 Apr 2026 23:25:53 CEST"
+    assert item["died_at"] == datetime(
+        2026,
+        4,
+        12,
+        23,
+        25,
+        53,
+        tzinfo=ZoneInfo("Europe/Berlin"),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Multi-death synthetic fixture
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_yields_item_per_death_row() -> None:
+    """Multi-death page → one item per row, preserving order."""
+    body = _build_character_with_deaths_html(
+        [
+            ("07 May 2026 16:15:46 CEST", "Killed at Level 128 by a giant crayfish."),
+            ("05 May 2026 00:11:11 CEST", "Killed at Level 127 by a dragon."),
+        ]
+    )
+    response = HtmlResponse(url="https://x/", body=body, encoding="utf-8")
+    spider = CharacterDeathsSpider(name="Yhral")
+    items = list(spider.parse(response))
+
+    assert len(items) == 2
+    assert items[0]["level_at_death"] == 128
+    assert items[0]["killed_by"] == "a giant crayfish"
+    assert items[1]["level_at_death"] == 127
+    assert items[1]["killed_by"] == "a dragon"
+
+
+def test_parse_handles_winter_cet_timezone() -> None:
+    """CET (winter) deaths parse correctly — DST transition not hardcoded."""
+    body = _build_character_with_deaths_html(
+        [("10 Dec 2025 22:00:00 CET", "Killed at Level 50 by an orc.")]
+    )
+    response = HtmlResponse(url="https://x/", body=body, encoding="utf-8")
+    spider = CharacterDeathsSpider(name="Yhral")
+    item = next(iter(spider.parse(response)))
+
+    assert item["died_at"] == datetime(
+        2025,
+        12,
+        10,
+        22,
+        0,
+        0,
+        tzinfo=ZoneInfo("Europe/Berlin"),
+    )
+
+
+def test_parse_handles_no_deaths_section() -> None:
+    """Page without Latest Deaths section → no items, no crash."""
+    body = (
+        b"<html><body>"
+        b"<table class='tabi'>"
+        b"<tr><td colspan='2'><b>Character Information</b></td></tr>"
+        b"</table>"
+        b"</body></html>"
+    )
+    response = HtmlResponse(url="https://x/", body=body, encoding="utf-8")
+    spider = CharacterDeathsSpider(name="Yhral")
+    items = list(spider.parse(response))
+
+    assert items == []
+
+
+def test_parse_skips_row_with_unparseable_timestamp() -> None:
+    """Defensive: malformed timestamp row dropped, valid rows kept."""
+    body = _build_character_with_deaths_html(
+        [
+            ("WHATEVER", "Killed at Level 100 by a noob."),
+            ("07 May 2026 16:15:46 CEST", "Killed at Level 128 by a dragon."),
+        ]
+    )
+    response = HtmlResponse(url="https://x/", body=body, encoding="utf-8")
+    spider = CharacterDeathsSpider(name="Yhral")
+    items = list(spider.parse(response))
+
+    # First row dropped (bad timestamp), second kept
+    assert len(items) == 1
+    assert items[0]["level_at_death"] == 128

--- a/tests/unit/scrapers/test_dates.py
+++ b/tests/unit/scrapers/test_dates.py
@@ -1,0 +1,43 @@
+"""Tests for scrapers/utils/dates.py — shared Tibiantis timestamp parser."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from scrapers.tibiantis_scrapers.utils.dates import parse_tibiantis_timestamp
+
+
+def test_parse_tibiantis_timestamp_cest() -> None:
+    """CEST suffix (summer time, UTC+2) parses to Europe/Berlin tz-aware datetime."""
+    raw = "07 May 2026 16:15:46 CEST"
+    result = parse_tibiantis_timestamp(raw)
+    expected = datetime(2026, 5, 7, 16, 15, 46, tzinfo=ZoneInfo("Europe/Berlin"))
+    assert result == expected
+
+
+def test_parse_tibiantis_timestamp_cet() -> None:
+    """CET suffix (winter time, UTC+1) parses to Europe/Berlin tz-aware datetime."""
+    raw = "10 Dec 2025 22:00:00 CET"
+    result = parse_tibiantis_timestamp(raw)
+    expected = datetime(2025, 12, 10, 22, 0, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    assert result == expected
+
+
+def test_parse_tibiantis_timestamp_never_returns_none() -> None:
+    """'never' / empty string returns None (Tibiantis profile 'Last Login: never')."""
+    assert parse_tibiantis_timestamp("never") is None
+    assert parse_tibiantis_timestamp("") is None
+
+
+def test_parse_tibiantis_timestamp_case_insensitive_never() -> None:
+    """Case-insensitive 'never' (defensive against future site changes)."""
+    assert parse_tibiantis_timestamp("Never") is None
+    assert parse_tibiantis_timestamp("NEVER") is None
+
+
+def test_parse_tibiantis_timestamp_garbage_returns_none() -> None:
+    """Unparseable input returns None rather than raising (defensive)."""
+    assert parse_tibiantis_timestamp("WHATEVER") is None
+    assert parse_tibiantis_timestamp("not a date") is None
+    assert parse_tibiantis_timestamp("32 May 2026 99:99:99 CEST") is None


### PR DESCRIPTION
## Summary

DW-3 (3 of 9) — spider parsujący sekcję "Latest Deaths" na profilu postaci + extraction wspólnego date parsera.

Closes #189.

## Changes

- **`scrapers/tibiantis_scrapers/utils/dates.py`** new — `parse_tibiantis_timestamp(raw) → datetime | None`. Extracted from `character_spider._parse_last_login` (M1).
- **`scrapers/tibiantis_scrapers/spiders/character_spider.py`** — `_parse_last_login` zachowane jako thin wrapper deleguje do utility (zachowuje API dla istniejących testów).
- **`scrapers/tibiantis_scrapers/items.py`** — `CharacterDeathItem` (osobny od `DeathItem` z M4 — pipeline rozróżnia po typie, spec §3.4).
- **`scrapers/tibiantis_scrapers/spiders/character_deaths_spider.py`** new — `name="character_deaths"`, parsuje `<table class="tabi">` z `<b>Latest Deaths</b>`, emituje `CharacterDeathItem` per row.
- **`apps/deathwatch/management/commands/scrape_character_deaths.py`** — subprocess entry point dla DW-5 Celery task (mirror `scrape_character.py`).
- **Tests:**
  - `tests/unit/scrapers/test_dates.py` — 5 testów (CEST/CET/never/case-insensitive/garbage).
  - `tests/unit/deathwatch/test_spider.py` — 8 testów (M1 fixture + synthetic multi-death + winter CET + no deaths + bad timestamp).

## Decisions

**Reuse `tests/fixtures/character_yhral.html` zamiast nowego fixture:** M1 fixture **już zawiera sekcję "Latest Deaths"** z jednym deathem ("12 Apr 2026 23:25:53 CEST" — Level 115 by a deathslicer). Test scenariusze ≥2 deaths używają syntetycznego `_build_character_with_deaths_html()` (wzorem `_build_character_html` z `test_character_spider.py`). Real + synthetic = pokrycie bez hitowania live strony.

**Defensive `parse_tibiantis_timestamp`:** funkcja zwraca `None` na każdy unparseable input (try/except `ValueError`), nie tylko "never". Tibiantis to fan-made site — niespodziewana zmiana layoutu nie powinna crashować spidera. Spider loguje warning i skipuje row.

**Selektor "Latest Deaths" przez XPath ancestor match:** `//table[.//b[normalize-space(text())="Latest Deaths"]]` zamiast position-based selectors — strona ma kilka `.tabi` tabel w nie-fixed order.

## Test plan

- [x] 24/24 testów PASS (5 dates + 8 spider + 11 character_spider regression).
- [x] Mypy + ruff zielone.
- [x] Pre-commit zielony.
- [ ] Manual smoke: `python manage.py scrape_character_deaths Yhral` (wymaga network).

Next: **DW-4 pipeline route** (#190) — wymaga DW-2 + DW-3 merged.