### PR TITLE
feat(deathwatch): discord cog with 4 slash commands (DW-7)

### DIFF
--- a/discord_bot/bot.py
+++ b/discord_bot/bot.py
@@ -40,10 +40,13 @@ def setup_bot() -> discord.Bot:
     multiple times (tests share the module-level bot singleton)."""
     from discord_bot.cogs.bedmages import BedmageCog
     from discord_bot.cogs.deaths import DeathsCog
+    from discord_bot.cogs.deathwatch import DeathWatchCog
 
     if "BedmageCog" not in bot.cogs:
         bot.add_cog(BedmageCog(bot))
     if "DeathsCog" not in bot.cogs:
         bot.add_cog(DeathsCog(bot))
+    if "DeathWatchCog" not in bot.cogs:
+        bot.add_cog(DeathWatchCog(bot))
 
     return bot

--- a/discord_bot/cogs/deathwatch.py
+++ b/discord_bot/cogs/deathwatch.py
@@ -1,0 +1,120 @@
+# NOTE: NO `from __future__ import annotations` here — py-cord introspects
+# parameter annotations at slash command invocation time and requires them
+# as runtime objects, not PEP 563 strings.
+from asgiref.sync import sync_to_async
+import discord
+from discord.ext import commands
+
+from apps.deathwatch.services import set_deathwatch_channel_for_guild
+from discord_bot.services import (
+    add_deathwatch_for_discord_user,
+    list_deathwatches_for_discord_user,
+    remove_deathwatch_for_discord_user,
+)
+
+
+class DeathWatchCog(commands.Cog):
+    """Slash commands for the per-character death blacklist (DW-7).
+
+    `/deathwatch add|remove|list` — user-scoped; ephemeral replies.
+    `/deathwatch channel` — guild-admin only; public ack (audit trail).
+    """
+
+    deathwatch = discord.SlashCommandGroup(
+        "deathwatch",
+        "Watch specific characters for new deaths",
+    )
+
+    def __init__(self, bot: discord.Bot) -> None:
+        self.bot = bot
+
+    @deathwatch.command(name="add", description="Watch a character for new deaths")
+    async def add(
+        self,
+        ctx: discord.ApplicationContext,
+        character_name: discord.Option(str, "Tibiantis character name", max_length=64),
+    ) -> None:
+        try:
+            _, created = await sync_to_async(add_deathwatch_for_discord_user)(
+                discord_id=ctx.author.id,
+                discord_username=ctx.author.name,
+                character_name=character_name,
+            )
+        except ValueError as exc:
+            # Cap exceeded surfaces here. Render the message verbatim — the
+            # service-layer string already explains the limit clearly. No
+            # stack trace leak (CLAUDE.md §8).
+            await ctx.respond(f"❌ {exc}", ephemeral=True)
+            return
+
+        msg = (
+            f"👀 Now watching `{character_name}` for new deaths."
+            if created
+            else f"ℹ️ `{character_name}` was already on your deathwatch list."
+        )
+        await ctx.respond(msg, ephemeral=True)
+
+    @deathwatch.command(name="remove", description="Stop watching a character")
+    async def remove(
+        self,
+        ctx: discord.ApplicationContext,
+        character_name: discord.Option(str, "Tibiantis character name", max_length=64),
+    ) -> None:
+        removed = await sync_to_async(remove_deathwatch_for_discord_user)(
+            discord_id=ctx.author.id,
+            character_name=character_name,
+        )
+        msg = (
+            f"🗑️ Stopped watching `{character_name}`."
+            if removed
+            else f"ℹ️ `{character_name}` wasn't on your deathwatch list."
+        )
+        await ctx.respond(msg, ephemeral=True)
+
+    @deathwatch.command(name="list", description="Show your deathwatch list")
+    async def list(self, ctx: discord.ApplicationContext) -> None:
+        watches = await sync_to_async(list_deathwatches_for_discord_user)(ctx.author.id)
+        if not watches:
+            await ctx.respond(
+                "Your deathwatch list is empty. " "Add with `/deathwatch add <name>`.",
+                ephemeral=True,
+            )
+            return
+        names = ", ".join(f"`{w.character.name}`" for w in watches)
+        await ctx.respond(f"Your deathwatches: {names}", ephemeral=True)
+
+    @deathwatch.command(
+        name="channel",
+        description="Set this channel as the deathwatch announcement target (admin only)",
+    )
+    async def channel(self, ctx: discord.ApplicationContext) -> None:
+        """Two-layer guard (order matters, mirror /deaths threshold):
+        DM rejection BEFORE admin check. `guild_permissions` is `Member`-only;
+        in a DM `ctx.author` is `discord.User` and accessing it raises
+        `AttributeError`. DM branch short-circuits first.
+        """
+        if ctx.guild is None:
+            await ctx.respond(
+                "❌ This command must be used in a server.", ephemeral=True
+            )
+            return
+
+        # Narrow types — post-guild-check guarantees:
+        assert isinstance(ctx.author, discord.Member)
+        assert ctx.channel_id is not None
+
+        if not ctx.author.guild_permissions.administrator:
+            await ctx.respond(
+                "❌ Only server admins can set the deathwatch channel.",
+                ephemeral=True,
+            )
+            return
+
+        await sync_to_async(set_deathwatch_channel_for_guild)(
+            guild_id=ctx.guild.id,
+            channel_id=ctx.channel_id,
+        )
+        # Public ack — audit trail, other admins see who pointed DW here.
+        await ctx.respond(
+            "💀👀 DeathWatch announcements will be posted to this channel."
+        )

--- a/discord_bot/services.py
+++ b/discord_bot/services.py
@@ -10,6 +10,12 @@ from discord_bot.models import DiscordChannel
 from apps.bedmages.models import BedmageWatch
 from apps.bedmages.services import add_bedmage_watch, remove_bedmage_watch
 from apps.characters.models import _canonicalize_name
+from apps.deathwatch.models import DeathWatch
+from apps.deathwatch.services import (
+    add_death_watch,
+    list_death_watches,
+    remove_death_watch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -105,3 +111,58 @@ def list_bedmages_for_discord_user(discord_id: int) -> list[BedmageWatch]:
     return list(
         BedmageWatch.objects.filter(user=user, active=True).select_related("character")
     )
+
+
+# ─── DeathWatch (DW-7) ──────────────────────────────────────────────────────
+# Mirror of the bedmage wrappers above: auto-create User + delegate to the
+# domain service in apps.deathwatch.services. Discord-cog-facing entry points
+# stay in discord_bot/* per project convention.
+
+
+def add_deathwatch_for_discord_user(
+    discord_id: int, discord_username: str, character_name: str
+) -> tuple[DeathWatch, bool]:
+    """Auto-create User + delegate to apps.deathwatch.services.add_death_watch.
+
+    Returns (watch, created). `created=False` means the watch was already on
+    the user's list — same idempotent-ack pattern as
+    `add_bedmage_for_discord_user`. Caller renders different copy for the two
+    cases. Canonicalize at entry so the recovery .get() below matches the row
+    actually stored (Character.save() canonicalizes on its side too).
+
+    Cap exceeded (`ValueError("cap of N unique characters exceeded")`) is
+    re-raised — the cog catches it and surfaces a user-friendly message,
+    NOT a stack trace (CLAUDE.md §8).
+    """
+    user, _ = get_or_create_user_by_discord_id(discord_id, discord_username)
+    character_name = _canonicalize_name(character_name)
+    try:
+        watch = add_death_watch(user, character_name)
+        return watch, True
+    except ValueError as exc:
+        # Two ValueError flavors from add_death_watch:
+        # 1. "already active" → idempotent; return existing watch
+        # 2. "cap of N unique characters exceeded" → re-raise for cog to surface
+        if "already active" in str(exc):
+            watch = DeathWatch.objects.get(user=user, character__name=character_name)
+            return watch, False
+        raise
+
+
+def remove_deathwatch_for_discord_user(discord_id: int, character_name: str) -> bool:
+    """Auto-create User + delegate to apps.deathwatch.services.remove_death_watch.
+
+    Returns True if watch existed and was deleted, False otherwise.
+    Idempotent — never raises.
+    """
+    user, _ = get_or_create_user_by_discord_id(discord_id, discord_username="")
+    return remove_death_watch(user, character_name)
+
+
+def list_deathwatches_for_discord_user(discord_id: int) -> list[DeathWatch]:
+    """Active deathwatches for user. Empty list when user unknown (no auto-create on read)."""
+    try:
+        user = User.objects.get(discord_id=discord_id)
+    except User.DoesNotExist:
+        return []
+    return list(list_death_watches(user).filter(active=True))

--- a/tests/unit/discord_bot/test_deathwatch_cog.py
+++ b/tests/unit/discord_bot/test_deathwatch_cog.py
@@ -1,0 +1,314 @@
+"""Tests for discord_bot.cogs.deathwatch — 4 slash commands (DW-7).
+
+Mirror of tests/unit/discord_bot/test_deaths_cog.py for the admin-only
+`/deathwatch channel` command + bedmage-style add/remove/list coverage.
+
+`monkeypatch.setattr` on the cog's import-site bindings, NOT on the source
+modules — cog imports the helpers at module load, so patching the source
+module after cog import is a no-op.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from discord_bot.cogs.deathwatch import DeathWatchCog
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# /deathwatch add
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_add_command_creates_watch_and_responds_ephemerally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.author.name = "alice"
+    mock_ctx.respond = AsyncMock()
+
+    spy = MagicMock(return_value=(MagicMock(), True))
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.add_deathwatch_for_discord_user", spy
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.add.callback(cog, mock_ctx, "Yhral")
+
+    spy.assert_called_once_with(
+        discord_id=12345, discord_username="alice", character_name="Yhral"
+    )
+    args, kwargs = mock_ctx.respond.call_args
+    assert "👀" in args[0]
+    assert "Yhral" in args[0]
+    assert kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_add_command_idempotent_ack_when_already_on_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """created=False from service → friendly 'already on list' message,
+    NOT an error. Same pattern as bedmage `add` (M7)."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.author.name = "alice"
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.add_deathwatch_for_discord_user",
+        MagicMock(return_value=(MagicMock(), False)),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.add.callback(cog, mock_ctx, "Yhral")
+
+    args, _ = mock_ctx.respond.call_args
+    assert "ℹ️" in args[0]
+    assert "already" in args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_add_command_surfaces_cap_exceeded_without_stack_trace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ValueError from cap check → ephemeral error, NO traceback (CLAUDE.md §8)."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.author.name = "alice"
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.add_deathwatch_for_discord_user",
+        MagicMock(
+            side_effect=ValueError(
+                "DeathWatch cap of 20 unique characters exceeded (would be 21)"
+            )
+        ),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.add.callback(cog, mock_ctx, "Yhral")
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "❌" in args[0]
+    assert "cap" in args[0].lower()
+    assert "Traceback" not in args[0]
+    assert kwargs["ephemeral"] is True
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# /deathwatch remove
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_remove_command_acknowledges_deletion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.remove_deathwatch_for_discord_user",
+        MagicMock(return_value=True),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.remove.callback(cog, mock_ctx, "Yhral")
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "🗑️" in args[0]
+    assert kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_remove_command_idempotent_when_not_on_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.remove_deathwatch_for_discord_user",
+        MagicMock(return_value=False),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.remove.callback(cog, mock_ctx, "Yhral")
+
+    args, _ = mock_ctx.respond.call_args
+    assert "ℹ️" in args[0]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# /deathwatch list
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_list_command_empty_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.list_deathwatches_for_discord_user",
+        MagicMock(return_value=[]),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "empty" in args[0].lower()
+    assert kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_command_renders_character_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.author.id = 12345
+    mock_ctx.respond = AsyncMock()
+
+    w1 = MagicMock()
+    w1.character.name = "Yhral"
+    w2 = MagicMock()
+    w2.character.name = "Bubble"
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.list_deathwatches_for_discord_user",
+        MagicMock(return_value=[w1, w2]),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "Yhral" in args[0]
+    assert "Bubble" in args[0]
+    assert kwargs["ephemeral"] is True
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# /deathwatch channel — guard layer (mirror /deaths threshold)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_channel_command_rejects_dm_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DM check MUST come before admin check — guild_permissions is Member-only
+    and accessing it on a discord.User (DM) raises AttributeError."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.guild = None
+    mock_ctx.respond = AsyncMock()
+
+    spy = MagicMock()
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.set_deathwatch_channel_for_guild", spy
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.channel.callback(cog, mock_ctx)
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "❌" in args[0]
+    assert "must be used in a server" in args[0]
+    assert kwargs["ephemeral"] is True
+    spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_channel_command_rejects_non_admin_caller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.guild = MagicMock()
+    mock_ctx.channel_id = 666
+    mock_ctx.author = MagicMock(spec=discord.Member)
+    mock_ctx.author.guild_permissions.administrator = False
+    mock_ctx.respond = AsyncMock()
+
+    spy = MagicMock()
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.set_deathwatch_channel_for_guild", spy
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.channel.callback(cog, mock_ctx)
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "❌" in args[0]
+    assert "Only server admins" in args[0]
+    assert kwargs["ephemeral"] is True
+    spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_channel_command_persists_on_admin_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 555
+    mock_ctx.channel_id = 666
+    mock_ctx.author = MagicMock(spec=discord.Member)
+    mock_ctx.author.guild_permissions.administrator = True
+    mock_ctx.respond = AsyncMock()
+
+    spy = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.set_deathwatch_channel_for_guild", spy
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.channel.callback(cog, mock_ctx)
+
+    spy.assert_called_once_with(guild_id=555, channel_id=666)
+
+
+@pytest.mark.asyncio
+async def test_channel_command_responds_with_public_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mirror /deaths threshold — public ack so other admins see the change."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 555
+    mock_ctx.channel_id = 666
+    mock_ctx.author = MagicMock(spec=discord.Member)
+    mock_ctx.author.guild_permissions.administrator = True
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.set_deathwatch_channel_for_guild",
+        lambda **kw: MagicMock(),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.channel.callback(cog, mock_ctx)
+
+    _, kwargs = mock_ctx.respond.call_args
+    assert kwargs.get("ephemeral", False) is False
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Cog structural sanity (M7 idiom)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_deathwatch_cog_has_slash_command_group_at_class_level() -> None:
+    """py-cord introspects class body at bot.add_cog time — group MUST be
+    a class attribute, not declared inside __init__."""
+    assert isinstance(DeathWatchCog.deathwatch, discord.SlashCommandGroup)
+    assert DeathWatchCog.deathwatch.name == "deathwatch"


### PR DESCRIPTION
## Summary

DW-7 (7 of 9) — Discord cog z 4 slash commands `/deathwatch add|remove|list|channel`. Pierwszy user-facing interface dla feature DeathWatch.

Closes #193.

## Changes

- **`discord_bot/services.py`** — 3 nowe wrappery (mirror bedmage pattern):
  - `add_deathwatch_for_discord_user(discord_id, discord_username, character_name)` — auto-create User + `_canonicalize_name` + delegate do `apps.deathwatch.services.add_death_watch`. Dwa flavors `ValueError`:
    - `"already active"` → idempotent recovery (return existing watch + `created=False`).
    - `"cap of N unique characters exceeded"` → re-raise (cog catches + surface user-friendly).
  - `remove_deathwatch_for_discord_user` — auto-create User + delegate. Idempotent.
  - `list_deathwatches_for_discord_user` — read-only (NO auto-create). Empty list gdy user unknown.
- **`discord_bot/cogs/deathwatch.py`** new — `DeathWatchCog` z `SlashCommandGroup("deathwatch", ...)`:
  - `/deathwatch add <name>` — ephemeral ack (success / already-on-list / cap-exceeded).
  - `/deathwatch remove <name>` — ephemeral ack.
  - `/deathwatch list` — ephemeral; pusty stan ze wskazówką.
  - `/deathwatch channel` — admin-only z **two-layer guard** (DM check przed admin check). Public ack.
- **`discord_bot/bot.py`** — `setup_bot()` rejestruje `DeathWatchCog` (idempotent).
- **`tests/unit/discord_bot/test_deathwatch_cog.py`** new — 12 unit testów (add x3 + remove x2 + list x2 + channel guard x4 + structural).

## Decisions

**Wrappery w `discord_bot/services.py` zamiast inline w cog:** projekt-wide convention (M7 bedmage + deaths wrappers tam). Cog jest cienki — auth helper'y + delegate. Reuse `get_or_create_user_by_discord_id` z M7.

**Re-raise cap ValueError, recover "already active":** dwa flavors `ValueError` z `add_death_watch` mają różne semantyki UI:
- `already active` = user już dodał, friendly idempotent ack.
- `cap exceeded` = global system limit, surface jako błąd z wyjaśnieniem.

Cog catches `ValueError` od wrappera → renders `f"❌ {exc}"` ephemeral. **Verbatim service message** — service-layer string już wyjaśnia limit clearly. Zero traceback leak (CLAUDE.md §8 + test `test_add_command_surfaces_cap_exceeded_without_stack_trace` pilnuje).

**Two-layer guard order (DM → admin):** identycznie jak `/deaths threshold` (M7-D32). `ctx.author.guild_permissions` to `Member`-only atrybut; w DM `ctx.author` to `discord.User` → `AttributeError`. DM check short-circuit przed admin check.

**`/deathwatch channel` reuse `apps.deathwatch.services.set_deathwatch_channel_for_guild` bezpośrednio** (bez wrappera w `discord_bot/services.py`) — nie wymaga User context (tylko guild_id + channel_id).

## Test plan

- [x] 12/12 cog testów PASS (1s).
- [x] Pre-commit zielony.
- [ ] Manual smoke: `python manage.py run_discord_bot` w dev guild — wszystkie 4 komendy.

Next: **DW-8 GraphQL schema** (#194, ostatni interface) + **DW-9 closure** (#195).