### PR TITLE
feat(deathwatch): celery task with redis lock + freshness gate (DW-5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,7 @@ DEATH_NOTIFICATION_HANDLER=apps.notifications.handlers.DiscordChannelHandler
 # DeathWatch (M12) — global cap on UNIQUE characters watched across all users.
 # With DOWNLOAD_DELAY=2s, 20 chars = 40s cycle / 1-min Beat = 50% margin.
 DEATHWATCH_MAX_WATCHED_CHARACTERS=20
+DEATHWATCH_FRESHNESS_SECONDS=50
 
 # ─── Discord bot ─────────────────────────────────────────────────────
 # Operator MUSI wypełnić — Discord Developer Portal → Application → Bot → Token.

--- a/apps/deathwatch/migrations/0002_seed_periodic_task.py
+++ b/apps/deathwatch/migrations/0002_seed_periodic_task.py
@@ -1,0 +1,43 @@
+"""Seed PeriodicTask for the deathwatch 1-min scrape (DW-5).
+
+Defaults to `enabled=False` — admin opts in via Django admin / Beat UI once
+ready to hit tibiantis.online at the 1-min cadence. Bedmage's check (every
+5 min, internal-only DB read) ships enabled=True; this one hits an external
+site, so we ship disabled to avoid auto-stressing tibiantis.online on every
+fresh deploy until the operator explicitly turns it on.
+
+Idempotent: `get_or_create` preserves operator overrides on re-run.
+"""
+
+from django.db import migrations
+
+
+def create_periodic_task(apps, schema_editor):
+    IntervalSchedule = apps.get_model("django_celery_beat", "IntervalSchedule")
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+
+    schedule, _ = IntervalSchedule.objects.get_or_create(
+        every=1,
+        period="minutes",
+    )
+    PeriodicTask.objects.get_or_create(
+        name="deathwatch.scrape_for_watched_deaths",
+        defaults={
+            "task": "apps.deathwatch.tasks.scrape_for_watched_deaths",
+            "interval": schedule,
+            "enabled": False,
+        },
+    )
+
+
+def remove_periodic_task(apps, schema_editor):
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+    PeriodicTask.objects.filter(name="deathwatch.scrape_for_watched_deaths").delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("deathwatch", "0001_initial"),
+        ("django_celery_beat", "0001_initial"),
+    ]
+    operations = [migrations.RunPython(create_periodic_task, remove_periodic_task)]

--- a/apps/deathwatch/tasks.py
+++ b/apps/deathwatch/tasks.py
@@ -1,0 +1,169 @@
+"""DeathWatch Celery task — per-1-min scrape of Latest Deaths sections.
+
+Subprocess per-Character isolates Twisted reactor from worker pool (M3 retro
+#8). Redis lock prevents overlapping Beat fires when iteration > 60s (§3.10).
+Freshness gate uses per-source `Character.last_deaths_scraped_at` (§3.12) —
+bedmage scraper updates `last_scraped_at` independently, so this gate must
+NOT reuse that field (spec §5.1).
+
+Spec: docs/superpowers/specs/2026-05-17-death-blacklist-design.md
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from datetime import timedelta
+
+from celery import Task, shared_task
+from django.conf import settings
+from django.core.cache import cache
+from django.utils import timezone
+
+from apps.characters.models import Character
+from apps.deathwatch.models import DeathWatch
+from apps.deathwatch.services import notify_watched_deaths_for_character
+
+logger = logging.getLogger(__name__)
+
+LOCK_KEY = "deathwatch_scrape_lock"
+LOCK_TIMEOUT_SECONDS = 55  # < 60s Beat interval, releases before next fire
+
+SUBPROCESS_TIMEOUT_SECONDS = 30
+
+
+@shared_task(bind=True, max_retries=2, acks_late=True)
+def scrape_for_watched_deaths(self: Task) -> dict[str, int | bool]:
+    """Iterate unique characters with active DeathWatch, scrape Latest Deaths,
+    fire notifications.
+
+    Lock-first short-circuit (`cache.add` atomic on Redis backend) — if the
+    previous fire is still running, the new fire returns immediately rather
+    than queueing and potentially double-hammering tibiantis.online.
+
+    Per-character flow:
+    1. Freshness skip if `last_deaths_scraped_at > now - DEATHWATCH_FRESHNESS_SECONDS`.
+    2. Subprocess `manage.py scrape_character_deaths <name>` (timeout 30s).
+    3. On success: update `last_deaths_scraped_at` + fire notify.
+    4. On failure: log + continue (next character).
+
+    Returns observability summary `{"checked", "skipped", "scraped", "failed",
+    "events_announced", "locked"}` for Flower / log inspection.
+    """
+    if not cache.add(LOCK_KEY, "1", timeout=LOCK_TIMEOUT_SECONDS):
+        logger.info("scrape_for_watched_deaths: lock held, skipping this fire")
+        return {
+            "checked": 0,
+            "skipped": 0,
+            "scraped": 0,
+            "failed": 0,
+            "events_announced": 0,
+            "locked": True,
+        }
+
+    try:
+        return _do_scrape()
+    finally:
+        cache.delete(LOCK_KEY)
+
+
+def _do_scrape() -> dict[str, int | bool]:
+    cap = settings.DEATHWATCH_MAX_WATCHED_CHARACTERS
+    freshness_seconds = settings.DEATHWATCH_FRESHNESS_SECONDS
+    cutoff = timezone.now() - timedelta(seconds=freshness_seconds)
+
+    character_names = list(
+        DeathWatch.objects.filter(active=True)
+        .values_list("character__name", flat=True)
+        .distinct()
+    )
+
+    if len(character_names) > cap:
+        # Defense-in-depth — service-layer cap check in add_death_watch should
+        # have prevented this. If it leaks through (manual DB edit, race, etc.)
+        # we refuse to bomb tibiantis rather than respecting the broken state.
+        logger.error(
+            "scrape_for_watched_deaths: cap breached (%s > %s) — refusing iteration",
+            len(character_names),
+            cap,
+        )
+        return {
+            "checked": 0,
+            "skipped": 0,
+            "scraped": 0,
+            "failed": 0,
+            "events_announced": 0,
+            "locked": False,
+        }
+
+    checked = skipped = scraped = failed = events_announced = 0
+
+    for name in character_names:
+        checked += 1
+        try:
+            character = Character.objects.get(name=name)
+        except Character.DoesNotExist:
+            logger.warning("character %r vanished mid-iteration", name)
+            failed += 1
+            continue
+
+        if (
+            character.last_deaths_scraped_at
+            and character.last_deaths_scraped_at > cutoff
+        ):
+            skipped += 1
+            continue
+
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "manage.py",
+                    "scrape_character_deaths",
+                    name,
+                ],
+                timeout=SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning("scrape_character_deaths %r timed out", name)
+            failed += 1
+            continue
+
+        if result.returncode != 0:
+            failed += 1
+            logger.warning(
+                "scrape_character_deaths %r failed: returncode=%s",
+                name,
+                result.returncode,
+            )
+            continue
+
+        scraped += 1
+        # §3.12 — update per-source field, NOT generic last_scraped_at. Bedmage
+        # scraper writes last_scraped_at via auto_now on every Character.save();
+        # reusing it here would let bedmage runs "hide" us from the freshness
+        # gate, skipping a 1-min cycle we needed.
+        Character.objects.filter(name=name).update(
+            last_deaths_scraped_at=timezone.now()
+        )
+
+        try:
+            character.refresh_from_db(fields=["last_deaths_scraped_at"])
+            events_announced += notify_watched_deaths_for_character(character)
+        except Exception:
+            # Notify is best-effort — a failure here doesn't undo the scrape.
+            # DW-6 will plug in real handler; current stub returns 0.
+            logger.exception("notify failed for character %r", name)
+
+    summary: dict[str, int | bool] = {
+        "checked": checked,
+        "skipped": skipped,
+        "scraped": scraped,
+        "failed": failed,
+        "events_announced": events_announced,
+        "locked": False,
+    }
+    logger.info("scrape_for_watched_deaths: %s", summary)
+    return summary

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -203,6 +203,11 @@ BEDMAGE_NOTIFICATION_HANDLER = env(
 DEATHWATCH_MAX_WATCHED_CHARACTERS = env.int(
     "DEATHWATCH_MAX_WATCHED_CHARACTERS", default=20
 )
+# Per-Character freshness threshold for the 1-min deathwatch scrape — skip
+# Characters whose last_deaths_scraped_at is younger than this. 50s default
+# leaves a 10s buffer under the 1-min Beat interval to absorb Celery queueing
+# jitter without re-scraping the same character twice in adjacent cycles.
+DEATHWATCH_FRESHNESS_SECONDS = env.int("DEATHWATCH_FRESHNESS_SECONDS", default=50)
 
 # MongoDB — used ONLY for app_logs / scrape_logs (CLAUDE.md §4).
 # Empty MONGO_URL disables Mongo logging gracefully via NullHandler (spec §3.4).

--- a/tests/integration/deathwatch/test_celery_task.py
+++ b/tests/integration/deathwatch/test_celery_task.py
@@ -1,0 +1,264 @@
+"""Integration tests for scrape_for_watched_deaths Celery task (DW-5).
+
+Subprocess + notify mocked — verify Redis lock, freshness gate, cap defense,
+and Character.last_deaths_scraped_at update semantics (§3.12). Real DB,
+mocked external boundary (subprocess + notify).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.cache import cache
+from django.test import override_settings
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.characters.models import Character
+from apps.deathwatch.models import DeathWatch
+from apps.deathwatch.services import add_death_watch
+from apps.deathwatch.tasks import LOCK_KEY, scrape_for_watched_deaths
+
+
+@pytest.fixture(autouse=True)
+def _clear_lock():
+    """Ensure each test starts with the lock released."""
+    cache.delete(LOCK_KEY)
+    yield
+    cache.delete(LOCK_KEY)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Redis lock
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_task_locked_returns_locked_summary_without_iterating() -> None:
+    """Existing lock → early return, no DB query, no subprocess."""
+    cache.set(LOCK_KEY, "1", timeout=55)
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")  # would be iterated if lock weren't held
+
+    with patch("apps.deathwatch.tasks.subprocess.run") as mock_subprocess:
+        result = scrape_for_watched_deaths()
+
+    assert result["locked"] is True
+    assert result["scraped"] == 0
+    mock_subprocess.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_task_releases_lock_after_completion() -> None:
+    """Lock released even when no characters to scrape (empty DB)."""
+    with patch("apps.deathwatch.tasks.subprocess.run"):
+        scrape_for_watched_deaths()
+
+    assert cache.get(LOCK_KEY) is None
+
+
+@pytest.mark.django_db
+def test_task_releases_lock_even_when_subprocess_raises() -> None:
+    """Lock cleanup in `finally` — exception must not leave it stuck."""
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+
+    with patch(
+        "apps.deathwatch.tasks.subprocess.run",
+        side_effect=RuntimeError("boom"),
+    ):
+        with pytest.raises(RuntimeError):
+            scrape_for_watched_deaths()
+
+    assert cache.get(LOCK_KEY) is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Freshness gate (§3.12 — uses last_deaths_scraped_at, not last_scraped_at)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_freshness_gate_uses_last_deaths_scraped_at_not_last_scraped_at() -> None:
+    """Critical: gate must read per-source field, not generic last_scraped_at.
+
+    Spec §5.1 — reusing last_scraped_at would let bedmage scraper "hide" us
+    from the freshness check by writing it via auto_now on every Character.save().
+    """
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+
+    # Last bedmage scrape (last_scraped_at) is fresh — but deathwatch hasn't
+    # touched this character. Gate should NOT skip; subprocess should run.
+    Character.objects.filter(name="Yhral").update(
+        last_deaths_scraped_at=None,  # never scraped by deathwatch
+    )
+
+    with patch("apps.deathwatch.tasks.subprocess.run") as mock_subprocess:
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        result = scrape_for_watched_deaths()
+
+    assert result["scraped"] == 1
+    assert result["skipped"] == 0
+    mock_subprocess.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_task_skips_freshly_scraped_character() -> None:
+    """Character with recent last_deaths_scraped_at → skipped, no subprocess."""
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+    Character.objects.filter(name="Yhral").update(last_deaths_scraped_at=timezone.now())
+
+    with patch("apps.deathwatch.tasks.subprocess.run") as mock_subprocess:
+        result = scrape_for_watched_deaths()
+
+    assert result["skipped"] == 1
+    assert result["scraped"] == 0
+    mock_subprocess.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_task_scrapes_character_with_stale_last_deaths_scraped_at() -> None:
+    """Character last scraped > DEATHWATCH_FRESHNESS_SECONDS ago → scrape."""
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+    Character.objects.filter(name="Yhral").update(
+        last_deaths_scraped_at=timezone.now() - timedelta(minutes=5),
+    )
+
+    with patch("apps.deathwatch.tasks.subprocess.run") as mock_subprocess:
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        result = scrape_for_watched_deaths()
+
+    assert result["scraped"] == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Subprocess + post-success bookkeeping (§3.12 — task updates the field, not pipeline)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_task_updates_last_deaths_scraped_at_on_success() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+
+    before = timezone.now()
+    with patch("apps.deathwatch.tasks.subprocess.run") as mock_subprocess:
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        scrape_for_watched_deaths()
+    after = timezone.now()
+
+    character = Character.objects.get(name="Yhral")
+    assert character.last_deaths_scraped_at is not None
+    assert before <= character.last_deaths_scraped_at <= after
+
+
+@pytest.mark.django_db
+def test_task_does_not_update_last_deaths_on_subprocess_failure() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+
+    with patch("apps.deathwatch.tasks.subprocess.run") as mock_subprocess:
+        mock_subprocess.return_value = MagicMock(returncode=1)
+        result = scrape_for_watched_deaths()
+
+    assert result["failed"] == 1
+    assert result["scraped"] == 0
+    character = Character.objects.get(name="Yhral")
+    assert character.last_deaths_scraped_at is None
+
+
+@pytest.mark.django_db
+def test_task_handles_subprocess_timeout() -> None:
+    """TimeoutExpired exception → counted as failed, lock released, no crash."""
+    import subprocess as _subprocess
+
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+
+    with patch(
+        "apps.deathwatch.tasks.subprocess.run",
+        side_effect=_subprocess.TimeoutExpired(cmd="x", timeout=30),
+    ):
+        result = scrape_for_watched_deaths()
+
+    assert result["failed"] == 1
+    assert cache.get(LOCK_KEY) is None  # lock released despite the exception
+
+
+@pytest.mark.django_db
+def test_task_calls_notify_after_successful_scrape() -> None:
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+
+    with (
+        patch("apps.deathwatch.tasks.subprocess.run") as mock_subprocess,
+        patch(
+            "apps.deathwatch.tasks.notify_watched_deaths_for_character",
+            return_value=3,
+        ) as mock_notify,
+    ):
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        result = scrape_for_watched_deaths()
+
+    mock_notify.assert_called_once()
+    assert result["events_announced"] == 3
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Cap defense
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+@override_settings(DEATHWATCH_MAX_WATCHED_CHARACTERS=1)
+def test_task_refuses_iteration_when_cap_breached() -> None:
+    """Defense-in-depth: if cap check in services leaked, task must NOT scrape.
+
+    Force two watches past cap by bypassing add_death_watch (service-layer
+    cap blocks it). Direct ORM insert simulates state drift / manual edit.
+    """
+    u1 = User.objects.create(username="alice", discord_id="1")
+    u2 = User.objects.create(username="bob", discord_id="2")
+    c1 = Character.objects.create(name="Yhral")
+    c2 = Character.objects.create(name="Bubble")
+    DeathWatch.objects.create(user=u1, character=c1)
+    DeathWatch.objects.create(user=u2, character=c2)
+
+    with patch("apps.deathwatch.tasks.subprocess.run") as mock_subprocess:
+        result = scrape_for_watched_deaths()
+
+    assert result["scraped"] == 0
+    assert result["failed"] == 0
+    mock_subprocess.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Empty / inactive watches
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_task_returns_zero_summary_when_no_active_watches() -> None:
+    """Inactive watches are not iterated (matches DW-5 DeathWatch.filter active=True)."""
+    user = User.objects.create(username="alice", discord_id="1")
+    watch = add_death_watch(user, "Yhral")
+    watch.active = False
+    watch.save(update_fields=["active"])
+
+    with patch("apps.deathwatch.tasks.subprocess.run") as mock_subprocess:
+        result = scrape_for_watched_deaths()
+
+    assert result == {
+        "checked": 0,
+        "skipped": 0,
+        "scraped": 0,
+        "failed": 0,
+        "events_announced": 0,
+        "locked": False,
+    }
+    mock_subprocess.assert_not_called()


### PR DESCRIPTION
## Summary

DW-5 (5 of 9) — Celery task uruchamiany co 1 min przez Beat. Iteruje unikalne postacie z aktywnych watchy, subprocess scrape, update `last_deaths_scraped_at`, fire notify.

Closes #191.

## Changes

- **`apps/deathwatch/tasks.py`** new — `scrape_for_watched_deaths`:
  - `bind=True, max_retries=2, acks_late=True`.
  - **Redis lock** `cache.add("deathwatch_scrape_lock", "1", timeout=55)` — atomic, returns False gdy lock held → early return z `{"locked": True}`. Lock cleanup w `finally` (działa nawet gdy subprocess rzuca).
  - **Cap defense-in-depth** — gdy `len(active watches) > DEATHWATCH_MAX_WATCHED_CHARACTERS` → log error + return zero summary. Service-layer cap powinien zatrzymać, ale gdy leakuje (state drift, manual DB edit), task odmawia bombardowania tibiantis.
  - **Freshness gate** używa `Character.last_deaths_scraped_at` (NIE `last_scraped_at`) — spec §3.12/§5.1, bedmage scraper nie może "kryć" deathwatcha.
  - Subprocess `manage.py scrape_character_deaths <name>`, `timeout=30s`, try/except `TimeoutExpired`.
  - Po success: `Character.objects.filter(name=name).update(last_deaths_scraped_at=now)` + `notify_watched_deaths_for_character(character)` (DW-6 plugnie real handler, na razie stub return 0).
  - Returns summary `{"checked", "skipped", "scraped", "failed", "events_announced", "locked"}`.
- **`apps/deathwatch/migrations/0002_seed_periodic_task.py`** — PeriodicTask "deathwatch.scrape_for_watched_deaths" co 1 min, `enabled=False` (admin świadomie włącza).
- **`config/settings/base.py`** + `.env.example` — `DEATHWATCH_FRESHNESS_SECONDS=50` (10s margin pod 60s Beat).
- **`tests/integration/deathwatch/test_celery_task.py`** new — 12 integration testów (3× lock, 3× freshness, 3× post-success bookkeeping + timeout + notify + cap defense + empty case).

## Decisions

**`enabled=False` w seed migration:** bedmage's check (`enabled=True`) jest DB-only side-effect-free. Tutaj task **uderza w tibiantis.online co 1 min** — admin musi świadomie włączyć po sprawdzeniu że ma wpisy w `DeathWatchChannel` (DW-6) i że cap settings OK. Bez tego fresh deploy zaczynałby bombić Tibiantis natychmiast.

**Per-source `last_deaths_scraped_at` (NIE `last_scraped_at`):** spec §3.12 explicit. Test `test_freshness_gate_uses_last_deaths_scraped_at_not_last_scraped_at` pilnuje. Bedmage scraper updateuje `last_scraped_at` via `auto_now`, więc reuse by zamaskował deathwatcha.

**Cap defense `len(names) > cap`:** strict `>` (nie `>=`). Service-layer check używa `>` po `get_or_create + count`, czyli akceptuje dokładnie `cap` unikalnych chars. Task czeka na **breach**, nie na edge case.

## Test plan

- [x] 12/12 integration testów PASS (28s pod local DB).
- [x] Migration applied + smoke: `PeriodicTask("deathwatch.scrape_for_watched_deaths") enabled=False every=1 minutes`.
- [x] Pre-commit zielony.

Next: **DW-6 handler** (#192) — wymaga tylko DW-2 (już merged), niezależnie od DW-5.