### PR TITLE
docs(dev-runbook): /deathwatch list sample output in §7.4

### DIFF
--- a/docs/dev-runbook.md
+++ b/docs/dev-runbook.md
@@ -287,7 +287,28 @@ W dowolnym kanale lub DM (bot ma slash commands globalnie):
    - albo świadomie zaakceptuj że może nie być deathów przez parę godzin.
 2. `/deathwatch add Yhral` (zamień `Yhral` na real character).
 3. Expected: ephemeral `👀 Now watching \`Yhral\` for new deaths.`
-4. `/deathwatch list` — verify postać widoczna na liście.
+4. `/deathwatch list` — verify postać widoczna. Lista jest **publiczna**
+   (każdy user widzi watches od wszystkich) po PR #206 (M12 follow-up).
+   Output jest **ephemeral** (tylko Ty widzisz w UI, nikt inny w kanale).
+
+   Expected sample output (3 watches, cap 20):
+   ```
+   Active deathwatches (3/20):
+   • `Yhral` (added by <@123>)
+   • `Bubble` (added by <@456>)
+   • `Eternal oblivion` (added by <@123>)
+   ```
+   - `(N/20)` — count unikalnych characters vs `DEATHWATCH_MAX_WATCHED_CHARACTERS`
+     cap (spec §3.5). Reminder że cap jest **shared across all users**.
+   - `<@discord_id>` — Discord mention syntax, renderuje się jako "@alice".
+     **Sanity check:** Discord NIE powinien pingować user'ów przy `/list` —
+     bot wysyła z `allowed_mentions=AllowedMentions.none()` (spec §3.3).
+     Jeśli widzisz @ping → handler routing broken.
+   - Empty state (zero watches w systemie):
+     ```
+     No active deathwatches. Add one with `/deathwatch add <name>`.
+     ```
+
 5. Verify w DB:
    ```bash
    poetry run python manage.py shell -c "from apps.deathwatch.models import DeathWatch; [print(f'{w.user.username} → {w.character.name} (active={w.active}, created_at={w.created_at})') for w in DeathWatch.objects.all()]"


### PR DESCRIPTION
## Summary

Follow-up po PR #206 (public list visibility). §7.4 Step 2 wspominał `/deathwatch list` jako linijkę "verify postać widoczna" bez sample. Dorzucam expected output z opisem behavior introduced w PR #206.

## Changes

- **`docs/dev-runbook.md` §7.4 krok 4** — expand z 1-line verify do full sample:
  - Sample output `Active deathwatches (3/20):` z 3 entries (mock discord IDs).
  - Explanation `(N/20)` cap indicator (shared across users, spec §3.5).
  - Explanation `<@discord_id>` mention syntax + sanity check (NO ping spam,
    `allowed_mentions=AllowedMentions.none()` per spec §3.3).
  - Empty state sample (zero watches): `No active deathwatches. Add one...`
  - Note że lista jest **public** (każdy user widzi all watches) po PR #206
    + Ephemeral preserved.

## Test plan

- [x] Pre-commit zielony.
- [ ] Po Twoim merge — readiness na manual smoke per §7 z faktycznym `/list` weryfikującym sample matchuje rzeczywisty output.