### PR TITLE
feat(deathwatch): pipeline route for CharacterDeathItem (DW-4)

### DIFF
--- a/scrapers/tibiantis_scrapers/pipelines.py
+++ b/scrapers/tibiantis_scrapers/pipelines.py
@@ -1,5 +1,9 @@
 from asgiref.sync import sync_to_async
-from scrapers.tibiantis_scrapers.items import CharacterItem, DeathItem
+from scrapers.tibiantis_scrapers.items import (
+    CharacterDeathItem,
+    CharacterItem,
+    DeathItem,
+)
 
 
 class DjangoPipeline:
@@ -15,5 +19,18 @@ class DjangoPipeline:
             result = await sync_to_async(save_death_event)(dict(item))
             if result is None:
                 spider.crawler.stats.inc_value("custom/death_duplicates")
+
+        elif isinstance(item, CharacterDeathItem):
+            # DW-4: route to deathwatch services. record_watched_death applies
+            # the §3.6 "po dodaniu" filter — returns None for items that
+            # don't qualify (no active watch, died before watch.created_at,
+            # missing Character, or unique-constraint dedup). Spider already
+            # emits ALL deaths from the Latest Deaths table; service decides
+            # which to persist.
+            from apps.deathwatch.services import record_watched_death
+
+            result = await sync_to_async(record_watched_death)(dict(item))
+            if result is None:
+                spider.crawler.stats.inc_value("custom/watched_death_dropped")
 
         return item

--- a/tests/integration/deathwatch/test_pipeline.py
+++ b/tests/integration/deathwatch/test_pipeline.py
@@ -1,0 +1,145 @@
+"""Integration tests for DjangoPipeline → record_watched_death (DW-4).
+
+E2E: CharacterDeathsSpider parses fixture HTML → emits items → pipeline routes
+to apps.deathwatch.services.record_watched_death → real DB rows in
+WatchedDeathEvent (or correctly dropped per §3.6 "po dodaniu" filter).
+
+Unit-level dispatch is covered by tests/unit/scrapers/test_pipeline.py. This
+file verifies the actual service is wired correctly without mocks.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from django.utils import timezone
+from scrapy.http import HtmlResponse
+
+from apps.accounts.models import User
+from apps.characters.models import Character
+from apps.deathwatch.models import DeathWatch, WatchedDeathEvent
+from apps.deathwatch.services import add_death_watch
+from scrapers.tibiantis_scrapers.pipelines import DjangoPipeline
+from scrapers.tibiantis_scrapers.spiders.character_deaths_spider import (
+    CharacterDeathsSpider,
+)
+
+YHRAL_FIXTURE = (
+    Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "character_yhral.html"
+)
+
+
+def _backdate_watch(watch: DeathWatch, delta: timedelta) -> None:
+    """Force watch.created_at backward (auto_now_add workaround)."""
+    DeathWatch.objects.filter(pk=watch.pk).update(created_at=timezone.now() - delta)
+
+
+@pytest.fixture()
+def yhral_response() -> HtmlResponse:
+    body = YHRAL_FIXTURE.read_bytes()
+    return HtmlResponse(
+        url="https://tibiantis.online/?page=character&name=Yhral",
+        body=body,
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def spider_stub():
+    """Minimal spider stub — pipeline only reads `crawler.stats.inc_value`."""
+
+    class _Spider:
+        class _Crawler:
+            class _Stats:
+                def __init__(self) -> None:
+                    self.calls: list[str] = []
+
+                def inc_value(self, key: str) -> None:
+                    self.calls.append(key)
+
+            stats = _Stats()
+
+        crawler = _Crawler()
+
+    return _Spider()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_pipeline_persists_event_for_active_watch_with_past_created_at(
+    yhral_response: HtmlResponse, spider_stub
+) -> None:
+    """Happy path E2E: watch with past created_at → fixture death → DB row."""
+    from asgiref.sync import sync_to_async
+
+    user = await sync_to_async(User.objects.create)(username="alice", discord_id="1")
+    watch = await sync_to_async(add_death_watch)(user, "Yhral")
+    await sync_to_async(_backdate_watch)(watch, timedelta(days=365))
+
+    spider = CharacterDeathsSpider(name="Yhral")
+    pipeline = DjangoPipeline()
+
+    items = list(spider.parse(yhral_response))
+    assert len(items) >= 1
+    for item in items:
+        await pipeline.process_item(item, spider_stub)
+
+    persisted = await sync_to_async(
+        lambda: WatchedDeathEvent.objects.filter(character__name="Yhral").count()
+    )()
+    assert persisted >= 1
+    # No drops on happy path
+    assert "custom/watched_death_dropped" not in spider_stub.crawler.stats.calls
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_pipeline_drops_event_when_no_watch_exists(
+    yhral_response: HtmlResponse, spider_stub
+) -> None:
+    """No watch for character → record_watched_death returns None → counter ticks."""
+    from asgiref.sync import sync_to_async
+
+    await sync_to_async(Character.objects.create)(name="Yhral")
+
+    spider = CharacterDeathsSpider(name="Yhral")
+    pipeline = DjangoPipeline()
+
+    items = list(spider.parse(yhral_response))
+    for item in items:
+        await pipeline.process_item(item, spider_stub)
+
+    persisted = await sync_to_async(WatchedDeathEvent.objects.count)()
+    assert persisted == 0
+    # Counter ticked at least once (per item dropped)
+    drops = [
+        c
+        for c in spider_stub.crawler.stats.calls
+        if c == "custom/watched_death_dropped"
+    ]
+    assert len(drops) == len(items)
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_pipeline_drops_event_when_died_before_watch_created(
+    yhral_response: HtmlResponse, spider_stub
+) -> None:
+    """Watch added AFTER death → service drops (§3.6 "po dodaniu")."""
+    from asgiref.sync import sync_to_async
+
+    user = await sync_to_async(User.objects.create)(username="alice", discord_id="1")
+    # Watch's created_at = now (auto_now_add); fixture death is from 2026-04-12,
+    # which (at test runtime in 2026-05+) is in the past → drop.
+    await sync_to_async(add_death_watch)(user, "Yhral")
+
+    spider = CharacterDeathsSpider(name="Yhral")
+    pipeline = DjangoPipeline()
+
+    for item in spider.parse(yhral_response):
+        await pipeline.process_item(item, spider_stub)
+
+    persisted = await sync_to_async(WatchedDeathEvent.objects.count)()
+    assert persisted == 0

--- a/tests/unit/scrapers/test_pipeline.py
+++ b/tests/unit/scrapers/test_pipeline.py
@@ -8,7 +8,12 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from scrapers.tibiantis_scrapers.items import CharacterItem, DeathItem
+
+from scrapers.tibiantis_scrapers.items import (
+    CharacterDeathItem,
+    CharacterItem,
+    DeathItem,
+)
 from scrapers.tibiantis_scrapers.pipelines import DjangoPipeline
 
 
@@ -21,6 +26,13 @@ def _make_item(**kwargs: object) -> CharacterItem:
 
 def _make_death_item(**kwargs: object) -> DeathItem:
     item = DeathItem()
+    for key, value in kwargs.items():
+        item[key] = value
+    return item
+
+
+def _make_watched_death_item(**kwargs: object) -> CharacterDeathItem:
+    item = CharacterDeathItem()
     for key, value in kwargs.items():
         item[key] = value
     return item
@@ -184,5 +196,84 @@ class TestDjangoPipelineProcessItem:
         fake_event = MagicMock(pk=1)
         with patch("apps.deaths.services.save_death_event", return_value=fake_event):
             await pipeline.process_item(full_death_item, spider)
+
+        spider.crawler.stats.inc_value.assert_not_called()
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # CharacterDeathItem (DW-4) — same dispatch+stats pattern as DeathItem
+    # ──────────────────────────────────────────────────────────────────────────
+
+    @pytest.fixture()
+    def full_watched_death_item(self) -> CharacterDeathItem:
+        return _make_watched_death_item(
+            character_name="Yhral",
+            level_at_death=128,
+            killed_by="a giant crayfish",
+            died_at=datetime(2026, 5, 7, 14, 15, 46, tzinfo=ZoneInfo("Europe/Berlin")),
+        )
+
+    @pytest.mark.asyncio
+    async def test_watched_death_item_dispatched_to_record_watched_death(
+        self,
+        pipeline: DjangoPipeline,
+        spider: MagicMock,
+        full_watched_death_item: CharacterDeathItem,
+    ) -> None:
+        with patch("apps.deathwatch.services.record_watched_death") as mock_record:
+            await pipeline.process_item(full_watched_death_item, spider)
+
+        mock_record.assert_called_once_with(dict(full_watched_death_item))
+
+    @pytest.mark.asyncio
+    async def test_watched_death_does_not_route_through_other_paths(
+        self,
+        pipeline: DjangoPipeline,
+        spider: MagicMock,
+        full_watched_death_item: CharacterDeathItem,
+    ) -> None:
+        """Regression: CharacterDeathItem must NOT trigger upsert_character or
+        save_death_event. Spec §3.4 — full separation from M4 deaths feature.
+        """
+        with (
+            patch("apps.deathwatch.services.record_watched_death"),
+            patch("apps.characters.services.upsert_character") as mock_upsert,
+            patch("apps.deaths.services.save_death_event") as mock_save_death,
+        ):
+            await pipeline.process_item(full_watched_death_item, spider)
+
+        mock_upsert.assert_not_called()
+        mock_save_death.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_watched_death_increments_dropped_counter_on_none(
+        self,
+        pipeline: DjangoPipeline,
+        spider: MagicMock,
+        full_watched_death_item: CharacterDeathItem,
+    ) -> None:
+        """When record_watched_death returns None (filter "po dodaniu" dropped,
+        no qualifying watch, missing Character, or dedup), pipeline must tick
+        ``custom/watched_death_dropped``. Same observability pattern as
+        ``custom/death_duplicates`` from M4.
+        """
+        with patch("apps.deathwatch.services.record_watched_death", return_value=None):
+            await pipeline.process_item(full_watched_death_item, spider)
+
+        spider.crawler.stats.inc_value.assert_called_once_with(
+            "custom/watched_death_dropped"
+        )
+
+    @pytest.mark.asyncio
+    async def test_watched_death_does_not_increment_counter_on_success(
+        self,
+        pipeline: DjangoPipeline,
+        spider: MagicMock,
+        full_watched_death_item: CharacterDeathItem,
+    ) -> None:
+        fake_event = MagicMock(pk=1)
+        with patch(
+            "apps.deathwatch.services.record_watched_death", return_value=fake_event
+        ):
+            await pipeline.process_item(full_watched_death_item, spider)
 
         spider.crawler.stats.inc_value.assert_not_called()


### PR DESCRIPTION
## Summary

DW-4 (4 of 9) — pipeline rozpoznaje `CharacterDeathItem` i dispatchuje do `record_watched_death`.

Closes #190.

## Changes

- **`scrapers/tibiantis_scrapers/pipelines.py`** — nowy `elif isinstance(item, CharacterDeathItem)` branch:
  - Wywołuje `apps.deathwatch.services.record_watched_death(dict(item))` przez `sync_to_async`.
  - Gdy service zwraca `None` (drop — no watch / "po dodaniu" filter / missing Character / dedup), tikuje `spider.crawler.stats.inc_value("custom/watched_death_dropped")` — observability dla DW-5 task summary.
- **`tests/unit/scrapers/test_pipeline.py`** — 4 nowe unit testy (mirror DeathItem stats counter logic):
  - dispatch do `record_watched_death`,
  - regression: NIE routes przez `upsert_character` ani `save_death_event` (spec §3.4 separation),
  - counter na `None` return,
  - brak counter na success.
- **`tests/integration/deathwatch/test_pipeline.py`** new — 3 testy E2E real DB:
  - happy path: watch z past `created_at` → fixture death → `WatchedDeathEvent` w DB,
  - drop bez watcha (counter tika),
  - drop "po dodaniu" (watch created after death).

## Decisions

**Async pipeline z `sync_to_async`:** istniejący `DjangoPipeline` jest async (M4). Wzorzec zachowany — `sync_to_async(record_watched_death)(dict(item))`.

**Stats key `custom/watched_death_dropped`:** osobny od M4 `custom/death_duplicates` (różne źródła, różne semantyki drop'u). DW-5 task summary może oczytać oba osobno.

**Integration testy używają `@pytest.mark.django_db(transaction=True)`:** plain `django_db` z async + DB cleanup powoduje `IntegrityError: duplicate key` między testami (savepoint nie działa w async context). Wzorzec z `tests/unit/accounts/test_graphql_async_canary.py`.

## Test plan

- [x] 4 unit testy (pipeline mock) PASS.
- [x] 3 integration testy (real DB) PASS.
- [x] Full pipeline suite (incl. M4 regression): 14 unit + 3 integration = 17/17 PASS.
- [x] Pre-commit zielony.

Next: **DW-5 Celery task** (#191) — wymaga DW-2 + DW-4 merged. Albo DW-6 handler (#192) równolegle (zależy tylko od DW-2).