### PR TITLE
feat(deathwatch): public /list visibility (M12 follow-up)

### DIFF
--- a/apps/deathwatch/schema.py
+++ b/apps/deathwatch/schema.py
@@ -42,6 +42,23 @@ class DeathWatchType:
     active: auto
     character: CharacterType
 
+    @strawberry.field
+    def added_by_discord_id(self) -> str:
+        """Discord ID of the user who added this watch (spec §3.2 / §4.4).
+
+        Returns User.discord_id raw — frontend renders as wants (Discord
+        `<@id>` mention in bot output, plain string elsewhere). Empty
+        string if user has no linked Discord (manual Django admin user).
+
+        `self.user` is a Django FK that Strawberry-Django doesn't expose in
+        the generated type signature (we didn't list `user: auto` because we
+        don't want to leak User to GraphQL), so mypy can't see it — runtime
+        is fine because Strawberry-Django wraps the underlying DeathWatch
+        model. Resolver runs in async context, so we pre-loaded `user` via
+        `select_related("user", "character")` in the resolver QuerySet.
+        """
+        return self.user.discord_id or ""  # type: ignore[attr-defined]
+
 
 @strawberry_django.type(WatchedDeathEvent)
 class WatchedDeathEventType:
@@ -84,11 +101,17 @@ def _require_superuser(info: strawberry.Info) -> User:
 @strawberry.type
 class Query:
     @strawberry.field
-    async def my_death_watches(self, info: strawberry.Info) -> list[DeathWatchType]:
-        user = _require_auth(info)
+    async def deathwatches(self, info: strawberry.Info) -> list[DeathWatchType]:
+        """All active deathwatches across all users (M12 follow-up).
+
+        Public list — every authenticated client sees every watch + added_by_discord_id.
+        Spec §3.4 — semantic break from M12 `myDeathWatches` (per-user filter).
+        Project has no external GraphQL consumers, so breaking rename OK.
+        """
+        _require_auth(info)
         qs = (
-            DeathWatch.objects.filter(user=user)
-            .select_related("character")
+            DeathWatch.objects.filter(active=True)
+            .select_related("user", "character")
             .order_by("-created_at")
         )
         return cast("list[DeathWatchType]", [w async for w in qs])

--- a/apps/deathwatch/services.py
+++ b/apps/deathwatch/services.py
@@ -84,14 +84,18 @@ def remove_death_watch(user: User, character_name: str) -> bool:
     return deleted > 0
 
 
-def list_death_watches(user: User) -> QuerySet[DeathWatch]:
-    """List user's watches, newest first, with Character preloaded.
+def list_all_death_watches() -> QuerySet[DeathWatch]:
+    """List all active DeathWatches across all users, newest first.
 
-    `select_related` to avoid N+1 when Discord cog / GraphQL renders names.
+    Public list visibility (M12 follow-up, spec §3.1) — drop per-user filter.
+    `select_related("user", "character")` pre-loads both FK objects so callers
+    can render `watch.user.discord_id` + `watch.character.name` without N+1
+    (Discord cog iterates the QuerySet to build a ~20-entry response, capped
+    by DEATHWATCH_MAX_WATCHED_CHARACTERS).
     """
     return (
-        DeathWatch.objects.filter(user=user)
-        .select_related("character")
+        DeathWatch.objects.filter(active=True)
+        .select_related("user", "character")
         .order_by("-created_at")
     )
 

--- a/discord_bot/cogs/deathwatch.py
+++ b/discord_bot/cogs/deathwatch.py
@@ -5,10 +5,12 @@ from asgiref.sync import sync_to_async
 import discord
 from discord.ext import commands
 
+from django.conf import settings
+
 from apps.deathwatch.services import set_deathwatch_channel_for_guild
 from discord_bot.services import (
     add_deathwatch_for_discord_user,
-    list_deathwatches_for_discord_user,
+    list_all_deathwatches,
     remove_deathwatch_for_discord_user,
 )
 
@@ -71,17 +73,39 @@ class DeathWatchCog(commands.Cog):
         )
         await ctx.respond(msg, ephemeral=True)
 
-    @deathwatch.command(name="list", description="Show your deathwatch list")
+    @deathwatch.command(name="list", description="Show all active deathwatches")
     async def list(self, ctx: discord.ApplicationContext) -> None:
-        watches = await sync_to_async(list_deathwatches_for_discord_user)(ctx.author.id)
+        """Public list visibility (M12 follow-up).
+
+        Shows EVERY active watch across all users, with `<@discord_id>`
+        mention syntax — Discord renders as "@alice" natively but we pass
+        `AllowedMentions.none()` so listing 20 watches doesn't ping 20 users.
+        Ephemeral response (only caller sees) — explicit user choice in spec §3.6.
+        """
+        watches = await sync_to_async(list_all_deathwatches)()
         if not watches:
             await ctx.respond(
-                "Your deathwatch list is empty. " "Add with `/deathwatch add <name>`.",
+                "No active deathwatches. Add one with `/deathwatch add <name>`.",
                 ephemeral=True,
             )
             return
-        names = ", ".join(f"`{w.character.name}`" for w in watches)
-        await ctx.respond(f"Your deathwatches: {names}", ephemeral=True)
+
+        cap = settings.DEATHWATCH_MAX_WATCHED_CHARACTERS
+        # Unique characters across all watches — matches cap semantics (a
+        # character watched by 2 users counts as 1 toward the global cap).
+        unique_count = len({w.character.name for w in watches})
+
+        lines = [
+            f"• `{w.character.name}` (added by <@{w.user.discord_id or 'unknown'}>)"
+            for w in watches
+        ]
+        body = f"Active deathwatches ({unique_count}/{cap}):\n" + "\n".join(lines)
+
+        await ctx.respond(
+            body,
+            ephemeral=True,
+            allowed_mentions=discord.AllowedMentions.none(),
+        )
 
     @deathwatch.command(
         name="channel",

--- a/discord_bot/services.py
+++ b/discord_bot/services.py
@@ -13,7 +13,7 @@ from apps.characters.models import _canonicalize_name
 from apps.deathwatch.models import DeathWatch
 from apps.deathwatch.services import (
     add_death_watch,
-    list_death_watches,
+    list_all_death_watches,
     remove_death_watch,
 )
 
@@ -159,10 +159,11 @@ def remove_deathwatch_for_discord_user(discord_id: int, character_name: str) -> 
     return remove_death_watch(user, character_name)
 
 
-def list_deathwatches_for_discord_user(discord_id: int) -> list[DeathWatch]:
-    """Active deathwatches for user. Empty list when user unknown (no auto-create on read)."""
-    try:
-        user = User.objects.get(discord_id=discord_id)
-    except User.DoesNotExist:
-        return []
-    return list(list_death_watches(user).filter(active=True))
+def list_all_deathwatches() -> list[DeathWatch]:
+    """All active deathwatches across all users (M12 follow-up, public list).
+
+    Wrapper over `apps.deathwatch.services.list_all_death_watches` — returns
+    concrete list (cog awaits via `sync_to_async`, py-cord doesn't consume
+    QuerySets across the sync/async boundary).
+    """
+    return list(list_all_death_watches())

--- a/docs/superpowers/plans/2026-05-17-public-deathwatch-list-implementation-plan.md
+++ b/docs/superpowers/plans/2026-05-17-public-deathwatch-list-implementation-plan.md
@@ -1,0 +1,720 @@
+# Public DeathWatch list — Implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/deathwatch list` (Discord) i GraphQL `deathwatches` zwracają wszystkie aktywne watches w systemie (nie per-user) — share visibility z preserved ephemeral Discord response.
+
+**Architecture:** Refactor `list_*_death_watches` services do drop user param (return all active + `select_related("user", "character")`). Discord cog renders `<@discord_id>` mentions z `allowed_mentions=AllowedMentions.none()` (no ping spam). GraphQL query rename `myDeathWatches` → `deathwatches` + `addedByDiscordId` resolved field. Cap globalny już istnieje od M12 (spec §3.2), bez zmian.
+
+**Tech Stack:** Django 6.0, Strawberry-Django, py-cord, pytest.
+
+**Data:** 2026-05-17
+**Spec:** [`docs/superpowers/specs/2026-05-17-public-deathwatch-list-design.md`](../specs/2026-05-17-public-deathwatch-list-design.md)
+**Status:** READY (spec accepted 2026-05-17, all 7 decisions §3 approved).
+
+---
+
+## Pre-flight checklist
+
+- [ ] **M12 merged** — patrz #186, #196-#205 (wszystkie zmergowane na master 2026-05-17).
+- [ ] **Branch** `feat/deathwatch-public-list` z spec commit `6971415` — already created, build on top.
+- [ ] **`User.discord_id`** field istnieje od M2-D9 — `CharField(max_length=64, blank=True, default="")`. Cog rendering polega na tym field.
+- [ ] **`DEATHWATCH_MAX_WATCHED_CHARACTERS`** w settings — istnieje od DW-2 (`config/settings/base.py`), value `20`.
+- [ ] **`discord.AllowedMentions.none()`** — py-cord API method, no extra deps.
+
+---
+
+## Task overview
+
+| # | Tytuł | Czas |
+|---|---|---|
+| 1 | Service layer rename (`list_death_watches` → `list_all_death_watches`) + tests | 30 min |
+| 2 | Bot wrapper rename + Discord cog rewrite + tests | 1h |
+| 3 | GraphQL rename + `addedByDiscordId` field + tests | 30 min |
+| 4 | Final pre-commit + PR | 15 min |
+
+**Total:** ~2h. Single PR (`feat/deathwatch-public-list`), wszystkie tasks na tym samym branchu.
+
+---
+
+## Task 1 — Service layer rename + tests
+
+**Files:**
+- Modify: `apps/deathwatch/services.py` — drop `list_death_watches(user)`, add `list_all_death_watches()`.
+- Modify: `tests/unit/deathwatch/test_services.py` — drop `test_list_death_watches_filters_by_user_and_orders_newest_first`, add 2 new tests.
+
+### TDD steps
+
+- [ ] **Step 1: Drop old test, write new failing tests**
+
+Otwórz `tests/unit/deathwatch/test_services.py`. **Usuń** funkcję `test_list_death_watches_filters_by_user_and_orders_newest_first` (anti-feature now). Zmień import line:
+
+```python
+from apps.deathwatch.services import (
+    add_death_watch,
+    list_all_death_watches,  # was: list_death_watches
+    record_watched_death,
+    remove_death_watch,
+    set_deathwatch_channel_for_guild,
+)
+```
+
+Dopisz w sekcji `# list_death_watches` (rename komentarz na `# list_all_death_watches`):
+
+```python
+@pytest.mark.django_db
+def test_list_all_death_watches_returns_all_users_newest_first() -> None:
+    """Public list: every active watch, ordered by created_at desc."""
+    alice = User.objects.create(username="alice", discord_id="1")
+    bob = User.objects.create(username="bob", discord_id="2")
+    add_death_watch(alice, "Yhral")
+    add_death_watch(bob, "Bubble")
+    add_death_watch(alice, "Eternal Oblivion")
+
+    watches = list(list_all_death_watches())
+
+    assert len(watches) == 3
+    names = [w.character.name for w in watches]
+    # Newest first
+    assert names[0] == "Eternal oblivion"
+    assert set(names) == {"Yhral", "Bubble", "Eternal oblivion"}
+
+
+@pytest.mark.django_db
+def test_list_all_death_watches_excludes_inactive() -> None:
+    """Soft-deactivated watches are excluded — consistent with cap counter."""
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+    inactive_watch = add_death_watch(user, "Bubble")
+    inactive_watch.active = False
+    inactive_watch.save(update_fields=["active"])
+
+    watches = list(list_all_death_watches())
+
+    assert len(watches) == 1
+    assert watches[0].character.name == "Yhral"
+```
+
+- [ ] **Step 2: Run tests — expected FAIL (ImportError)**
+
+```bash
+poetry run pytest tests/unit/deathwatch/test_services.py -v -k "list_all_death_watches"
+```
+
+Expected: `ImportError: cannot import name 'list_all_death_watches'`.
+
+- [ ] **Step 3: Implement service rename**
+
+W `apps/deathwatch/services.py`, znajdź `def list_death_watches(user: User) -> QuerySet[DeathWatch]:` i **zastąp** całą funkcję:
+
+```python
+def list_all_death_watches() -> QuerySet[DeathWatch]:
+    """List all active DeathWatches across all users, newest first.
+
+    `select_related("user", "character")` pre-loads both FK objects so
+    callers can render `watch.user.discord_id` + `watch.character.name`
+    without N+1 — Discord cog iterates the QuerySet to build a multi-line
+    response (~20 entries max, capped by DEATHWATCH_MAX_WATCHED_CHARACTERS).
+
+    Spec §3.1 — public list visibility change (M12 follow-up).
+    """
+    return (
+        DeathWatch.objects.filter(active=True)
+        .select_related("user", "character")
+        .order_by("-created_at")
+    )
+```
+
+- [ ] **Step 4: Run tests — expected PASS**
+
+```bash
+poetry run pytest tests/unit/deathwatch/test_services.py -v
+```
+
+Expected: wszystkie testy PASS (z włączeniem 2 nowych + reszty z M12).
+
+- [ ] **Step 5: Verify nothing else imports old name**
+
+```bash
+poetry run python -c "from apps.deathwatch.services import list_death_watches" 2>&1
+```
+
+Expected: `ImportError: cannot import name 'list_death_watches'`. Jeśli nie — usuń lingering re-export.
+
+```bash
+grep -rn "list_death_watches" --include="*.py" | grep -v "list_all_death_watches"
+```
+
+Expected: zero hits (poza tym planem/spec docs). Jeśli są — to T2/T3 callery (sprawdź, naprawimy w następnym tasku).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/deathwatch/services.py tests/unit/deathwatch/test_services.py
+git commit -m "refactor(deathwatch): rename list_death_watches to list_all_death_watches"
+```
+
+---
+
+## Task 2 — Bot wrapper + Discord cog rewrite + tests
+
+**Files:**
+- Modify: `discord_bot/services.py` — `list_deathwatches_for_discord_user(discord_id)` → `list_all_deathwatches()`.
+- Modify: `discord_bot/cogs/deathwatch.py` — `/list` rewrite: all watches, mentions, count/cap.
+- Modify: `tests/unit/discord_bot/test_deathwatch_cog.py` — update + add 3 tests.
+
+### TDD steps
+
+- [ ] **Step 1: Update bot wrapper service**
+
+W `discord_bot/services.py`, znajdź `def list_deathwatches_for_discord_user(discord_id: int) -> list[DeathWatch]:` i **zastąp** całą funkcję + zmień import:
+
+```python
+from apps.deathwatch.services import (
+    add_death_watch,
+    list_all_death_watches,  # was: list_death_watches
+    remove_death_watch,
+)
+```
+
+```python
+def list_all_deathwatches() -> list[DeathWatch]:
+    """All active deathwatches across all users (M12 follow-up, public list).
+
+    Wrapper over `apps.deathwatch.services.list_all_death_watches` —
+    returns concrete list (cog awaits via `sync_to_async`, py-cord doesn't
+    consume QuerySets across sync/async boundary).
+    """
+    return list(list_all_death_watches())
+```
+
+- [ ] **Step 2: Write failing cog tests**
+
+W `tests/unit/discord_bot/test_deathwatch_cog.py`, **zastąp** test `test_list_command_renders_character_names` całością + dopisz 3 nowe testy. Zmień import top-of-file:
+
+```python
+import discord  # already imported, just confirm
+```
+
+**Usuń** `test_list_command_empty_state` body (zmieniamy semantykę message) — przepisuj:
+
+```python
+@pytest.mark.asyncio
+async def test_list_command_empty_state_when_no_watches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No watches anywhere in the system → hint to add."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.respond = AsyncMock()
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.list_all_deathwatches",
+        MagicMock(return_value=[]),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    args, kwargs = mock_ctx.respond.call_args
+    assert "No active deathwatches" in args[0]
+    assert "/deathwatch add" in args[0]
+    assert kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_command_renders_all_users_watches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Public list visibility — every user's watches included (M12 follow-up)."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.respond = AsyncMock()
+
+    w1 = MagicMock()
+    w1.character.name = "Yhral"
+    w1.user.discord_id = "111"
+    w2 = MagicMock()
+    w2.character.name = "Bubble"
+    w2.user.discord_id = "222"
+    w3 = MagicMock()
+    w3.character.name = "Eternal oblivion"
+    w3.user.discord_id = "111"  # alice again
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.list_all_deathwatches",
+        MagicMock(return_value=[w1, w2, w3]),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    args, kwargs = mock_ctx.respond.call_args
+    text = args[0]
+    # All three character names present
+    assert "Yhral" in text
+    assert "Bubble" in text
+    assert "Eternal oblivion" in text
+    assert kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_command_shows_added_by_discord_mention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each entry includes `<@discord_id>` mention syntax (spec §3.2)."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.respond = AsyncMock()
+
+    w = MagicMock()
+    w.character.name = "Yhral"
+    w.user.discord_id = "99999"
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.list_all_deathwatches",
+        MagicMock(return_value=[w]),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    args, _ = mock_ctx.respond.call_args
+    assert "<@99999>" in args[0]
+
+
+@pytest.mark.asyncio
+async def test_list_command_uses_allowed_mentions_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """20 mentions w outputie nie mogą pingować users (spec §3.3)."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.respond = AsyncMock()
+
+    w = MagicMock()
+    w.character.name = "Yhral"
+    w.user.discord_id = "1"
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.list_all_deathwatches",
+        MagicMock(return_value=[w]),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    _, kwargs = mock_ctx.respond.call_args
+    am = kwargs["allowed_mentions"]
+    # AllowedMentions.none() = no everyone/users/roles pings
+    assert am.everyone is False
+    assert am.users is False
+    assert am.roles is False
+
+
+@pytest.mark.asyncio
+async def test_list_command_shows_count_over_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cap indicator `(N/20)` w outputie (spec §3.5)."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.respond = AsyncMock()
+
+    # 3 watches in the system
+    watches = []
+    for i in range(3):
+        w = MagicMock()
+        w.character.name = f"Char{i}"
+        w.user.discord_id = str(i)
+        watches.append(w)
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.list_all_deathwatches",
+        MagicMock(return_value=watches),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    args, _ = mock_ctx.respond.call_args
+    # "(3/20)" or "3/20" — accept either format
+    assert "3/20" in args[0]
+```
+
+Plus **usuń** stary test `test_list_command_renders_character_names` (zastąpiony przez `test_list_command_renders_all_users_watches`) i stary `test_list_command_empty_state` (zastąpiony przez `test_list_command_empty_state_when_no_watches`).
+
+- [ ] **Step 3: Run cog tests — expected FAIL**
+
+```bash
+poetry run pytest tests/unit/discord_bot/test_deathwatch_cog.py -v
+```
+
+Expected: 5 new list-related testów FAIL (import error / `list_all_deathwatches` nie istnieje na cog level, plus old `list` semantyka nie matchuje new tests).
+
+- [ ] **Step 4: Update cog `/list`**
+
+W `discord_bot/cogs/deathwatch.py`, zmień import section:
+
+```python
+from apps.deathwatch.services import set_deathwatch_channel_for_guild
+from discord_bot.services import (
+    add_deathwatch_for_discord_user,
+    list_all_deathwatches,  # was: list_deathwatches_for_discord_user
+    remove_deathwatch_for_discord_user,
+)
+```
+
+I **zastąp** całą metodę `list` (`/deathwatch list`):
+
+```python
+    @deathwatch.command(name="list", description="Show all active deathwatches")
+    async def list(self, ctx: discord.ApplicationContext) -> None:
+        """Public list visibility (M12 follow-up).
+
+        Shows EVERY active watch across all users, with `<@discord_id>`
+        mention syntax — Discord renders as "@alice" natively but we pass
+        `AllowedMentions.none()` so listing 20 watches doesn't ping 20 users.
+        Ephemeral response (only caller sees) — explicit user choice in spec.
+        """
+        import discord
+        from django.conf import settings
+
+        watches = await sync_to_async(list_all_deathwatches)()
+        if not watches:
+            await ctx.respond(
+                "No active deathwatches. "
+                "Add one with `/deathwatch add <name>`.",
+                ephemeral=True,
+            )
+            return
+
+        cap = settings.DEATHWATCH_MAX_WATCHED_CHARACTERS
+        # Unique characters across all watches — matches cap semantics.
+        unique_count = len({w.character.name for w in watches})
+
+        lines = [
+            f"• `{w.character.name}` (added by <@{w.user.discord_id or 'unknown'}>)"
+            for w in watches
+        ]
+        body = (
+            f"Active deathwatches ({unique_count}/{cap}):\n"
+            + "\n".join(lines)
+        )
+
+        await ctx.respond(
+            body,
+            ephemeral=True,
+            allowed_mentions=discord.AllowedMentions.none(),
+        )
+```
+
+- [ ] **Step 5: Run cog tests — expected PASS**
+
+```bash
+poetry run pytest tests/unit/discord_bot/test_deathwatch_cog.py -v
+```
+
+Expected: wszystkie 14 testów PASS (was 12, +5 nowych -3 starych = 14).
+
+- [ ] **Step 6: Update test_deathwatch_cog.py top-level `list_deathwatches_for_discord_user` references**
+
+```bash
+grep -n "list_deathwatches_for_discord_user" tests/unit/discord_bot/test_deathwatch_cog.py
+```
+
+Expected: zero hits (po Step 2 update). Jeśli są lingering — usuń (były tylko w usuniętych test bodies).
+
+- [ ] **Step 7: Verify no orphaned references**
+
+```bash
+grep -rn "list_deathwatches_for_discord_user" --include="*.py"
+```
+
+Expected: zero hits.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add discord_bot/services.py discord_bot/cogs/deathwatch.py tests/unit/discord_bot/test_deathwatch_cog.py
+git commit -m "feat(deathwatch): public /list with all watches + mentions + cap indicator"
+```
+
+---
+
+## Task 3 — GraphQL rename + `addedByDiscordId` field + tests
+
+**Files:**
+- Modify: `apps/deathwatch/schema.py` — rename query, add resolved field.
+- Modify: `tests/unit/deathwatch/test_graphql_deathwatch.py` — rename + drop 1 test + add 2 tests.
+
+### TDD steps
+
+- [ ] **Step 1: Write failing GraphQL tests**
+
+W `tests/unit/deathwatch/test_graphql_deathwatch.py`, **rename** wszystkie `test_my_death_watches_*` na `test_deathwatches_*` (find/replace). **Usuń** `test_my_death_watches_filters_by_request_user` całkowicie (anti-feature). Update query strings z `myDeathWatches` na `deathwatches`.
+
+Po rename, ten test już istnieje (dawniej `test_my_death_watches_requires_authentication`) — zostaw jako `test_deathwatches_requires_authentication`, ale update query:
+
+```python
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_deathwatches_requires_authentication() -> None:
+    payload = await _post(AsyncClient(), "{ deathwatches { id } }", bearer=None)
+    assert "errors" in payload
+    msg = payload["errors"][0]["message"]
+    assert "auth" in msg.lower()
+```
+
+Po rename, ten test (dawniej `test_my_death_watches_returns_empty_list_for_user_without_watches`) zmienia semantykę — nie ma już per-user filtru. **Zastąp** treść:
+
+```python
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_deathwatches_returns_empty_list_when_no_watches() -> None:
+    """Empty system → empty list, NOT errors. Distinguishes "no data" from auth fail."""
+    _, bearer = await _make_user_and_token("anyone")
+    payload = await _post(AsyncClient(), "{ deathwatches { id } }", bearer)
+    assert "errors" not in payload, payload
+    assert payload["data"]["deathwatches"] == []
+```
+
+Dopisz 2 nowe testy w sekcji `# myDeathWatches query` (rename sekcji na `# deathwatches query`):
+
+```python
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_deathwatches_returns_watches_from_all_users() -> None:
+    """Public list visibility (spec §3.4) — alice sees bob's watches too."""
+    user_a, bearer_a = await _make_user_and_token("alice")
+    user_b, _ = await _make_user_and_token("bob")
+
+    def _seed() -> None:
+        c1 = Character.objects.create(name="Yhral")
+        c2 = Character.objects.create(name="Bubble")
+        DeathWatch.objects.create(user=user_a, character=c1)
+        DeathWatch.objects.create(user=user_b, character=c2)
+
+    await sync_to_async(_seed)()
+
+    payload = await _post(
+        AsyncClient(),
+        "{ deathwatches { character { name } } }",
+        bearer_a,
+    )
+
+    assert "errors" not in payload, payload
+    names = sorted(w["character"]["name"] for w in payload["data"]["deathwatches"])
+    assert names == ["Bubble", "Yhral"]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_deathwatches_exposes_added_by_discord_id() -> None:
+    """Resolved field `addedByDiscordId` returns watch.user.discord_id (spec §4.4)."""
+    user, bearer = await _make_user_and_token("alice")
+    user.discord_id = "99999"
+    await sync_to_async(user.save)(update_fields=["discord_id"])
+    char = await sync_to_async(Character.objects.create)(name="Yhral")
+    await sync_to_async(DeathWatch.objects.create)(user=user, character=char)
+
+    payload = await _post(
+        AsyncClient(),
+        "{ deathwatches { addedByDiscordId character { name } } }",
+        bearer,
+    )
+
+    assert "errors" not in payload, payload
+    data = payload["data"]["deathwatches"]
+    assert len(data) == 1
+    assert data[0]["addedByDiscordId"] == "99999"
+    assert data[0]["character"]["name"] == "Yhral"
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+poetry run pytest tests/unit/deathwatch/test_graphql_deathwatch.py -v -k "deathwatches"
+```
+
+Expected: nowe testy FAIL (`Cannot query field 'deathwatches'` lub `addedByDiscordId`).
+
+- [ ] **Step 3: Update GraphQL schema**
+
+W `apps/deathwatch/schema.py`, **rozszerz** `DeathWatchType` o resolved field. Znajdź:
+
+```python
+@strawberry_django.type(DeathWatch)
+class DeathWatchType:
+    id: auto
+    created_at: auto
+    active: auto
+    character: CharacterType
+```
+
+**Zastąp** całą klasę:
+
+```python
+@strawberry_django.type(DeathWatch)
+class DeathWatchType:
+    id: auto
+    created_at: auto
+    active: auto
+    character: CharacterType
+
+    @strawberry.field
+    def added_by_discord_id(self) -> str:
+        """Discord ID of the user who added this watch (spec §3.2 / §4.4).
+
+        Returns User.discord_id raw — frontend renders as wants (Discord
+        `<@id>` mention in bot output, plain string elsewhere). Empty
+        string if user has no linked Discord (manual Django admin user).
+        """
+        return self.user.discord_id or ""
+```
+
+W tej samej klasie `Query`, znajdź `async def my_death_watches`:
+
+```python
+    @strawberry.field
+    async def my_death_watches(
+        self, info: strawberry.Info
+    ) -> list[DeathWatchType]:
+        user = _require_auth(info)
+        qs = (
+            DeathWatch.objects.filter(user=user)
+            .select_related("character")
+            .order_by("-created_at")
+        )
+        return cast("list[DeathWatchType]", [w async for w in qs])
+```
+
+**Zastąp** całą metodę:
+
+```python
+    @strawberry.field
+    async def deathwatches(
+        self, info: strawberry.Info
+    ) -> list[DeathWatchType]:
+        """All active deathwatches across all users (M12 follow-up).
+
+        Public list — every authenticated client sees every watch + added_by_discord_id.
+        Spec §3.4 — semantic break from M12 `myDeathWatches` (per-user filter).
+        Project has no external GraphQL consumers, so breaking rename OK.
+        """
+        _require_auth(info)
+        qs = (
+            DeathWatch.objects.filter(active=True)
+            .select_related("user", "character")
+            .order_by("-created_at")
+        )
+        return cast("list[DeathWatchType]", [w async for w in qs])
+```
+
+- [ ] **Step 4: Run tests — expected PASS**
+
+```bash
+poetry run pytest tests/unit/deathwatch/test_graphql_deathwatch.py -v
+```
+
+Expected: wszystkie testy PASS (was 16, drop 1 + rename 3 + add 2 = 17).
+
+- [ ] **Step 5: Verify no orphaned `my_death_watches` references**
+
+```bash
+grep -rn "my_death_watches\|myDeathWatches" --include="*.py"
+```
+
+Expected: zero hits.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/deathwatch/schema.py tests/unit/deathwatch/test_graphql_deathwatch.py
+git commit -m "feat(deathwatch): rename myDeathWatches to deathwatches + addedByDiscordId field"
+```
+
+---
+
+## Task 4 — Final pre-commit + PR
+
+- [ ] **Step 1: Pre-commit full pass**
+
+```bash
+poetry run pre-commit run --all-files
+```
+
+Expected: wszystkie hooki PASS (lub auto-fix + re-stage + re-run).
+
+Jeśli `ruff-format` lub `mixed-line-ending` fixują pliki — `git add` + `git commit --amend --no-edit` ostatniego commita (lub fold w osobny "style" commit jeśli wiele).
+
+- [ ] **Step 2: Full DW test suite**
+
+```bash
+poetry run pytest tests/unit/deathwatch tests/unit/discord_bot/test_deathwatch_cog.py tests/integration/deathwatch -v
+```
+
+Expected: wszystkie testy PASS. Sanity że żaden M12 test nie regresszał.
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push -u origin feat/deathwatch-public-list
+```
+
+- [ ] **Step 4: Create PR**
+
+```bash
+gh pr create --title "feat(deathwatch): public /list visibility (M12 follow-up)" --body "$(cat <<'EOF'
+## Summary
+
+M12 follow-up — `/deathwatch list` widoczne dla wszystkich (drop per-user filter), GraphQL query rename, added by-mention rendering, no-ping `AllowedMentions.none()`. Cap globalny już istniał od M12 spec §3.2, bez zmian.
+
+**Spec:** \`docs/superpowers/specs/2026-05-17-public-deathwatch-list-design.md\`
+**Plan:** \`docs/superpowers/plans/2026-05-17-public-deathwatch-list-implementation-plan.md\`
+
+## Changes
+
+- \`apps/deathwatch/services.py\` — \`list_death_watches(user)\` → \`list_all_death_watches()\`, drop user param, \`select_related("user", "character")\`.
+- \`discord_bot/services.py\` — \`list_deathwatches_for_discord_user(discord_id)\` → \`list_all_deathwatches()\`.
+- \`discord_bot/cogs/deathwatch.py\` — \`/list\` rewrite: all watches, \`<@discord_id>\` mention syntax, \`AllowedMentions.none()\`, \`count/cap\` indicator. Ephemeral preserved.
+- \`apps/deathwatch/schema.py\` — query rename \`myDeathWatches\` → \`deathwatches\`, drop per-user filter, add \`addedByDiscordId\` resolved field.
+- Tests updated we wszystkich 3 warstwach (services + cog + GraphQL).
+
+## Breaking changes
+
+- **GraphQL** — \`myDeathWatches\` rename → \`deathwatches\`. Projekt nie ma external GraphQL consumers, akceptowalne.
+- **Discord cog** — \`/deathwatch list\` zmienia output shape (multi-user, mentions, count/cap). User-facing, ale konsystentne z user request.
+
+## Test plan
+
+- [x] All M12 tests still PASS (no regression).
+- [x] 2 new service tests (\`list_all_death_watches\` happy path + inactive filter).
+- [x] 5 new cog tests (empty state, all-users render, mention syntax, allowed_mentions=none, cap indicator).
+- [x] 2 new GraphQL tests (multi-user visibility, addedByDiscordId field).
+- [x] Pre-commit zielony.
+- [ ] Manual smoke per \`docs/dev-runbook.md §7\` — verify mentions render as @username bez pingowania, cap indicator visible.
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-review (run after writing the plan)
+
+**1. Spec coverage:**
+- Spec §3.1 (`list_all_death_watches` rename) → Task 1 ✓
+- Spec §3.2 (`<@discord_id>` mention) → Task 2 Step 4 + test Step 2 ✓
+- Spec §3.3 (`AllowedMentions.none()`) → Task 2 Step 4 + test ✓
+- Spec §3.4 (GraphQL rename) → Task 3 ✓
+- Spec §3.5 (count/cap indicator) → Task 2 Step 4 + test ✓
+- Spec §3.6 (ephemeral preserved) → Task 2 Step 4 + test assertion `ephemeral is True` ✓
+- Spec §3.7 (auth nadal required) → Task 3 (`_require_auth(info)` zachowany w resolverze) ✓
+- Spec §5 (`<@unknown>` fallback) → Task 2 Step 4 (`w.user.discord_id or 'unknown'`) ✓
+- Spec §6 (testy 3 warstwy) → Task 1 + 2 + 3 ✓
+
+**2. Placeholder scan:** brak TBD/TODO. Wszystkie steps mają konkretny kod.
+
+**3. Type consistency:**
+- `list_all_death_watches()` (service) — używane w T1, T2 (`from apps.deathwatch.services import list_all_death_watches` w bot wrapper) ✓
+- `list_all_deathwatches()` (bot wrapper) — używane w T2 cog import + tests ✓
+- `added_by_discord_id` (Python snake_case w schema) ↔ `addedByDiscordId` (GraphQL camelCase) — Strawberry auto-conversion, OK ✓
+- `discord_id` field na `User` — string, M2-D9, used in T2 cog (`w.user.discord_id`) i T3 schema (`self.user.discord_id`) ✓
+
+Self-review pass.

--- a/docs/superpowers/specs/2026-05-17-public-deathwatch-list-design.md
+++ b/docs/superpowers/specs/2026-05-17-public-deathwatch-list-design.md
@@ -1,0 +1,165 @@
+# Public DeathWatch list — Design
+
+**Data:** 2026-05-17
+**Feature:** M12 follow-up — `/deathwatch list` widoczne dla wszystkich (Discord cog + GraphQL query change).
+**Skala:** mała (~5 plików, brak migracji, brak nowych modeli).
+
+---
+
+## 1. Cel
+
+Po M12 lista deathwatches była per-user — każdy widział tylko swoje wpisy. User-feedback: lista ma być **shared** — `/deathwatch list` pokazuje wszystkie aktywne watches w systemie (kto dodał, na kogo).
+
+**Cap pozostaje globalny** (już taki był od spec §3.2): 20 unikalnych postaci across all users — widoczny w outputie `/list` jako `count/cap` reminder.
+
+## 2. Scope
+
+**W scope:**
+- Refactor service `apps.deathwatch.services.list_death_watches(user)` → `list_all_death_watches()` (drop param, return all active watches).
+- Update Discord cog `/deathwatch list` — wszystkie watches, format z `(added by <@discord_id>)`, `allowed_mentions=AllowedMentions.none()` (no ping spam), ephemeral pozostaje.
+- Update bot service wrapper `discord_bot.services.list_deathwatches_for_discord_user(discord_id)` → `list_all_deathwatches()` (drop param).
+- Rename GraphQL query `myDeathWatches` → `deathwatches`. Add resolved field `addedByDiscordId` na `DeathWatchType`.
+- Update tests we wszystkich trzech warstwach.
+
+**Poza scope:**
+- Cap value change (zostaje 20).
+- GraphQL backwards-compat — projekt nie ma external GraphQL consumers, breaking rename OK.
+- Per-channel filtering, search, pagination — YAGNI, lista max ~20 chars.
+- `who-removed` audit history — soft delete poza scope.
+
+---
+
+## 3. Decisions
+
+### 3.1. Nazewnictwo service: `list_all_death_watches` zamiast reuse `list_death_watches`
+Explicit `all_` prefix usuwa ambiguity ze starą signaturą `(user)`. Reader natychmiast widzi że to globalny query. Wszystkie callery aktualizowane atomically.
+
+### 3.2. Discord mention syntax `<@discord_id>` zamiast `user.username`
+Auto-create User pattern z M7 zapisuje `username = f"discord_{discord_id}"` — raw "discord_12345" wygląda nieprzyjaźnie w embedzie. Discord renderuje `<@id>` jako "@alice" natywnie (faktyczny username z Discord profile, nie z DB). Pole `User.discord_id` istnieje od M2-D9, używane w cogach.
+
+### 3.3. `allowed_mentions=discord.AllowedMentions.none()`
+Bez tego `<@id>` w response pinguje każdego usera listed → potencjalny spam (jeden `/list` = 20 notifikacji). `AllowedMentions.none()` renderuje mentions wizualnie bez pingowania. **Critical UX**, test pilnuje.
+
+### 3.4. GraphQL rename `myDeathWatches` → `deathwatches`
+Breaking change ALE projekt nie ma external GraphQL consumers (single internal client = aktualnie nieużywany). Zmiana semantyki przy zachowaniu `myDeathWatches` byłaby źródłem przyszłej confusion ("dlaczego `my` zwraca cudze?"). Auth nadal required — nieautoryzowani klienci nie widzą.
+
+### 3.5. Visible cap w `/list` outputie (`count/20`)
+Bonus UX nad pure list. User natychmiast widzi że zostało N slotów w systemie. Reminder że cap jest shared. Tani — `settings.DEATHWATCH_MAX_WATCHED_CHARACTERS` access + format string.
+
+### 3.6. Ephemeral zachowany
+User explicit chciał ephemeral mimo public list. Trade-off: tylko caller widzi, więc kanał nie spamowany, ale każdy user musi sam zawołać. Akceptowalne — `/list` w deathwatch nie jest częsty, nie ma value w kanał-wide audit trail.
+
+### 3.7. Auth nadal required na GraphQL
+Lista jest shared, ale tylko między authenticated clients. Anonymous webhook nie widzi czyje postacie są obserwowane (mild privacy guard mimo że bot expose to przez `/list`).
+
+---
+
+## 4. Implementation outline
+
+### 4.1. Files to modify
+
+| Plik | Zmiana |
+|---|---|
+| `apps/deathwatch/services.py` | `list_death_watches(user)` → `list_all_death_watches()`. `select_related("user", "character")` (N+1 guard dla username rendering). Order by `-created_at` zachowany. |
+| `discord_bot/services.py` | `list_deathwatches_for_discord_user(discord_id)` → `list_all_deathwatches()`. Drop `discord_id` param. |
+| `discord_bot/cogs/deathwatch.py` | `/list` resolver: drop `ctx.author.id` arg, fetch all, render z `<@discord_id>`, `count/cap`, `allowed_mentions=AllowedMentions.none()`. |
+| `apps/deathwatch/schema.py` | `my_death_watches` resolver → `deathwatches`. Drop user filter. Add `added_by_discord_id` resolved field na `DeathWatchType`. |
+| `config/schema.py` | No change (merge_types accepts renamed Query field automatycznie). |
+
+### 4.2. Files to test
+
+| Plik | Zmiana |
+|---|---|
+| `tests/unit/deathwatch/test_services.py` | Drop `test_list_death_watches_filters_by_user_and_orders_newest_first`. Add `test_list_all_death_watches_returns_all_users_newest_first`. |
+| `tests/unit/discord_bot/test_deathwatch_cog.py` | Update `test_list_command_renders_character_names` (multi-user seed, assert both watches visible). Add `test_list_command_shows_added_by_discord_mention` (assert `<@id>` w outputie). Add `test_list_command_uses_allowed_mentions_none` (assert kwarg passed). Add `test_list_command_includes_cap_indicator` (`/20` w outputie). |
+| `tests/unit/deathwatch/test_graphql_deathwatch.py` | Rename 3 tests `test_my_death_watches_*` → `test_deathwatches_*`. Drop "filters by user" (anti-feature). Add `test_deathwatches_returns_watches_from_all_users`. Add `test_deathwatches_exposes_added_by_discord_id`. |
+
+### 4.3. Discord output sample
+
+```
+Active deathwatches (3/20):
+• `Yhral` (added by <@123456789012345678>)
+• `Bubble` (added by <@987654321098765432>)
+• `Eternal oblivion` (added by <@123456789012345678>)
+```
+
+Empty state (no watches w systemie):
+```
+No active deathwatches. Add one with `/deathwatch add <name>`.
+```
+
+### 4.4. GraphQL schema delta
+
+```graphql
+type DeathWatchType {
+  id: ID!
+  createdAt: DateTime!
+  active: Boolean!
+  character: CharacterType!
+  addedByDiscordId: String!  # NEW — resolved from user.discord_id
+}
+
+type Query {
+  # OLD: myDeathWatches: [DeathWatchType!]!
+  deathwatches: [DeathWatchType!]!  # all active, auth-gated
+  watchedDeaths(characterName: String, limit: Int = 20): [WatchedDeathEventType!]!
+}
+```
+
+---
+
+## 5. Edge cases
+
+| Sytuacja | Zachowanie |
+|---|---|
+| User nie ma `discord_id` (manual Django admin user) | Render `<@unknown>` w outputie. Field `discord_id` jest CharField bez null, default `""`. Test pilnuje. |
+| Lista pusta (no watches w systemie) | Empty state ze wskazówką `/deathwatch add`. Nie pokazuje cap counter (`0/20` mylące). |
+| User dodał inactive watch (`active=False`) | Filter `active=True` w service — inactive watches nie liczą się do cap ani nie renderowane w `/list`. Konsystencja z istniejącym cap check (services.py:59). |
+| Same character watched przez wielu userów | Każdy watch jako osobna linia (`Yhral (added by alice)` + `Yhral (added by bob)`). Cap liczy jako 1 unique char. To **expected** — user widzi że Yhral jest watched przez wielu. |
+
+---
+
+## 6. Test plan
+
+### 6.1. Unit (`tests/unit/deathwatch/test_services.py`)
+- `test_list_all_death_watches_returns_all_users_newest_first` — seed 2 users × 2 watches, assert order desc.
+- `test_list_all_death_watches_excludes_inactive` — soft-deactivated watch nie w wyniku.
+
+### 6.2. Discord cog (`tests/unit/discord_bot/test_deathwatch_cog.py`)
+- `test_list_command_renders_character_names` (updated) — multi-user seed, assert both watches w outputie.
+- `test_list_command_shows_added_by_discord_mention` — assert `<@discord_id>` literal w response string.
+- `test_list_command_uses_allowed_mentions_none` — `respond.call_args.kwargs["allowed_mentions"]` matches `discord.AllowedMentions.none()`.
+- `test_list_command_includes_cap_indicator` — assert `(N/20)` w response.
+- `test_list_command_empty_state` (existing, no change) — assert "No active deathwatches" gdy pusta.
+
+### 6.3. GraphQL (`tests/unit/deathwatch/test_graphql_deathwatch.py`)
+- Rename 3 testy `test_my_death_watches_*` → `test_deathwatches_*`.
+- **Drop** `test_my_death_watches_filters_by_request_user` (anti-feature now).
+- Add `test_deathwatches_returns_watches_from_all_users` — 2 users seed, assert oba watches w results.
+- Add `test_deathwatches_exposes_added_by_discord_id` — query `{ deathwatches { addedByDiscordId } }`, assert non-empty.
+- Keep `test_deathwatches_requires_authentication` (renamed).
+
+---
+
+## 7. Definition of Done
+
+- [ ] `list_all_death_watches()` service + drop `list_death_watches(user)`.
+- [ ] `list_all_deathwatches()` bot service wrapper + drop `list_deathwatches_for_discord_user(discord_id)`.
+- [ ] Discord cog `/list` updated: all watches, `<@id>` mention, `allowed_mentions=none`, `count/cap` indicator.
+- [ ] GraphQL: `myDeathWatches` → `deathwatches` rename, `DeathWatchType.addedByDiscordId` added.
+- [ ] Tests updated we wszystkich 3 warstwach (services + cog + GraphQL).
+- [ ] Pre-commit + CI zielone.
+- [ ] Manual smoke (`docs/dev-runbook.md §7`) re-run dla updated `/list` behavior.
+
+---
+
+## 8. Risks & follow-ups
+
+### 8.1. Ryzyko: jeden `/list` = 20 user mentions w response, mimo `allowed_mentions=none`
+Discord embed/message z 20 `<@id>` mentions może wyglądać przeładowane. Jeśli prod feedback to potwierdzi — switch na `**username**` (markdown bold derived z Discord User cache) zamiast mention syntax. Trigger: user complaint po smoke. Memory note dla follow-up.
+
+### 8.2. Follow-up: `removed_by` audit
+Aktualnie hard delete — kto usunął watch nie jest tracked. Jeśli kiedyś będzie potrzeba audit log (np. "ktoś removed Yhral bez powodu"), zmiana modelu na soft delete + `removed_by_user_id` field. Spec §1 odroczone.
+
+### 8.3. Follow-up: pagination
+20 watches × ~80 char per line = ~1600 chars per response — pod Discord 2000 char limit, ale tight. Jeśli cap kiedyś rośnie >25, pagination wymagana. YAGNI dla MVP.

--- a/tests/unit/deathwatch/test_graphql_deathwatch.py
+++ b/tests/unit/deathwatch/test_graphql_deathwatch.py
@@ -1,4 +1,4 @@
-"""Tests for myDeathWatches / watchedDeaths queries + DW mutations (DW-8).
+"""Tests for deathwatches / watchedDeaths queries + DW mutations.
 
 Mirror of `tests/unit/bedmages/test_graphql_bedmages.py`: JWT auth via
 `AccessToken.for_user`, AsyncClient against /graphql/, async resolvers
@@ -60,44 +60,63 @@ async def _make_user_and_token(
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# myDeathWatches query
+# deathwatches query (M12 follow-up — public list visibility)
 # ═══════════════════════════════════════════════════════════════════════════
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_my_death_watches_filters_by_request_user() -> None:
-    """Security invariant — never leak other users' deathwatch subscriptions."""
+async def test_deathwatches_returns_watches_from_all_users() -> None:
+    """Public list visibility (spec §3.4) — alice sees bob's watches too."""
     user_a, bearer_a = await _make_user_and_token("alice")
     user_b, _ = await _make_user_and_token("bob")
 
     def _seed() -> None:
         c1 = Character.objects.create(name="Yhral")
         c2 = Character.objects.create(name="Bubble")
-        c3 = Character.objects.create(name="Otherusers")
         DeathWatch.objects.create(user=user_a, character=c1)
-        DeathWatch.objects.create(user=user_a, character=c2)
-        DeathWatch.objects.create(user=user_b, character=c3)
+        DeathWatch.objects.create(user=user_b, character=c2)
 
     await sync_to_async(_seed)()
 
     payload = await _post(
         AsyncClient(),
-        "{ myDeathWatches { id character { name } active } }",
+        "{ deathwatches { character { name } } }",
         bearer_a,
     )
 
     assert "errors" not in payload, payload
-    watches = payload["data"]["myDeathWatches"]
-    assert len(watches) == 2
-    names = sorted(w["character"]["name"] for w in watches)
+    names = sorted(w["character"]["name"] for w in payload["data"]["deathwatches"])
     assert names == ["Bubble", "Yhral"]
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_my_death_watches_requires_authentication() -> None:
-    payload = await _post(AsyncClient(), "{ myDeathWatches { id } }", bearer=None)
+async def test_deathwatches_exposes_added_by_discord_id() -> None:
+    """Resolved field `addedByDiscordId` returns watch.user.discord_id (spec §4.4)."""
+    user, bearer = await _make_user_and_token("alice")
+    user.discord_id = "99999"
+    await sync_to_async(user.save)(update_fields=["discord_id"])
+    char = await sync_to_async(Character.objects.create)(name="Yhral")
+    await sync_to_async(DeathWatch.objects.create)(user=user, character=char)
+
+    payload = await _post(
+        AsyncClient(),
+        "{ deathwatches { addedByDiscordId character { name } } }",
+        bearer,
+    )
+
+    assert "errors" not in payload, payload
+    data = payload["data"]["deathwatches"]
+    assert len(data) == 1
+    assert data[0]["addedByDiscordId"] == "99999"
+    assert data[0]["character"]["name"] == "Yhral"
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_deathwatches_requires_authentication() -> None:
+    payload = await _post(AsyncClient(), "{ deathwatches { id } }", bearer=None)
     assert "errors" in payload
     msg = payload["errors"][0]["message"]
     assert "auth" in msg.lower()
@@ -105,11 +124,12 @@ async def test_my_death_watches_requires_authentication() -> None:
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_my_death_watches_returns_empty_list_for_user_without_watches() -> None:
-    _, bearer = await _make_user_and_token("nobody")
-    payload = await _post(AsyncClient(), "{ myDeathWatches { id } }", bearer)
+async def test_deathwatches_returns_empty_list_when_no_watches() -> None:
+    """Empty system → empty list, NOT errors. Distinguishes "no data" from auth fail."""
+    _, bearer = await _make_user_and_token("anyone")
+    payload = await _post(AsyncClient(), "{ deathwatches { id } }", bearer)
     assert "errors" not in payload, payload
-    assert payload["data"]["myDeathWatches"] == []
+    assert payload["data"]["deathwatches"] == []
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/deathwatch/test_services.py
+++ b/tests/unit/deathwatch/test_services.py
@@ -9,7 +9,7 @@ from apps.characters.models import Character
 from apps.deathwatch.models import DeathWatch, DeathWatchChannel, WatchedDeathEvent
 from apps.deathwatch.services import (
     add_death_watch,
-    list_death_watches,
+    list_all_death_watches,
     record_watched_death,
     remove_death_watch,
     set_deathwatch_channel_for_guild,
@@ -116,25 +116,43 @@ def test_remove_death_watch_canonicalizes_name() -> None:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# list_death_watches
+# list_all_death_watches (public visibility — M12 follow-up)
 # ──────────────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.django_db
-def test_list_death_watches_filters_by_user_and_orders_newest_first() -> None:
+def test_list_all_death_watches_returns_all_users_newest_first() -> None:
+    """Public list: every active watch across all users, ordered desc."""
     alice = User.objects.create(username="alice", discord_id="1")
     bob = User.objects.create(username="bob", discord_id="2")
     add_death_watch(alice, "Yhral")
     add_death_watch(bob, "Bubble")
     add_death_watch(alice, "Eternal Oblivion")
 
-    alice_watches = list(list_death_watches(alice))
+    watches = list(list_all_death_watches())
 
     # _canonicalize_name uppercases ONLY the first letter ("Eternal Oblivion"
     # → "Eternal oblivion"). Match canonical form.
-    assert len(alice_watches) == 2
-    assert {w.character.name for w in alice_watches} == {"Yhral", "Eternal oblivion"}
-    assert alice_watches[0].character.name == "Eternal oblivion"
+    assert len(watches) == 3
+    names = [w.character.name for w in watches]
+    # Newest first
+    assert names[0] == "Eternal oblivion"
+    assert set(names) == {"Yhral", "Bubble", "Eternal oblivion"}
+
+
+@pytest.mark.django_db
+def test_list_all_death_watches_excludes_inactive() -> None:
+    """Soft-deactivated watches are excluded — consistent with cap counter."""
+    user = User.objects.create(username="alice", discord_id="1")
+    add_death_watch(user, "Yhral")
+    bubble_watch = add_death_watch(user, "Bubble")
+    bubble_watch.active = False
+    bubble_watch.save(update_fields=["active"])
+
+    watches = list(list_all_death_watches())
+
+    assert len(watches) == 1
+    assert watches[0].character.name == "Yhral"
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/discord_bot/test_deathwatch_cog.py
+++ b/tests/unit/discord_bot/test_deathwatch_cog.py
@@ -154,13 +154,15 @@ async def test_remove_command_idempotent_when_not_on_list(
 
 
 @pytest.mark.asyncio
-async def test_list_command_empty_state(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_list_command_empty_state_when_no_watches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No watches anywhere in the system → hint to add (M12 follow-up)."""
     mock_ctx = MagicMock(spec=discord.ApplicationContext)
-    mock_ctx.author.id = 12345
     mock_ctx.respond = AsyncMock()
 
     monkeypatch.setattr(
-        "discord_bot.cogs.deathwatch.list_deathwatches_for_discord_user",
+        "discord_bot.cogs.deathwatch.list_all_deathwatches",
         MagicMock(return_value=[]),
     )
 
@@ -168,34 +170,121 @@ async def test_list_command_empty_state(monkeypatch: pytest.MonkeyPatch) -> None
     await cog.list.callback(cog, mock_ctx)
 
     args, kwargs = mock_ctx.respond.call_args
-    assert "empty" in args[0].lower()
+    assert "No active deathwatches" in args[0]
+    assert "/deathwatch add" in args[0]
     assert kwargs["ephemeral"] is True
 
 
 @pytest.mark.asyncio
-async def test_list_command_renders_character_names(
+async def test_list_command_renders_all_users_watches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Public list visibility — every user's watches included (spec §3.4)."""
     mock_ctx = MagicMock(spec=discord.ApplicationContext)
-    mock_ctx.author.id = 12345
     mock_ctx.respond = AsyncMock()
 
     w1 = MagicMock()
     w1.character.name = "Yhral"
+    w1.user.discord_id = "111"
     w2 = MagicMock()
     w2.character.name = "Bubble"
+    w2.user.discord_id = "222"
+    w3 = MagicMock()
+    w3.character.name = "Eternal oblivion"
+    w3.user.discord_id = "111"  # alice again
+
     monkeypatch.setattr(
-        "discord_bot.cogs.deathwatch.list_deathwatches_for_discord_user",
-        MagicMock(return_value=[w1, w2]),
+        "discord_bot.cogs.deathwatch.list_all_deathwatches",
+        MagicMock(return_value=[w1, w2, w3]),
     )
 
     cog = DeathWatchCog(bot=MagicMock())
     await cog.list.callback(cog, mock_ctx)
 
     args, kwargs = mock_ctx.respond.call_args
-    assert "Yhral" in args[0]
-    assert "Bubble" in args[0]
+    text = args[0]
+    assert "Yhral" in text
+    assert "Bubble" in text
+    assert "Eternal oblivion" in text
     assert kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_command_shows_added_by_discord_mention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each entry includes `<@discord_id>` mention syntax (spec §3.2)."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.respond = AsyncMock()
+
+    w = MagicMock()
+    w.character.name = "Yhral"
+    w.user.discord_id = "99999"
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.list_all_deathwatches",
+        MagicMock(return_value=[w]),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    args, _ = mock_ctx.respond.call_args
+    assert "<@99999>" in args[0]
+
+
+@pytest.mark.asyncio
+async def test_list_command_uses_allowed_mentions_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """20 mentions w outputie nie mogą pingować users (spec §3.3)."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.respond = AsyncMock()
+
+    w = MagicMock()
+    w.character.name = "Yhral"
+    w.user.discord_id = "1"
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.list_all_deathwatches",
+        MagicMock(return_value=[w]),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    _, kwargs = mock_ctx.respond.call_args
+    am = kwargs["allowed_mentions"]
+    # AllowedMentions.none() = no everyone/users/roles pings
+    assert am.everyone is False
+    assert am.users is False
+    assert am.roles is False
+
+
+@pytest.mark.asyncio
+async def test_list_command_shows_count_over_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cap indicator `(N/20)` w outputie (spec §3.5)."""
+    mock_ctx = MagicMock(spec=discord.ApplicationContext)
+    mock_ctx.respond = AsyncMock()
+
+    watches = []
+    for i in range(3):
+        w = MagicMock()
+        w.character.name = f"Char{i}"
+        w.user.discord_id = str(i)
+        watches.append(w)
+
+    monkeypatch.setattr(
+        "discord_bot.cogs.deathwatch.list_all_deathwatches",
+        MagicMock(return_value=watches),
+    )
+
+    cog = DeathWatchCog(bot=MagicMock())
+    await cog.list.callback(cog, mock_ctx)
+
+    args, _ = mock_ctx.respond.call_args
+    assert "3/20" in args[0]
 
 
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

M12 follow-up — \`/deathwatch list\` widoczne dla wszystkich (drop per-user filter), GraphQL query rename, added-by mention rendering, no-ping \`AllowedMentions.none()\`. Cap globalny już istniał od M12 spec §3.2, bez zmian.

**Spec:** \`docs/superpowers/specs/2026-05-17-public-deathwatch-list-design.md\`
**Plan:** \`docs/superpowers/plans/2026-05-17-public-deathwatch-list-implementation-plan.md\`

## Changes

- **\`apps/deathwatch/services.py\`** — \`list_death_watches(user)\` → \`list_all_death_watches()\`, drop user param, \`select_related("user", "character")\`.
- **\`discord_bot/services.py\`** — \`list_deathwatches_for_discord_user(discord_id)\` → \`list_all_deathwatches()\`.
- **\`discord_bot/cogs/deathwatch.py\`** — \`/list\` rewrite: all watches, \`<@discord_id>\` mention syntax, \`AllowedMentions.none()\` (no ping spam), \`(N/20)\` cap indicator. Ephemeral preserved.
- **\`apps/deathwatch/schema.py\`** — query rename \`myDeathWatches\` → \`deathwatches\`, drop per-user filter, add \`addedByDiscordId\` resolved field.
- Tests updated we wszystkich 3 warstwach (2 services + 5 cog + 4 GraphQL).

## Breaking changes

- **GraphQL** — \`myDeathWatches\` rename → \`deathwatches\`. Projekt nie ma external GraphQL consumers, akceptowalne.
- **Discord cog** — \`/deathwatch list\` zmienia output shape (multi-user, mentions, count/cap). User-facing, ale konsystentne z user request.

## Sample output

\`\`\`
Active deathwatches (3/20):
• \`Yhral\` (added by <@123>)
• \`Bubble\` (added by <@456>)
• \`Eternal oblivion\` (added by <@123>)
\`\`\`

Empty state: \`No active deathwatches. Add one with /deathwatch add <name>.\`

## Test plan

- [x] 98/98 tests PASS (full DW suite, no regression z M12).
- [x] 2 new service tests (\`list_all_death_watches\` happy + inactive filter).
- [x] 5 new cog tests (empty state, all-users render, mention syntax, allowed_mentions=none, cap indicator).
- [x] 2 new GraphQL tests (multi-user visibility, addedByDiscordId field).
- [x] Pre-commit zielony (mypy fix: \`# type: ignore[attr-defined]\` na \`self.user\` w Strawberry-Django resolved field — Django FK runtime OK, mypy traci visibility).
- [ ] Manual smoke per \`docs/dev-runbook.md §7\` (zaktualizować runbook po smoke o nowy format outputu, jeśli różni się od opisanego).