### PR TITLE
feat(deathwatch): notification handler + multi-channel notify (DW-6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@ DEATH_NOTIFICATION_HANDLER=apps.notifications.handlers.DiscordChannelHandler
 # With DOWNLOAD_DELAY=2s, 20 chars = 40s cycle / 1-min Beat = 50% margin.
 DEATHWATCH_MAX_WATCHED_CHARACTERS=20
 DEATHWATCH_FRESHNESS_SECONDS=50
+DEATHWATCH_NOTIFICATION_HANDLER=apps.notifications.handlers.DeathWatchChannelHandler
 
 # ─── Discord bot ─────────────────────────────────────────────────────
 # Operator MUSI wypełnić — Discord Developer Portal → Application → Bot → Token.

--- a/apps/deathwatch/services.py
+++ b/apps/deathwatch/services.py
@@ -155,9 +155,51 @@ def record_watched_death(item: dict[str, Any]) -> WatchedDeathEvent | None:
 def notify_watched_deaths_for_character(character: Character) -> int:
     """Dispatch pending WatchedDeathEvents for character via configured handler.
 
-    DW-2 STUB: returns 0. DW-6 will plug in DeathWatchAnnouncementHandler
-    with multi-channel iteration and atomic flag-set-on-full-success.
-    Kept in DW-2 so DW-5 (Celery task) can import it without ImportError.
+    Multi-channel iteration (§3.9): an event fans out to every configured
+    `DeathWatchChannel` row. The `announced_on_discord` flag is set ONLY when
+    every channel returns True (§3.13 — partial failure leaves the flag false
+    so the next task fire retries on all channels). This trades duplicate
+    posts on healthy channels for at-least-once delivery on unhealthy ones —
+    acceptable for MVP, follow-up §9.5 plans per-channel tracking.
+
+    Returns count of events fully announced this call (for task summary).
     """
-    # TODO(DW-6): wire up DeathWatchAnnouncementHandler — see spec §3.9, §3.13.
-    return 0
+    from apps.deathwatch.models import DeathWatchChannel
+    from apps.notifications import get_deathwatch_handler
+
+    channels = list(DeathWatchChannel.objects.all())
+    if not channels:
+        # No channel configured (admin hasn't run /deathwatch channel yet).
+        # Pending events stay with announced_on_discord=False and will fire
+        # next time a channel exists — acceptable backlog per spec §5 edge.
+        return 0
+
+    handler = get_deathwatch_handler()
+    fired = 0
+
+    events = WatchedDeathEvent.objects.filter(
+        character=character, announced_on_discord=False
+    ).select_related("character")
+
+    for event in events:
+        all_channels_ok = True
+        for channel in channels:
+            try:
+                if not handler.announce(event, channel):
+                    all_channels_ok = False
+            except Exception:
+                # Isolate per-channel failure — one channel's 5xx must not
+                # short-circuit dispatch to the others (spec §3.9).
+                logger.exception(
+                    "deathwatch announce raised for event=%s channel=%s",
+                    event.pk,
+                    channel.pk,
+                )
+                all_channels_ok = False
+
+        if all_channels_ok:
+            event.announced_on_discord = True
+            event.save(update_fields=["announced_on_discord"])
+            fired += 1
+
+    return fired

--- a/apps/notifications/__init__.py
+++ b/apps/notifications/__init__.py
@@ -6,6 +6,7 @@ from django.utils.module_loading import import_string
 from apps.notifications.handlers import (
     BedmageNotificationHandler,
     DeathAnnouncementHandler,
+    DeathWatchAnnouncementHandler,
 )
 
 
@@ -23,3 +24,13 @@ def get_bedmage_handler() -> BedmageNotificationHandler:
 def get_death_handler() -> DeathAnnouncementHandler:  # NEW M8
     handler_class = import_string(settings.DEATH_NOTIFICATION_HANDLER)
     return cast(DeathAnnouncementHandler, handler_class())
+
+
+def get_deathwatch_handler() -> DeathWatchAnnouncementHandler:  # DW-6
+    """Resolve DeathWatchAnnouncementHandler from settings.DEATHWATCH_NOTIFICATION_HANDLER.
+
+    Same per-call resolution pattern as get_bedmage_handler / get_death_handler —
+    @override_settings in tests must work; cost is negligible at 1-min cadence.
+    """
+    handler_class = import_string(settings.DEATHWATCH_NOTIFICATION_HANDLER)
+    return cast(DeathWatchAnnouncementHandler, handler_class())

--- a/apps/notifications/handlers.py
+++ b/apps/notifications/handlers.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo
 if TYPE_CHECKING:
     from apps.bedmages.models import BedmageWatch
     from apps.deaths.models import DeathEvent
+    from apps.deathwatch.models import DeathWatchChannel, WatchedDeathEvent
     from discord_bot.models import DiscordChannel
 
 logger = logging.getLogger(__name__)
@@ -166,5 +167,77 @@ class DeathLoggingHandler:
             death_event.level_at_death,
             discord_channel.guild_id,
             discord_channel.channel_id,
+        )
+        return True
+
+
+# ─── DeathWatch (DW-6) — per-character death blacklist announcements ────────
+#
+# Mirrors the DeathEvent stack above (Protocol + REST + Logging impls). Key
+# differences:
+# - Operates on `WatchedDeathEvent` (FK to Character) instead of `DeathEvent`
+#   (denormalized character_name string).
+# - Channel model is `DeathWatchChannel` (no per-guild threshold field).
+# - Embed color: 0x8B008B (purple) — visually distinct from M4 crimson when
+#   both feeds post to the same Discord server.
+
+
+class DeathWatchAnnouncementHandler(Protocol):
+    """Protocol for deathwatch announcements.
+
+    Implementations swap via settings.DEATHWATCH_NOTIFICATION_HANDLER.
+    """
+
+    def announce(
+        self, event: WatchedDeathEvent, channel: DeathWatchChannel
+    ) -> bool: ...
+
+
+class DeathWatchChannelHandler:
+    """Implements DeathWatchAnnouncementHandler. Posts purple embed to per-guild channel."""
+
+    def announce(self, event: WatchedDeathEvent, channel: DeathWatchChannel) -> bool:
+        from apps.notifications.discord_client import DiscordRESTClient
+
+        client = DiscordRESTClient()
+        embed = self._render_embed(event)
+        return client.send_channel_message(
+            channel_id=channel.channel_id,
+            embed=embed,
+        )
+
+    def _render_embed(self, event: WatchedDeathEvent) -> dict[str, Any]:
+        """Build Discord embed mirroring M4 DiscordChannelHandler shape.
+
+        Color differs (purple vs crimson) so operators distinguish DW from M4
+        deaths in the same channel. `died_at` converted UTC → Europe/Warsaw
+        before formatting (matches #180 convention).
+        """
+        died_at_local = event.died_at.astimezone(ZoneInfo("Europe/Warsaw"))
+        return {
+            "title": event.character.name,
+            "url": (
+                "https://www.tibiantis.online/?page=character&name="
+                + urllib.parse.quote_plus(event.character.name)
+            ),
+            "description": (
+                f"Died at level {event.level_at_death}\n"
+                f"{died_at_local:%Y-%m-%d %H:%M:%S}\n"
+                f"Killed by: {event.killed_by or 'unknown'}"
+            ),
+            "color": 0x8B008B,  # purple — distinct from M4 crimson
+        }
+
+
+class DeathWatchLoggingHandler:
+    """Test/dev variant — logs only, returns True (success). No Discord call."""
+
+    def announce(self, event: WatchedDeathEvent, channel: DeathWatchChannel) -> bool:
+        logger.info(
+            "DEATHWATCH ANNOUNCE: %s (lvl %s) → guild=%s channel=%s",
+            event.character.name,
+            event.level_at_death,
+            channel.guild_id,
+            channel.channel_id,
         )
         return True

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -208,6 +208,13 @@ DEATHWATCH_MAX_WATCHED_CHARACTERS = env.int(
 # leaves a 10s buffer under the 1-min Beat interval to absorb Celery queueing
 # jitter without re-scraping the same character twice in adjacent cycles.
 DEATHWATCH_FRESHNESS_SECONDS = env.int("DEATHWATCH_FRESHNESS_SECONDS", default=50)
+# Handler swap point (DW-6) — mirrors BEDMAGE_NOTIFICATION_HANDLER /
+# DEATH_NOTIFICATION_HANDLER. Default ships real Discord dispatch; tests use
+# DeathWatchLoggingHandler via @override_settings or env override.
+DEATHWATCH_NOTIFICATION_HANDLER = env(
+    "DEATHWATCH_NOTIFICATION_HANDLER",
+    default="apps.notifications.handlers.DeathWatchChannelHandler",
+)
 
 # MongoDB — used ONLY for app_logs / scrape_logs (CLAUDE.md §4).
 # Empty MONGO_URL disables Mongo logging gracefully via NullHandler (spec §3.4).

--- a/tests/integration/deathwatch/test_notify.py
+++ b/tests/integration/deathwatch/test_notify.py
@@ -1,0 +1,183 @@
+"""Integration tests for notify_watched_deaths_for_character (DW-6 real impl).
+
+Verifies multi-channel iteration + atomic flag-set-on-full-success (§3.13).
+Handler swapped to DeathWatchLoggingHandler for default success cases; mocked
+explicitly when partial failure semantics are under test.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pytest
+from django.test import override_settings
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.characters.models import Character
+from apps.deathwatch.models import DeathWatch, WatchedDeathEvent
+from apps.deathwatch.services import (
+    add_death_watch,
+    notify_watched_deaths_for_character,
+    set_deathwatch_channel_for_guild,
+)
+
+
+def _backdate_watch(watch: DeathWatch, delta: timedelta) -> None:
+    DeathWatch.objects.filter(pk=watch.pk).update(created_at=timezone.now() - delta)
+
+
+@pytest.fixture
+def alice_watching_yhral(db) -> tuple[User, Character, DeathWatch]:
+    user = User.objects.create(username="alice", discord_id="1")
+    watch = add_death_watch(user, "Yhral")
+    _backdate_watch(watch, timedelta(hours=1))
+    character = Character.objects.get(name="Yhral")
+    return user, character, watch
+
+
+@pytest.fixture
+def pending_event(alice_watching_yhral) -> WatchedDeathEvent:
+    _, character, _ = alice_watching_yhral
+    return WatchedDeathEvent.objects.create(
+        character=character,
+        level_at_death=128,
+        killed_by="a giant crayfish",
+        died_at=datetime(2026, 5, 7, 14, 15, 46, tzinfo=ZoneInfo("UTC")),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Multi-channel iteration + atomic flag-set
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+@override_settings(
+    DEATHWATCH_NOTIFICATION_HANDLER="apps.notifications.handlers.DeathWatchLoggingHandler"
+)
+def test_notify_marks_event_announced_when_all_channels_succeed(
+    alice_watching_yhral, pending_event: WatchedDeathEvent
+) -> None:
+    _, character, _ = alice_watching_yhral
+    set_deathwatch_channel_for_guild(guild_id=1, channel_id=10)
+    set_deathwatch_channel_for_guild(guild_id=2, channel_id=20)
+
+    fired = notify_watched_deaths_for_character(character)
+
+    assert fired == 1
+    pending_event.refresh_from_db()
+    assert pending_event.announced_on_discord is True
+
+
+@pytest.mark.django_db
+def test_notify_does_not_mark_when_one_channel_fails(
+    alice_watching_yhral, pending_event: WatchedDeathEvent
+) -> None:
+    """§3.13 — partial channel failure leaves flag False so next fire retries."""
+    _, character, _ = alice_watching_yhral
+    set_deathwatch_channel_for_guild(guild_id=1, channel_id=10)
+    set_deathwatch_channel_for_guild(guild_id=2, channel_id=20)
+
+    with patch(
+        "apps.notifications.handlers.DeathWatchChannelHandler.announce",
+        side_effect=[True, False],
+    ):
+        fired = notify_watched_deaths_for_character(character)
+
+    assert fired == 0
+    pending_event.refresh_from_db()
+    assert pending_event.announced_on_discord is False
+
+
+@pytest.mark.django_db
+def test_notify_isolates_per_channel_exceptions(
+    alice_watching_yhral, pending_event: WatchedDeathEvent
+) -> None:
+    """One channel's exception must not short-circuit dispatch to the others.
+
+    Handler raises on channel A → handler succeeds on channel B → event stays
+    unannounced (partial failure rule from §3.13) but the second channel's
+    announce was still called.
+    """
+    _, character, _ = alice_watching_yhral
+    set_deathwatch_channel_for_guild(guild_id=1, channel_id=10)
+    set_deathwatch_channel_for_guild(guild_id=2, channel_id=20)
+
+    with patch(
+        "apps.notifications.handlers.DeathWatchChannelHandler.announce",
+        side_effect=[RuntimeError("boom"), True],
+    ) as mock_announce:
+        fired = notify_watched_deaths_for_character(character)
+
+    assert mock_announce.call_count == 2  # second channel still attempted
+    assert fired == 0
+    pending_event.refresh_from_db()
+    assert pending_event.announced_on_discord is False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Edge cases
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_notify_returns_zero_when_no_channels_configured(
+    alice_watching_yhral, pending_event: WatchedDeathEvent
+) -> None:
+    """Admin hasn't run /deathwatch channel yet → backlog stays pending."""
+    _, character, _ = alice_watching_yhral
+
+    fired = notify_watched_deaths_for_character(character)
+
+    assert fired == 0
+    pending_event.refresh_from_db()
+    assert pending_event.announced_on_discord is False
+
+
+@pytest.mark.django_db
+@override_settings(
+    DEATHWATCH_NOTIFICATION_HANDLER="apps.notifications.handlers.DeathWatchLoggingHandler"
+)
+def test_notify_skips_already_announced_events(
+    alice_watching_yhral, pending_event: WatchedDeathEvent
+) -> None:
+    _, character, _ = alice_watching_yhral
+    set_deathwatch_channel_for_guild(guild_id=1, channel_id=10)
+    pending_event.announced_on_discord = True
+    pending_event.save(update_fields=["announced_on_discord"])
+
+    with patch(
+        "apps.notifications.handlers.DeathWatchLoggingHandler.announce"
+    ) as mock_announce:
+        fired = notify_watched_deaths_for_character(character)
+
+    assert fired == 0
+    mock_announce.assert_not_called()
+
+
+@pytest.mark.django_db
+@override_settings(
+    DEATHWATCH_NOTIFICATION_HANDLER="apps.notifications.handlers.DeathWatchLoggingHandler"
+)
+def test_notify_processes_multiple_pending_events_in_one_call(
+    alice_watching_yhral,
+) -> None:
+    """Several pending events for the same character → each gets fanned out."""
+    _, character, _ = alice_watching_yhral
+    set_deathwatch_channel_for_guild(guild_id=1, channel_id=10)
+    base_t = datetime(2026, 5, 7, 14, 0, 0, tzinfo=ZoneInfo("UTC"))
+    for i in range(3):
+        WatchedDeathEvent.objects.create(
+            character=character,
+            level_at_death=100 + i,
+            killed_by=f"k{i}",
+            died_at=base_t + timedelta(minutes=i),
+        )
+
+    fired = notify_watched_deaths_for_character(character)
+
+    assert fired == 3
+    assert WatchedDeathEvent.objects.filter(announced_on_discord=False).count() == 0

--- a/tests/unit/deathwatch/test_handlers.py
+++ b/tests/unit/deathwatch/test_handlers.py
@@ -1,0 +1,181 @@
+"""Unit tests for DW-6 handlers — embed shape + dispatch wiring."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from apps.characters.models import Character
+from apps.deathwatch.models import DeathWatchChannel, WatchedDeathEvent
+from apps.notifications import get_deathwatch_handler
+from apps.notifications.handlers import (
+    DeathWatchChannelHandler,
+    DeathWatchLoggingHandler,
+)
+
+
+@pytest.fixture
+def character(db) -> Character:
+    return Character.objects.create(name="Yhral")
+
+
+@pytest.fixture
+def event(character: Character) -> WatchedDeathEvent:
+    return WatchedDeathEvent.objects.create(
+        character=character,
+        level_at_death=128,
+        killed_by="a giant crayfish",
+        died_at=datetime(2026, 5, 7, 14, 15, 46, tzinfo=ZoneInfo("UTC")),
+    )
+
+
+@pytest.fixture
+def channel(db) -> DeathWatchChannel:
+    return DeathWatchChannel.objects.create(guild_id=1, channel_id=42)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# DeathWatchChannelHandler._render_embed
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_render_embed_uses_purple_color(event: WatchedDeathEvent) -> None:
+    """Spec §3.11 — purple (0x8B008B) distinguishes DW from M4 crimson."""
+    embed = DeathWatchChannelHandler()._render_embed(event)
+    assert embed["color"] == 0x8B008B
+
+
+def test_render_embed_title_is_character_name(event: WatchedDeathEvent) -> None:
+    embed = DeathWatchChannelHandler()._render_embed(event)
+    assert embed["title"] == "Yhral"
+
+
+def test_render_embed_url_is_clickable_tibiantis_profile(
+    event: WatchedDeathEvent,
+) -> None:
+    embed = DeathWatchChannelHandler()._render_embed(event)
+    assert embed["url"].startswith("https://www.tibiantis.online/?page=character&name=")
+    assert "Yhral" in embed["url"]
+
+
+def test_render_embed_url_quote_plus_encodes_spaces(db) -> None:
+    """Character names with spaces use `+` separator (Tibiantis URL convention)."""
+    character = Character.objects.create(name="Eternal oblivion")
+    event = WatchedDeathEvent.objects.create(
+        character=character,
+        level_at_death=200,
+        killed_by="x",
+        died_at=datetime(2026, 5, 7, 14, 15, 46, tzinfo=ZoneInfo("UTC")),
+    )
+    embed = DeathWatchChannelHandler()._render_embed(event)
+    assert "name=Eternal+oblivion" in embed["url"]
+
+
+def test_render_embed_description_includes_level_time_killer(
+    event: WatchedDeathEvent,
+) -> None:
+    embed = DeathWatchChannelHandler()._render_embed(event)
+    desc = embed["description"]
+    assert "Died at level 128" in desc
+    assert "Killed by: a giant crayfish" in desc
+
+
+def test_render_embed_died_at_converted_to_europe_warsaw(
+    event: WatchedDeathEvent,
+) -> None:
+    """May 2026 → CEST (UTC+2). 14:15:46 UTC = 16:15:46 Warsaw."""
+    embed = DeathWatchChannelHandler()._render_embed(event)
+    assert "16:15:46" in embed["description"]
+
+
+def test_render_embed_renders_unknown_killer_when_empty(
+    character: Character,
+) -> None:
+    event = WatchedDeathEvent.objects.create(
+        character=character,
+        level_at_death=50,
+        killed_by="",
+        died_at=datetime(2026, 5, 7, 12, 0, 0, tzinfo=ZoneInfo("UTC")),
+    )
+    embed = DeathWatchChannelHandler()._render_embed(event)
+    assert "Killed by: unknown" in embed["description"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Dispatch wiring
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_channel_handler_announce_calls_discord_rest_client(
+    event: WatchedDeathEvent, channel: DeathWatchChannel
+) -> None:
+    """announce() routes through DiscordRESTClient.send_channel_message
+    with channel.channel_id + rendered embed payload.
+    """
+    with patch(
+        "apps.notifications.discord_client.DiscordRESTClient.send_channel_message",
+        return_value=True,
+    ) as mock_send:
+        result = DeathWatchChannelHandler().announce(event, channel)
+
+    assert result is True
+    mock_send.assert_called_once()
+    call_kwargs = mock_send.call_args.kwargs
+    assert call_kwargs["channel_id"] == 42
+    assert call_kwargs["embed"]["title"] == "Yhral"
+
+
+@pytest.mark.django_db
+def test_channel_handler_propagates_false_on_send_failure(
+    event: WatchedDeathEvent, channel: DeathWatchChannel
+) -> None:
+    """When DiscordRESTClient signals failure (None or False return), handler
+    returns False — caller treats as failed-on-this-channel.
+    """
+    with patch(
+        "apps.notifications.discord_client.DiscordRESTClient.send_channel_message",
+        return_value=False,
+    ):
+        result = DeathWatchChannelHandler().announce(event, channel)
+    assert result is False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Logging handler (test/dev variant)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_logging_handler_always_returns_true_no_discord_call(
+    event: WatchedDeathEvent, channel: DeathWatchChannel
+) -> None:
+    with patch(
+        "apps.notifications.discord_client.DiscordRESTClient.send_channel_message"
+    ) as mock_send:
+        result = DeathWatchLoggingHandler().announce(event, channel)
+
+    assert result is True
+    mock_send.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Factory resolution
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_get_deathwatch_handler_default_is_channel_handler() -> None:
+    handler = get_deathwatch_handler()
+    assert isinstance(handler, DeathWatchChannelHandler)
+
+
+def test_get_deathwatch_handler_swappable_via_settings(settings) -> None:
+    """@override_settings (via pytest's settings fixture) must affect resolution."""
+    settings.DEATHWATCH_NOTIFICATION_HANDLER = (
+        "apps.notifications.handlers.DeathWatchLoggingHandler"
+    )
+    handler = get_deathwatch_handler()
+    assert isinstance(handler, DeathWatchLoggingHandler)


### PR DESCRIPTION
## Summary

DW-6 (6 of 9) — notification handler stack + multi-channel notify integration. Po tym tasku backend DW jest komplet — pozostają tylko interfejsy użytkownika (DW-7 Discord cog, DW-8 GraphQL, DW-9 closure).

Closes #192.

## Changes

- **`apps/notifications/handlers.py`** — trzy nowe klasy (mirror M8 stack):
  - `DeathWatchAnnouncementHandler(Protocol)` — `announce(event, channel) → bool`.
  - `DeathWatchChannelHandler` — real dispatch via `DiscordRESTClient.send_channel_message` z embed (purple `0x8B008B`).
  - `DeathWatchLoggingHandler` — test/dev variant, logger.info + return True.
- **`apps/notifications/__init__.py`** — `get_deathwatch_handler()` factory (per-call resolution, swappable via settings).
- **`apps/deathwatch/services.py`** — `notify_watched_deaths_for_character` real implementation (zastępuje DW-2 stub return 0):
  - Iteruje `DeathWatchChannel.objects.all()` × pending events.
  - Per-channel try/except — exception izolowana, nie short-circuit.
  - Flag set TYLKO gdy wszystkie kanały True (§3.13 partial-failure rule).
- **`config/settings/base.py`** + `.env.example` — `DEATHWATCH_NOTIFICATION_HANDLER` z default `DeathWatchChannelHandler`.
- **`tests/unit/deathwatch/test_handlers.py`** new — 12 unit testów (embed shape + dispatch wiring + factory).
- **`tests/integration/deathwatch/test_notify.py`** new — 6 integration testów (multi-channel, partial fail, exception isolation, no-channels, skip-announced, multi-event).

## Decisions

**Purple `0x8B008B` vs crimson `0xDC143C`:** spec §3.11 — operatorzy widzący oba feeds (M4 deaths + DW-6 watched deaths) w tym samym Discord muszą natychmiast odróżnić źródło.

**Multi-channel atomic flag-set (§3.13):** flag ustawiana TYLKO gdy wszystkie kanały zwróciły True. Partial failure leaves flag False → następny task fire retries na wszystkich kanałach (duplicate posts na healthy channels w zamian za at-least-once delivery). Trade-off opisany w spec §9.5 follow-up.

**Per-channel exception isolation:** test `test_notify_isolates_per_channel_exceptions` pilnuje że jeden Discord 5xx nie zatrzymuje dispatchu na pozostałe kanały. Spec §3.9.

**Backlog gdy `DeathWatchChannel` pusty:** `notify` early-return zero gdy `channels.exists() is False`. Pending events czekają z flagą False — admin może później skonfigurować kanał (DW-7 `/deathwatch channel`) i dostać batch zaległych eventów na pierwszy task fire.

## Test plan

- [x] 12 unit handler testów PASS.
- [x] 6 integration notify testów PASS.
- [x] Regression: 19 services testów (DW-2) + 12 task testów (DW-5) still green.
- [x] Pre-commit zielony.

Backend DW jest komplet. Next: **DW-7 Discord cog** (#193) lub **DW-8 GraphQL** (#194) — oba zależą tylko od DW-2 (merged), niezależne od siebie.