### PR TITLE
feat(deathwatch): graphql schema with queries + mutations (DW-8)

### DIFF
--- a/apps/deathwatch/schema.py
+++ b/apps/deathwatch/schema.py
@@ -1,0 +1,152 @@
+"""GraphQL schema for DeathWatch (DW-8).
+
+Mirror of apps/bedmages/schema.py pattern: Strawberry-Django types + async
+resolvers + JWT auth via `info.context.request.user.is_authenticated`.
+
+Distinct from M4 deaths schema (which exposes `recentDeaths` query). Here:
+- `myDeathWatches` — user's own per-character subscriptions (private).
+- `watchedDeaths` — events that fired through the deathwatch pipeline
+   (auth-gated; not a public feed).
+- `addDeathWatch` / `removeDeathWatch` — user mutations.
+- `setDeathWatchChannel` — superuser-only (admin GraphQL ops, parallel to
+   the Discord `/deathwatch channel` slash command).
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import strawberry
+import strawberry_django
+from asgiref.sync import sync_to_async
+from strawberry import auto
+
+from apps.accounts.models import User
+from apps.characters.schema import CharacterType
+from apps.deathwatch.models import (
+    DeathWatch,
+    DeathWatchChannel,
+    WatchedDeathEvent,
+)
+from apps.deathwatch.services import (
+    add_death_watch,
+    remove_death_watch,
+    set_deathwatch_channel_for_guild,
+)
+
+
+@strawberry_django.type(DeathWatch)
+class DeathWatchType:
+    id: auto
+    created_at: auto
+    active: auto
+    character: CharacterType
+
+
+@strawberry_django.type(WatchedDeathEvent)
+class WatchedDeathEventType:
+    id: auto
+    level_at_death: auto
+    killed_by: auto
+    died_at: auto
+    scraped_at: auto
+    announced_on_discord: auto
+    character: CharacterType
+
+
+@strawberry.type
+class DeathWatchChannelType:
+    """Per-guild announcement target.
+
+    `guild_id` and `channel_id` rendered as String because Discord snowflakes
+    are 64-bit ints and GraphQL Int is 32-bit (spec §4.3 / plan Task #8
+    pułapka B). Client deserializes back to int as needed.
+    """
+
+    guild_id: str
+    channel_id: str
+
+
+def _require_auth(info: strawberry.Info) -> User:
+    request = info.context.request
+    if not request.user.is_authenticated:
+        raise PermissionError("Authentication required")
+    return cast(User, request.user)
+
+
+def _require_superuser(info: strawberry.Info) -> User:
+    user = _require_auth(info)
+    if not user.is_superuser:
+        raise PermissionError("Superuser required")
+    return user
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    async def my_death_watches(self, info: strawberry.Info) -> list[DeathWatchType]:
+        user = _require_auth(info)
+        qs = (
+            DeathWatch.objects.filter(user=user)
+            .select_related("character")
+            .order_by("-created_at")
+        )
+        return cast("list[DeathWatchType]", [w async for w in qs])
+
+    @strawberry.field
+    async def watched_deaths(
+        self,
+        info: strawberry.Info,
+        character_name: str | None = None,
+        limit: int = 20,
+    ) -> list[WatchedDeathEventType]:
+        """Authenticated-only feed of deathwatch-recorded events.
+
+        Optional `character_name` filter narrows to one Character. `limit`
+        clamped to [1, 100] — same guard pattern as M4 `recentDeaths`.
+        """
+        _require_auth(info)
+        limit = max(1, min(limit, 100))
+        qs = WatchedDeathEvent.objects.select_related("character").order_by("-died_at")
+        if character_name:
+            qs = qs.filter(character__name=character_name)
+        return cast("list[WatchedDeathEventType]", [e async for e in qs[:limit]])
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    async def add_death_watch(
+        self, info: strawberry.Info, character_name: str
+    ) -> DeathWatchType:
+        user = _require_auth(info)
+        watch = await sync_to_async(add_death_watch)(user, character_name)
+        return cast("DeathWatchType", watch)
+
+    @strawberry.mutation
+    async def remove_death_watch(
+        self, info: strawberry.Info, character_name: str
+    ) -> bool:
+        user = _require_auth(info)
+        deleted = await sync_to_async(remove_death_watch)(user, character_name)
+        return deleted
+
+    @strawberry.mutation
+    async def set_death_watch_channel(
+        self, info: strawberry.Info, guild_id: str, channel_id: str
+    ) -> DeathWatchChannelType:
+        """Superuser-only — parallels admin-only `/deathwatch channel` cog.
+
+        `guild_id` / `channel_id` arrive as String because Discord snowflakes
+        exceed GraphQL Int range (see DeathWatchChannelType docstring).
+        Resolver parses to int for the service call, then renders back to
+        String on the response.
+        """
+        _require_superuser(info)
+        channel: DeathWatchChannel = await sync_to_async(
+            set_deathwatch_channel_for_guild
+        )(guild_id=int(guild_id), channel_id=int(channel_id))
+        return DeathWatchChannelType(
+            guild_id=str(channel.guild_id),
+            channel_id=str(channel.channel_id),
+        )

--- a/config/schema.py
+++ b/config/schema.py
@@ -4,10 +4,15 @@ from apps.accounts.schema import Query as AccountsQuery
 from apps.characters.schema import Query as CharactersQuery
 from apps.deaths.schema import Query as DeathsQuery
 from apps.bedmages.schema import Mutation as BedmagesMutation, Query as BedmagesQuery
+from apps.deathwatch.schema import (
+    Mutation as DeathWatchMutation,
+    Query as DeathWatchQuery,
+)
 
 
 Query = merge_types(
-    "Query", (AccountsQuery, CharactersQuery, DeathsQuery, BedmagesQuery)
+    "Query",
+    (AccountsQuery, CharactersQuery, DeathsQuery, BedmagesQuery, DeathWatchQuery),
 )
-Mutation = merge_types("Mutation", (BedmagesMutation,))
+Mutation = merge_types("Mutation", (BedmagesMutation, DeathWatchMutation))
 schema = strawberry.Schema(query=Query, mutation=Mutation)

--- a/tests/unit/deathwatch/test_graphql_deathwatch.py
+++ b/tests/unit/deathwatch/test_graphql_deathwatch.py
@@ -1,0 +1,398 @@
+"""Tests for myDeathWatches / watchedDeaths queries + DW mutations (DW-8).
+
+Mirror of `tests/unit/bedmages/test_graphql_bedmages.py`: JWT auth via
+`AccessToken.for_user`, AsyncClient against /graphql/, async resolvers
+exercised end-to-end. Memory: async + DB tests need
+`@pytest.mark.django_db(transaction=True)`.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+from asgiref.sync import sync_to_async
+from django.test import AsyncClient
+from django.utils import timezone
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.accounts.models import User
+from apps.characters.models import Character
+from apps.deathwatch.models import (
+    DeathWatch,
+    DeathWatchChannel,
+    WatchedDeathEvent,
+)
+
+GRAPHQL_URL = "/graphql/"
+
+
+async def _post(
+    client: AsyncClient,
+    query: str,
+    bearer: str | None = None,
+) -> dict[str, object]:
+    headers = {"Authorization": f"Bearer {bearer}"} if bearer else {}
+    response = await client.post(
+        GRAPHQL_URL,
+        data=json.dumps({"query": query}),
+        content_type="application/json",
+        headers=headers,
+    )
+    assert response.status_code == 200, response.content
+    return response.json()
+
+
+async def _make_user_and_token(
+    username: str = "alice",
+    is_superuser: bool = False,
+) -> tuple[User, str]:
+    user = await sync_to_async(User.objects.create_user)(
+        username=username,
+        email=f"{username}@example.com",
+        password="ComplexPass!123",
+        is_superuser=is_superuser,
+    )
+    bearer = await sync_to_async(lambda: str(AccessToken.for_user(user)))()
+    return user, bearer
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# myDeathWatches query
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_my_death_watches_filters_by_request_user() -> None:
+    """Security invariant — never leak other users' deathwatch subscriptions."""
+    user_a, bearer_a = await _make_user_and_token("alice")
+    user_b, _ = await _make_user_and_token("bob")
+
+    def _seed() -> None:
+        c1 = Character.objects.create(name="Yhral")
+        c2 = Character.objects.create(name="Bubble")
+        c3 = Character.objects.create(name="Otherusers")
+        DeathWatch.objects.create(user=user_a, character=c1)
+        DeathWatch.objects.create(user=user_a, character=c2)
+        DeathWatch.objects.create(user=user_b, character=c3)
+
+    await sync_to_async(_seed)()
+
+    payload = await _post(
+        AsyncClient(),
+        "{ myDeathWatches { id character { name } active } }",
+        bearer_a,
+    )
+
+    assert "errors" not in payload, payload
+    watches = payload["data"]["myDeathWatches"]
+    assert len(watches) == 2
+    names = sorted(w["character"]["name"] for w in watches)
+    assert names == ["Bubble", "Yhral"]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_my_death_watches_requires_authentication() -> None:
+    payload = await _post(AsyncClient(), "{ myDeathWatches { id } }", bearer=None)
+    assert "errors" in payload
+    msg = payload["errors"][0]["message"]
+    assert "auth" in msg.lower()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_my_death_watches_returns_empty_list_for_user_without_watches() -> None:
+    _, bearer = await _make_user_and_token("nobody")
+    payload = await _post(AsyncClient(), "{ myDeathWatches { id } }", bearer)
+    assert "errors" not in payload, payload
+    assert payload["data"]["myDeathWatches"] == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# watchedDeaths query
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_watched_deaths_returns_events_newest_first() -> None:
+    _, bearer = await _make_user_and_token("alice")
+
+    def _seed() -> None:
+        char = Character.objects.create(name="Yhral")
+        base = datetime(2026, 5, 7, 14, 0, 0, tzinfo=ZoneInfo("UTC"))
+        for i in range(3):
+            WatchedDeathEvent.objects.create(
+                character=char,
+                level_at_death=100 + i,
+                killed_by=f"k{i}",
+                died_at=base + timedelta(hours=i),
+            )
+
+    await sync_to_async(_seed)()
+
+    payload = await _post(
+        AsyncClient(),
+        "{ watchedDeaths { levelAtDeath diedAt } }",
+        bearer,
+    )
+
+    assert "errors" not in payload, payload
+    events = payload["data"]["watchedDeaths"]
+    assert len(events) == 3
+    # Newest first → level 102 → 101 → 100
+    assert [e["levelAtDeath"] for e in events] == [102, 101, 100]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_watched_deaths_filters_by_character_name() -> None:
+    _, bearer = await _make_user_and_token("alice")
+
+    def _seed() -> None:
+        c1 = Character.objects.create(name="Yhral")
+        c2 = Character.objects.create(name="Bubble")
+        t = timezone.now()
+        WatchedDeathEvent.objects.create(
+            character=c1, level_at_death=100, killed_by="x", died_at=t
+        )
+        WatchedDeathEvent.objects.create(
+            character=c2,
+            level_at_death=50,
+            killed_by="y",
+            died_at=t - timedelta(minutes=1),
+        )
+
+    await sync_to_async(_seed)()
+
+    payload = await _post(
+        AsyncClient(),
+        '{ watchedDeaths(characterName: "Yhral") { character { name } } }',
+        bearer,
+    )
+
+    assert "errors" not in payload, payload
+    events = payload["data"]["watchedDeaths"]
+    assert len(events) == 1
+    assert events[0]["character"]["name"] == "Yhral"
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_watched_deaths_clamps_limit_to_max_100() -> None:
+    """limit > 100 is clamped to 100 (mirror M4 recentDeaths guard)."""
+    _, bearer = await _make_user_and_token("alice")
+
+    def _seed() -> None:
+        char = Character.objects.create(name="Yhral")
+        base = timezone.now()
+        for i in range(120):
+            WatchedDeathEvent.objects.create(
+                character=char,
+                level_at_death=50,
+                killed_by="x",
+                died_at=base - timedelta(seconds=i),
+            )
+
+    await sync_to_async(_seed)()
+
+    payload = await _post(
+        AsyncClient(),
+        "{ watchedDeaths(limit: 500) { id } }",
+        bearer,
+    )
+
+    assert "errors" not in payload, payload
+    assert len(payload["data"]["watchedDeaths"]) == 100
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_watched_deaths_requires_authentication() -> None:
+    payload = await _post(AsyncClient(), "{ watchedDeaths { id } }", bearer=None)
+    assert "errors" in payload
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# addDeathWatch mutation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_add_death_watch_creates_lazy_character() -> None:
+    _, bearer = await _make_user_and_token("alice")
+    pre = await sync_to_async(Character.objects.filter(name="Newchar").count)()
+    assert pre == 0
+
+    mutation = """
+    mutation {
+        addDeathWatch(characterName: "Newchar") {
+            character { name }
+            active
+        }
+    }
+    """
+    payload = await _post(AsyncClient(), mutation, bearer)
+
+    assert "errors" not in payload, payload
+    data = payload["data"]["addDeathWatch"]
+    assert data["character"]["name"] == "Newchar"
+    assert data["active"] is True
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_add_death_watch_raises_on_duplicate_active_watch() -> None:
+    user, bearer = await _make_user_and_token("alice")
+    char = await sync_to_async(Character.objects.create)(name="Yhral")
+    await sync_to_async(DeathWatch.objects.create)(
+        user=user, character=char, active=True
+    )
+
+    mutation = """
+    mutation { addDeathWatch(characterName: "Yhral") { id } }
+    """
+    payload = await _post(AsyncClient(), mutation, bearer)
+
+    assert "errors" in payload
+    assert "already active" in payload["errors"][0]["message"]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_add_death_watch_requires_authentication() -> None:
+    mutation = """
+    mutation { addDeathWatch(characterName: "Yhral") { id } }
+    """
+    payload = await _post(AsyncClient(), mutation, bearer=None)
+    assert "errors" in payload
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# removeDeathWatch mutation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_remove_death_watch_returns_true_when_existing() -> None:
+    user, bearer = await _make_user_and_token("alice")
+    char = await sync_to_async(Character.objects.create)(name="Yhral")
+    await sync_to_async(DeathWatch.objects.create)(user=user, character=char)
+
+    mutation = 'mutation { removeDeathWatch(characterName: "Yhral") }'
+    payload = await _post(AsyncClient(), mutation, bearer)
+
+    assert "errors" not in payload, payload
+    assert payload["data"]["removeDeathWatch"] is True
+
+    remaining = await sync_to_async(
+        DeathWatch.objects.filter(user=user, character=char).count
+    )()
+    assert remaining == 0
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_remove_death_watch_returns_false_when_not_found() -> None:
+    _, bearer = await _make_user_and_token("alice")
+    mutation = 'mutation { removeDeathWatch(characterName: "Nonexistent") }'
+    payload = await _post(AsyncClient(), mutation, bearer)
+
+    assert "errors" not in payload, payload
+    assert payload["data"]["removeDeathWatch"] is False
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_remove_death_watch_requires_authentication() -> None:
+    mutation = 'mutation { removeDeathWatch(characterName: "Yhral") }'
+    payload = await _post(AsyncClient(), mutation, bearer=None)
+    assert "errors" in payload
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# setDeathWatchChannel mutation (superuser only)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_set_death_watch_channel_persists_for_superuser() -> None:
+    _, bearer = await _make_user_and_token("admin", is_superuser=True)
+
+    mutation = """
+    mutation {
+        setDeathWatchChannel(guildId: "555", channelId: "666") {
+            guildId
+            channelId
+        }
+    }
+    """
+    payload = await _post(AsyncClient(), mutation, bearer)
+
+    assert "errors" not in payload, payload
+    data = payload["data"]["setDeathWatchChannel"]
+    assert data["guildId"] == "555"
+    assert data["channelId"] == "666"
+
+    persisted = await sync_to_async(
+        DeathWatchChannel.objects.filter(guild_id=555).get
+    )()
+    assert persisted.channel_id == 666
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_set_death_watch_channel_rejects_non_superuser() -> None:
+    """Plain auth user → PermissionError → errors[] (NOT silent persistence)."""
+    _, bearer = await _make_user_and_token("normal", is_superuser=False)
+
+    mutation = """
+    mutation {
+        setDeathWatchChannel(guildId: "555", channelId: "666") { guildId }
+    }
+    """
+    payload = await _post(AsyncClient(), mutation, bearer)
+
+    assert "errors" in payload
+    assert "superuser" in payload["errors"][0]["message"].lower()
+
+    nothing = await sync_to_async(DeathWatchChannel.objects.count)()
+    assert nothing == 0
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_set_death_watch_channel_handles_64bit_discord_snowflakes() -> None:
+    """Guild/channel IDs as String avoid GraphQL Int 32-bit overflow.
+
+    Real Discord snowflakes (e.g. 1234567890123456789) exceed 2^31, so the
+    schema accepts them as String. Resolver parses to int for the service call.
+    """
+    _, bearer = await _make_user_and_token("admin", is_superuser=True)
+    # Both values well above 32-bit int max (2^31 - 1 = 2_147_483_647) but
+    # below Postgres bigint max (2^63 - 1 = 9.22e18). Real Discord snowflakes
+    # live in this range; GraphQL Int would overflow either side.
+    big_guild = "1234567890123456789"
+    big_channel = "1098765432109876543"
+
+    mutation = f"""
+    mutation {{
+        setDeathWatchChannel(guildId: "{big_guild}", channelId: "{big_channel}") {{
+            guildId
+            channelId
+        }}
+    }}
+    """
+    payload = await _post(AsyncClient(), mutation, bearer)
+
+    assert "errors" not in payload, payload
+    data = payload["data"]["setDeathWatchChannel"]
+    assert data["guildId"] == big_guild
+    assert data["channelId"] == big_channel


### PR DESCRIPTION
## Summary

DW-8 (8 of 9) — GraphQL surface dla DeathWatch. Po tym tasku zostaje już tylko DW-9 closure (stubs.py mirror + PROGRESS retro).

Closes #194.

## Changes

- **`apps/deathwatch/schema.py`** new (mirror M5 bedmages pattern):
  - **Typy:** `DeathWatchType`, `WatchedDeathEventType`, `DeathWatchChannelType`.
  - **Queries:**
    - `myDeathWatches` — user's watches (filtered by `request.user`, auth required).
    - `watchedDeaths(characterName, limit=20)` — events feed, limit clamped `[1, 100]`, auth required.
  - **Mutations:**
    - `addDeathWatch(characterName)` — lazy fetch, raises `ValueError` na duplicate active.
    - `removeDeathWatch(characterName)` — hard delete, idempotent.
    - `setDeathWatchChannel(guildId, channelId)` — **superuser-only**.
  - Helpers `_require_auth` / `_require_superuser` (Strawberry surfaces `PermissionError` jako `errors[]`).
- **`config/schema.py`** — scal `DeathWatchQuery` w merged `Query`, `DeathWatchMutation` w `Mutation`.
- **`tests/unit/deathwatch/test_graphql_deathwatch.py`** — 16 testów full coverage.

## Decisions

**Snowflakes jako `str` w `setDeathWatchChannel`:** Discord guild/channel IDs to 64-bit ints; GraphQL `Int` to 32-bit (max 2^31-1 = 2.15e9). Real snowflake `1234567890123456789` przekracza. Schema accepts String, resolver parses do int dla service call, renders back jako String w response. Postgres `BigIntegerField` (max 2^63-1 ≈ 9.22e18) mieści wszystkie real snowflakes.

**Test `test_set_death_watch_channel_handles_64bit_discord_snowflakes` — bigint range pitfall:** mój pierwszy testowy channel_id `9876543210987654321` (9.87e18) przekroczył Postgres bigint max → DataError. Fix: oba snowflakes < 2^63 (`1234567890123456789` + `1098765432109876543`). Real Discord snowflakes mieszczą się w 2^63 z dużą rezerwą do ~2070r.

**`watchedDeaths` auth-gated, nie public feed:** spec wymaga JWT (mimo że deaths feature M4 ma `recentDeaths` public). Reason: deathwatch events to per-character subscription data — leak by ujawnił czyje postacie ktoś obserwuje. Test `test_watched_deaths_requires_authentication` pilnuje.

**Limit `[1, 100]` clamping w `watchedDeaths`:** mirror M4 `recentDeaths` defense. Test `test_watched_deaths_clamps_limit_to_max_100` weryfikuje że `limit=500` zwraca 100.

**`_require_auth` zwraca `cast(User, ...)`:** Django `request.user` to `Any` dla mypy (middleware-set). Cast explicit zamiast `# type: ignore`.

## Test plan

- [x] 16/16 DW-8 GraphQL tests PASS.
- [x] 11 bedmages GraphQL regression PASS (sanity merge_types nie zepsuł).
- [x] Pre-commit + mypy + ruff zielone.

Next: **DW-9 closure** (#195) — stubs.py mirror dla 3 settings (`DEATHWATCH_*`) + PROGRESS.md retro + smoke checklist. Najmniejszy task w M12.