### PR TITLE
docs: english README and codebase docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,218 @@
 # Tibiantis Monitor
 
-Backend application that scrapes two Tibiantis services on a schedule, stores character data and events in a database, and communicates with users through a Discord bot.
+A backend application that scrapes two Tibiantis services on a schedule, stores character data and events in a database, and communicates with users through a Discord bot.
 
-## Core features
+## About the project
 
-1. **Character monitoring** — profile scraper for [`tibiantis.online`](https://tibiantis.online).
-2. **Death monitoring** — death-list scraper for [`tibiantis.info`](https://tibiantis.info/stats/deaths).
-3. **Bedmage tracker** — reminds users when 100 minutes have passed since a character's last login (end of in-bed mana regeneration).
-4. **Discord bot** — user-facing interface: notifications about high-level character deaths and commands for managing the bedmages list.
+Tibiantis is a retro Tibia world. This application aggregates data that the game client itself does not expose and delivers it to players reactively — through Discord channels and DMs.
 
-The application is modular — more features are planned, so the architecture must be extensible.
+### Core features
+
+1. **Character monitoring** — profile scraper for [`tibiantis.online`](https://tibiantis.online) (level, vocation, last login, account status, guild, residence, etc.).
+2. **Death monitoring** — scraper of the public death list at [`tibiantis.info/stats/deaths`](https://tibiantis.info/stats/deaths) with deduplication on `(character_name, died_at)`.
+3. **Bedmage tracker** — reminds users when **100 minutes** have passed since a monitored character's last login (end of in-bed mana regeneration).
+4. **DeathWatch** — public list of characters watched for deaths; notifications are pushed to a dedicated Discord channel.
+5. **Discord bot** — user-facing interface: slash commands (`/bedmage add`, `/bedmage remove`, `/bedmage list`, `/deathwatch …`, `/deaths threshold`) and notification delivery.
+
+The architecture is **modular** — every feature lives in its own Django app (`apps/<feature>/`) with its own GraphQL schema, services, and Celery tasks.
+
+---
 
 ## Tech stack
 
-Python 3.13 · Django 6 · PostgreSQL · MongoDB (logs only) · Scrapy · Celery + Redis · Strawberry-Django (GraphQL) · DRF (auth only) · discord.py · Docker.
+| Layer | Technology |
+|---|---|
+| Language | **Python 3.13** |
+| Framework | **Django 6.0** |
+| Dependency management | **Poetry 2.x** (PEP 621 `[project]`) |
+| Scraping | **Scrapy** (executed from Celery via subprocess) |
+| Auth API | **Django REST Framework** + `djangorestframework-simplejwt` (login / register / refresh — **auth only**) |
+| Domain API | **Strawberry-Django** (GraphQL at `/graphql/`) |
+| Relational database | **PostgreSQL 16** — domain data |
+| Document database | **MongoDB 7** — application and scraping logs (`app_logs`, `scrape_logs`) |
+| Scheduler / queue | **Celery + Celery Beat** (broker: **Redis 7**, scheduler: `django-celery-beat` backed by the DB) |
+| Discord bot | **discord.py** (runs as a separate process / container) |
+| Containerisation | **Docker + docker-compose** (dev + prod) |
+| Lint / format / types | **Ruff** + **mypy strict** (on `apps/`) |
+| CI/CD | **GitHub Actions** + **pre-commit** + **Gitleaks** |
 
-## Local development
+> Full stack specification and project-wide rules (REST is auth-only, scrapers go through services, database separation, etc.) — see [`CLAUDE.md`](./CLAUDE.md).
 
-The dev environment uses `docker-compose.dev.yml` with two services: **postgres** (16-alpine, host port **5435** → container 5432) and **redis** (7-alpine, port 6379, ephemeral — no persistent volume).
+---
+
+## Repository layout
+
+```
+.
+├── config/                 # Django project (settings, urls, celery, merged schema)
+├── apps/
+│   ├── accounts/           # User + REST auth (JWT)
+│   ├── characters/         # Character model, scraping orchestration, GraphQL
+│   ├── bedmages/           # 100-min tracker, Celery tasks, GraphQL
+│   ├── deaths/             # Death monitor, configurable notification threshold
+│   ├── deathwatch/         # Public watch list + channel notifications
+│   ├── notifications/      # Abstract notification handlers (Discord DM/channel)
+│   └── core/               # Shared utilities / mixins
+├── scrapers/               # Scrapy project (spiders → pipeline → services)
+├── discord_bot/            # Separate process, slash commands (cogs)
+├── logs_backend/           # Logging handler → MongoDB
+├── docs/                   # Specs, milestone plans, runbooks
+├── tests/                  # unit / integration / e2e + HTML fixtures
+├── docker-compose.dev.yml  # Local services (postgres, redis, mongo)
+├── docker-compose.yml      # Production stack (web, worker, beat, bot, db, nginx)
+└── CLAUDE.md               # Full project specification
+```
+
+---
+
+## Local setup
 
 ### Prerequisites
 
-- Docker Desktop (Windows/Mac) or Docker Engine (Linux)
-- Python 3.13 and Poetry 2.x
+- **Docker Desktop** (Windows/Mac) or **Docker Engine** (Linux)
+- **Python 3.13**
+- **Poetry 2.x** (`pipx install poetry==2.0.1` recommended)
+- Git
 
-### Commands
+### 1. Clone the repo and configure `.env`
 
 ```bash
-docker compose -f docker-compose.dev.yml up -d      # start in the background
-docker compose -f docker-compose.dev.yml ps         # status — both services should be `(healthy)`
-docker compose -f docker-compose.dev.yml logs -f    # follow logs from both services
-docker compose -f docker-compose.dev.yml down       # stop (named volumes preserved)
-docker compose -f docker-compose.dev.yml down -v    # stop + wipe Postgres volume (re-init from POSTGRES_* env)
+git clone https://github.com/bgozlinski/tibiantis-scraper.git
+cd tibiantis-scraper
+cp .env.example .env
 ```
 
-Once the containers report `(healthy)`, install dependencies, apply migrations, and start Django:
+Must be filled in `.env`:
+
+- `DJANGO_SECRET_KEY` — generate with:
+  ```bash
+  python -c "import string, secrets; print(''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(50)))"
+  ```
+  (alphanumeric only — a `$` in the secret breaks Compose v2 variable expansion).
+- `DISCORD_BOT_TOKEN` — from the [Discord Developer Portal](https://discord.com/developers/applications) (optional if you only work on the backend).
+
+If you run Django **outside** of compose (i.e. with `runserver` against the dev services only), also set:
+
+```bash
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5435       # host port mapped in docker-compose.dev.yml
+REDIS_URL=redis://localhost:6379/0
+CELERY_BROKER_URL=redis://localhost:6379/1
+MONGO_URL=mongodb://localhost:27017
+```
+
+### 2. Start the dev services (Postgres + Redis + Mongo)
+
+```bash
+docker compose -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml ps              # both should be (healthy)
+```
+
+- **postgres** — host `localhost:5435` (container: `5432`); port `5435` avoids conflicts with a locally installed Postgres or other Docker projects
+- **redis** — host `localhost:6379` (ephemeral, no persistent volume)
+- **mongo** — host `localhost:27017`
+
+### 3. Python dependencies
 
 ```bash
 poetry install
+```
+
+### 4. Migrations + superuser
+
+```bash
 poetry run python manage.py migrate
+poetry run python manage.py createsuperuser
+```
+
+### 5. Run Django
+
+```bash
 poetry run python manage.py runserver
 ```
 
-### Why port 5435 (not 5432)
+Endpoints:
+- REST auth: `http://localhost:8000/api/auth/...`
+- GraphQL: `http://localhost:8000/graphql/`
+- Django admin: `http://localhost:8000/admin/`
 
-A locally installed Postgres on 5432 and other Docker projects on 5433–5434 can run alongside this stack without conflict. The container still listens on 5432 internally; only the host-side mapping is `5435`. Make sure `.env` has `DATABASE_URL=postgres://...@localhost:5435/...`.
+### 6. Celery (worker + beat)
 
-### Resetting Postgres credentials
-
-
-
-The Postgres image runs `initdb` **only on the first start against an empty volume**. If you later change `POSTGRES_USER`, `POSTGRES_PASSWORD`, or `POSTGRES_DB` in `.env`, the new values are silently ignored — the container keeps using the credentials baked in on first init. To pick up the new values, wipe the volume and recreate:
+Each runs in its own terminal. **On Windows the worker MUST use `-P solo`** (Win32 has no `fork()`, the default prefork pool crashes with `WinError 5`):
 
 ```bash
-docker compose -f docker-compose.dev.yml down -v
+# Terminal 1 — worker
+poetry run celery -A config worker -l info -P solo
+
+# Terminal 2 — beat (scheduler)
+poetry run celery -A config beat -l info
+```
+
+Beat polls `PeriodicTask` rows in the DB every 5 seconds — changes made via `/admin/django_celery_beat/` propagate without a restart.
+
+On Linux (prod/CI) the default `prefork` pool is used — see `docker-compose.yml`.
+
+### 7. Discord bot (optional)
+
+The bot runs as a **separate process** that shares Django models via a management command:
+
+```bash
+poetry run python manage.py run_discord_bot
+```
+
+Requires `DISCORD_BOT_TOKEN` set in `.env`, and — to register slash commands against a single dev guild only — `DISCORD_DEV_GUILD_ID`.
+
+### 8. Tests, linting, types
+
+```bash
+poetry run pytest                              # full suite
+poetry run pytest apps/bedmages -v             # one app
+poetry run ruff check . && poetry run ruff format --check .
+poetry run mypy apps/
+```
+
+### 9. Pre-commit
+
+After a fresh clone, install the hooks:
+
+```bash
+poetry run pre-commit install
+poetry run pre-commit install --hook-type commit-msg     # Conventional Commits
+poetry run pre-commit run --all-files                    # smoke test
+```
+
+Hook rules and CI policy — see §12–13 in [`CLAUDE.md`](./CLAUDE.md).
+
+---
+
+## Resetting Postgres (dev only)
+
+Postgres only runs `initdb` **the first time it starts against an empty volume**. Changing `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` in `.env` after that point is silently ignored. To reload with the current `.env`:
+
+```bash
+docker compose -f docker-compose.dev.yml down -v   # `-v` wipes the volume
 docker compose -f docker-compose.dev.yml up -d
 ```
 
-`-v` drops the named volume, triggering a fresh `initdb` with the current env vars. Destructive — only safe in dev, where seed data is regenerable.
+Destructive — fine in dev (seed data is reproducible), **never** in production.
 
-### Running Celery dev
+---
 
-Worker + beat as separate processes. On Windows the worker pool **must** be `solo` (Win32 lacks `fork()`):
+## Production
 
-```bash
-# Terminal 1: worker
-poetry run celery -A config worker -l info -P solo
+The full stack is brought up by `docker-compose.yml` (services: `web`, `celery_worker`, `celery_beat`, `discord_bot`, `postgres`, `mongo`, `redis`, `nginx`). The image is multi-stage and built through Poetry. Details — section 10 in [`CLAUDE.md`](./CLAUDE.md).
 
-# Terminal 2: beat (scheduler)
-poetry run celery -A config beat -l info
-
-# Terminal 3 (optional): Django runserver
-poetry run python manage.py runserver
-```
-
-The worker logs `[tasks] . apps.characters.tasks.ping` once `autodiscover_tasks` finds the task. Beat logs
-`Scheduler: ... DatabaseScheduler` and reads `PeriodicTask` rows from the database.
-
-#### Adding/changing scheduled tasks
-
-`PeriodicTask`/`IntervalSchedule`/`CrontabSchedule` rows are managed via Django admin
-(`/admin/django_celery_beat/`). Beat polls the DB every 5 seconds (`CELERY_BEAT_MAX_LOOP_INTERVAL`), so admin
-changes propagate without restart.
-
-#### Why `-P solo` on Windows
-
-Default Celery worker pool is `prefork` — relies on `os.fork()`, missing on Win32. Using `prefork` raises
-`PermissionError: [WinError 5] Access is denied`. `-P solo` runs the worker single-threaded in the main
-process. Linux Docker prod (M9) will use prefork.
+---
 
 ## Documentation
 
-- [`CLAUDE.md`](./CLAUDE.md) — full project specification (stack, structure, conventions, CI rules).
-- [`docs/superpowers/specs/2026-04-17-tibiantis-execution-plan-design.md`](./docs/superpowers/specs/2026-04-17-tibiantis-execution-plan-design.md) — execution process (roles, workflow, milestones).
-- [`docs/superpowers/plans/2026-04-17-m0-m1-implementation-plan.md`](./docs/superpowers/plans/2026-04-17-m0-m1-implementation-plan.md) — detailed plan for M0 + M1.
+- [`CLAUDE.md`](./CLAUDE.md) — full specification: stack, structure, conventions, CI, AI-assistant rules.
 - [`PROGRESS.md`](./PROGRESS.md) — current milestone status.
+- [`docs/`](./docs/) — implementation plans, retros, runbooks (e.g. the M12 DeathWatch smoke-test dev-runbook).
+- [Issues](https://github.com/bgozlinski/tibiantis-scraper/issues) — backlog and active work.
+
+---
 
 ## Status
 
-Work in progress. See `PROGRESS.md` and [open issues](https://github.com/bgozlinski/tibiantis-scraper/issues) for the current state.
+Work in progress — milestones M0–M12 are closed (auth, character scraper, bedmages, deaths, deathwatch). Current state and next steps live in [`PROGRESS.md`](./PROGRESS.md).

--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -1,3 +1,5 @@
+"""Django admin registration for the accounts app."""
+
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from apps.accounts.models import User
@@ -5,6 +7,8 @@ from apps.accounts.models import User
 
 @admin.register(User)
 class UserAdmin(BaseUserAdmin):
+    """Admin for :class:`User` that adds a Discord fieldset to the default form."""
+
     fieldsets = (
         *(BaseUserAdmin.fieldsets or ()),
         ("Discord", {"fields": ("discord_id",)}),

--- a/apps/accounts/api/serializers.py
+++ b/apps/accounts/api/serializers.py
@@ -1,3 +1,5 @@
+"""Serializers for the REST registration endpoint."""
+
 from typing import Any
 
 from rest_framework import serializers
@@ -9,6 +11,13 @@ from apps.accounts.models import User
 
 
 class RegisterSerializer(serializers.ModelSerializer[User]):
+    """Serializer that creates a new :class:`User` from the REST register call.
+
+    Enforces a non-empty unique ``email`` (the model column is nullable to
+    accommodate Discord-only users, but the REST flow always requires it) and
+    runs every Django password validator before accepting the credentials.
+    """
+
     email = serializers.EmailField(required=True, allow_null=False, allow_blank=False)
 
     class Meta:
@@ -21,6 +30,12 @@ class RegisterSerializer(serializers.ModelSerializer[User]):
         extra_kwargs = {"password": {"write_only": True}}
 
     def validate_password(self, value: str) -> str:
+        """Run Django's configured password validators on ``value``.
+
+        Re-raises any :class:`~django.core.exceptions.ValidationError` from
+        Django as a DRF :class:`~rest_framework.serializers.ValidationError`
+        so the API responds with structured field errors instead of a 500.
+        """
         try:
             django_validate_password(value)
         except DjangoValidationError as e:
@@ -28,4 +43,5 @@ class RegisterSerializer(serializers.ModelSerializer[User]):
         return value
 
     def create(self, validated_data: dict[str, Any]) -> User:
+        """Create the user through ``create_user`` so the password gets hashed."""
         return User.objects.create_user(**validated_data)

--- a/apps/accounts/api/views.py
+++ b/apps/accounts/api/views.py
@@ -1,3 +1,10 @@
+"""REST views for the accounts app.
+
+Per the project rule that REST is auth-only, this module exposes just user
+registration. Login, refresh and logout are handled by ``rest_framework_simplejwt``
+views wired in :mod:`apps.accounts.api.urls`.
+"""
+
 from rest_framework.generics import CreateAPIView
 from rest_framework.permissions import AllowAny
 from apps.accounts.api.serializers import RegisterSerializer
@@ -5,6 +12,12 @@ from apps.accounts.models import User
 
 
 class RegisterView(CreateAPIView[User]):
+    """Anonymous endpoint that creates a new :class:`User`.
+
+    Accepts ``username``, ``email`` and ``password`` and runs Django's password
+    validators through :class:`RegisterSerializer`.
+    """
+
     queryset = User.objects.all()
     serializer_class = RegisterSerializer
     permission_classes = [AllowAny]

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -1,8 +1,27 @@
+"""User model for the project.
+
+Extends Django's ``AbstractUser`` with a Discord identifier so that the same
+account can be created either from the REST registration endpoint or
+auto-provisioned by the Discord bot on first slash-command interaction.
+"""
+
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 
 
 class User(AbstractUser):
+    """Project user.
+
+    Adds two project-specific changes on top of Django's ``AbstractUser``:
+
+    * ``email`` is nullable and unique — Discord-only users (created by the bot
+      on first command) do not have an email yet, but REST-registered users do.
+      The REST ``RegisterSerializer`` enforces a non-empty value at the API
+      layer, so the relaxed column never produces empty rows through that path.
+    * ``discord_id`` stores the Discord snowflake used to link a Django user
+      with a Discord account; nullable for REST-only users.
+    """
+
     # AbstractUser declares `email: EmailField` (non-null, blank=True). We narrow
     # the column to allow NULL so Discord-only users can be auto-created without
     # colliding on the unique constraint (#133). REST register enforces a real

--- a/apps/accounts/schema.py
+++ b/apps/accounts/schema.py
@@ -1,3 +1,10 @@
+"""GraphQL schema for the ``accounts`` app.
+
+Exposes the currently authenticated user through the ``me`` query. Login,
+registration and token refresh stay in REST (DRF + SimpleJWT) — GraphQL only
+reads identity, never issues credentials.
+"""
+
 import strawberry
 import strawberry_django
 from strawberry import auto
@@ -9,6 +16,12 @@ from apps.accounts.models import User
 
 @strawberry_django.type(User)
 class UserType:
+    """GraphQL representation of :class:`apps.accounts.models.User`.
+
+    Only the fields safe to expose publicly are listed — password hashes,
+    permission flags and ``is_staff`` are intentionally omitted.
+    """
+
     username: auto
     email: auto
     date_joined: auto
@@ -17,8 +30,16 @@ class UserType:
 
 @strawberry.type
 class Query:
+    """Root query for the accounts app."""
+
     @strawberry.field
     async def me(self, info: strawberry.Info) -> UserType | None:
+        """Return the authenticated user, or ``None`` for anonymous requests.
+
+        The resolver is async because Strawberry runs the schema under ASGI;
+        the actual user lookup uses ``sync_to_async`` to read the ORM-managed
+        request user.
+        """
         request = info.context.request
 
         def _resolve_user() -> User | None:

--- a/apps/bedmages/models.py
+++ b/apps/bedmages/models.py
@@ -1,8 +1,24 @@
+"""Models for the bedmages app.
+
+A :class:`BedmageWatch` is the link between a Django user and a Tibiantis
+character they want a "regen-finished" reminder for. The pair must be
+unique — re-adding an already-watched character either raises (active row)
+or reactivates the existing inactive row.
+"""
+
 from django.conf import settings
 from django.db import models
 
 
 class BedmageWatch(models.Model):
+    """A single user → character bedmage subscription.
+
+    ``last_notified_login`` stores the character's ``last_login`` value at
+    the time of the last sent notification. It is the idempotency key that
+    prevents the 5-min Celery task from re-notifying about the same in-bed
+    session — see :func:`apps.bedmages.services.check_bedmage_watches_for_character`.
+    """
+
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,

--- a/apps/bedmages/schema.py
+++ b/apps/bedmages/schema.py
@@ -1,3 +1,10 @@
+"""GraphQL schema for the bedmages app.
+
+All queries and mutations require authentication. The schema is intentionally
+thin: it forwards work to :mod:`apps.bedmages.services` instead of
+re-implementing the lifecycle rules in resolvers.
+"""
+
 from typing import cast
 
 import strawberry
@@ -14,6 +21,8 @@ from apps.characters.schema import CharacterType
 
 @strawberry_django.type(BedmageWatch)
 class BedmageWatchType:
+    """GraphQL projection of :class:`apps.bedmages.models.BedmageWatch`."""
+
     id: auto
     created_at: auto
     last_notified_login: auto
@@ -23,8 +32,11 @@ class BedmageWatchType:
 
 @strawberry.type
 class Query:
+    """Authenticated queries for bedmage subscriptions."""
+
     @strawberry.field
     async def my_bedmages(self, info: strawberry.Info) -> list[BedmageWatchType]:
+        """Return the requesting user's watches, newest first."""
         request = info.context.request
         if not request.user.is_authenticated:
             raise PermissionError("Authentication required")
@@ -39,10 +51,13 @@ class Query:
 
 @strawberry.type
 class Mutation:
+    """Authenticated mutations that mutate the user's bedmage list."""
+
     @strawberry.mutation
     async def add_bedmage_watch(
         self, info: strawberry.Info, character_name: str
     ) -> BedmageWatchType:
+        """Subscribe the user to bedmage notifications for ``character_name``."""
         request = info.context.request
         if not request.user.is_authenticated:
             raise PermissionError("Authentication required")
@@ -56,6 +71,11 @@ class Mutation:
     async def remove_bedmage_watch(
         self, info: strawberry.Info, character_name: str
     ) -> bool:
+        """Remove the user's watch for ``character_name``; idempotent.
+
+        Returns ``True`` if a row was deleted, ``False`` if no matching
+        watch was found.
+        """
         request = info.context.request
         if not request.user.is_authenticated:
             raise PermissionError("Authentication required")

--- a/apps/bedmages/services.py
+++ b/apps/bedmages/services.py
@@ -1,3 +1,10 @@
+"""Service layer for the bedmages app.
+
+Owns the bedmage subscription lifecycle (add / remove / reactivate) and the
+notification-firing rule that the periodic Celery task drives every five
+minutes.
+"""
+
 import logging
 from datetime import timedelta
 from django.utils import timezone

--- a/apps/characters/management/commands/scrape_character.py
+++ b/apps/characters/management/commands/scrape_character.py
@@ -1,3 +1,12 @@
+"""Management command that scrapes a single Tibiantis character profile.
+
+The command is the subprocess target invoked by
+:func:`apps.characters.tasks.scrape_watched_characters`. Running each scrape
+in its own process is the safe way to integrate Scrapy's Twisted reactor with
+Celery — see M1 retro #8 (a CrawlerProcess cannot be started twice in the
+same interpreter).
+"""
+
 import asyncio
 import os
 import sys
@@ -22,11 +31,19 @@ setup()
 
 
 class Command(BaseCommand):
+    """``manage.py scrape_character <name>`` — crawl a single profile."""
+
     def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument("name", type=str)
 
     @wait_for(timeout=60.0)
     def _run_crawl(self, name: str) -> Any:
+        """Start the Scrapy crawl through crochet's reactor bridge.
+
+        ``wait_for`` blocks the calling thread until the deferred returned by
+        ``runner.crawl`` resolves, or 60 seconds elapse — whichever comes
+        first.
+        """
         settings = get_project_settings()
         runner = CrawlerRunner(settings)
         from scrapers.tibiantis_scrapers.spiders.character_spider import CharacterSpider

--- a/apps/characters/models.py
+++ b/apps/characters/models.py
@@ -1,3 +1,11 @@
+"""Models for the characters app.
+
+The :class:`Character` row is the canonical record for a scraped Tibiantis
+character profile. Names are stored in canonical form (first letter upper,
+the rest lower) so that two scrapes coming from different sources cannot
+duplicate the same character under a different casing.
+"""
+
 from typing import Any
 
 from django.db import models
@@ -27,6 +35,22 @@ def _canonicalize_name(name: str) -> str:
 
 
 class Character(models.Model):
+    """A Tibiantis character profile.
+
+    Most of the fields mirror what the ``tibiantis.online`` profile page
+    exposes. Two timestamps are managed by the project itself:
+
+    * ``last_scraped_at`` — updated on every save (``auto_now``), used by
+      the Celery freshness gate to skip recently-scraped characters.
+    * ``last_deaths_scraped_at`` — updated by the DeathWatch spider once it
+      finishes a per-character deaths scrape, used by that scheduler to
+      pick the oldest watched character on each cycle.
+
+    The ``name`` column is unique case-insensitively via the ``Lower``
+    functional index; ``save`` canonicalises the value before writing so
+    every read returns the same shape regardless of the input casing.
+    """
+
     name = CharField(max_length=64, unique=True)
     sex = CharField(max_length=16, blank=True, default="")
     vocation = CharField(max_length=32, blank=True, default="")
@@ -50,6 +74,7 @@ class Character(models.Model):
         ]
 
     def save(self, *args: Any, **kwargs: Any) -> None:
+        """Canonicalise ``name`` before delegating to the default ``save``."""
         if self.name:
             self.name = _canonicalize_name(self.name)
         super().save(*args, **kwargs)

--- a/apps/characters/schema.py
+++ b/apps/characters/schema.py
@@ -1,3 +1,9 @@
+"""GraphQL schema for the characters app.
+
+Exposes a single read endpoint — fetching a character by name — and lets
+clients project any subset of the scraped profile fields.
+"""
+
 import strawberry
 import strawberry_django
 from strawberry import auto
@@ -7,6 +13,8 @@ from typing import cast
 
 @strawberry_django.type(Character)
 class CharacterType:
+    """GraphQL projection of :class:`apps.characters.models.Character`."""
+
     name: auto
     sex: auto
     vocation: auto
@@ -22,7 +30,15 @@ class CharacterType:
 
 @strawberry.type
 class Query:
+    """Root query for the characters app."""
+
     @strawberry.field
     async def character(self, name: str) -> CharacterType | None:
+        """Return the character matching ``name`` exactly, or ``None``.
+
+        The lookup is case-sensitive against the canonicalised name stored
+        in the DB — pass the name in the form the bot/UI uses, not in raw
+        user input casing.
+        """
         result = await Character.objects.filter(name=name).afirst()
         return cast("CharacterType | None", result)

--- a/apps/characters/services.py
+++ b/apps/characters/services.py
@@ -1,3 +1,10 @@
+"""Service layer for the characters app.
+
+All scraper pipelines and management commands must route writes through
+``upsert_character`` instead of touching the ORM directly — this keeps the
+canonicalisation rules and the race-safe retry logic in one place.
+"""
+
 from django.db import IntegrityError, transaction
 
 from apps.characters.models import Character, _canonicalize_name

--- a/apps/characters/tasks.py
+++ b/apps/characters/tasks.py
@@ -1,3 +1,10 @@
+"""Celery tasks for the characters app.
+
+Beat triggers :func:`scrape_watched_characters` periodically; the configured
+``CELERY_SCRAPE_FRESHNESS_MINUTES`` cutoff keeps overlapping schedules from
+producing duplicate scrapes for the same character.
+"""
+
 import logging
 import subprocess
 import sys
@@ -14,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 @shared_task
 def ping() -> str:
+    """Trivial heartbeat task used by smoke tests and ``autodiscover`` checks."""
     return "pong"
 
 

--- a/apps/characters/types.py
+++ b/apps/characters/types.py
@@ -1,8 +1,21 @@
+"""Typed payload contracts for the characters app.
+
+These dicts are the boundary between Scrapy pipelines and the service layer:
+spiders build a :class:`CharacterPayload`, the pipeline forwards it to
+``services.upsert_character`` and only there it crosses into the ORM.
+"""
+
 from typing import TypedDict
 from datetime import datetime
 
 
 class CharacterPayload(TypedDict, total=False):
+    """Subset of :class:`apps.characters.models.Character` fields.
+
+    Marked ``total=False`` so scrapers can omit fields they could not extract;
+    only ``name`` is mandatory and validated by ``upsert_character``.
+    """
+
     name: str
     sex: str
     vocation: str

--- a/apps/core/health.py
+++ b/apps/core/health.py
@@ -1,3 +1,5 @@
+"""HTTP health endpoint used by Docker ``HEALTHCHECK`` and the load balancer."""
+
 from __future__ import annotations
 
 import logging
@@ -14,18 +16,18 @@ logger = logging.getLogger(__name__)
 
 @require_GET
 def health_check(request: HttpRequest) -> JsonResponse:
-    """Liveness + readiness check dla Docker HEALTHCHECK i load balancer'a.
+    """Liveness + readiness probe for the web container.
 
-    Sprawdza:
-    - DB connectivity (cursor.execute("SELECT 1"))
-    - Redis connectivity (redis.Redis(...).ping())
+    Checks:
 
-    Returns:
-        200 + {"db": "ok", "redis": "ok"} gdy oba OK.
-        503 + {"db": "fail"|"ok", "redis": "fail"|"ok", "error": "..."} gdy fail.
+    * **DB connectivity** — runs ``SELECT 1`` through the default cursor.
+    * **Redis connectivity** — issues a ``PING`` against ``settings.REDIS_URL``.
 
-    Out of scope (M-future): Mongo check (logging może gracefully degradować),
-    Celery worker ping (osobny healthcheck per service w compose).
+    Returns ``200`` with ``{"db": "ok", "redis": "ok"}`` when both succeed, or
+    ``503`` and a per-component status when one of them fails. Mongo and
+    Celery worker checks are intentionally out of scope — Mongo only carries
+    logs (graceful-degradation candidate), and each Celery container ships
+    its own ``healthcheck`` in compose.
     """
     status: dict[str, Any] = {"db": "ok", "redis": "ok"}
     status_code = 200

--- a/apps/deaths/management/commands/scrape_deaths.py
+++ b/apps/deaths/management/commands/scrape_deaths.py
@@ -1,3 +1,9 @@
+"""Management command that scrapes the public deaths list.
+
+Always invoked by the Celery ``scrape_deaths`` task in a fresh subprocess so
+the Twisted reactor can be reused safely across runs.
+"""
+
 import json
 from typing import Any
 
@@ -9,9 +15,16 @@ from scrapers.tibiantis_scrapers.spiders.deaths_spider import DeathsSpider
 
 
 class Command(BaseCommand):
+    """``manage.py scrape_deaths`` — run the deaths spider once."""
+
     help = "Scrape latest deaths from tibiantis.info/stats/deaths"
 
     def handle(self, *args: Any, **options: Any) -> None:
+        """Crawl the deaths page and print a JSON summary to stdout.
+
+        The summary (``{"yielded": int, "duplicates": int}``) is parsed by
+        the Celery wrapper for observability.
+        """
         settings = get_project_settings()
         process = CrawlerProcess(settings=settings, install_root_handler=False)
         crawler = process.create_crawler(DeathsSpider)

--- a/apps/deaths/models.py
+++ b/apps/deaths/models.py
@@ -1,7 +1,23 @@
+"""Models for the deaths app.
+
+A :class:`DeathEvent` is an immutable record of a single character death
+pulled from the public Tibiantis deaths list. Deduplication is enforced at
+the DB level via the ``(character_name, died_at)`` unique constraint.
+"""
+
 from django.db import models
 
 
 class DeathEvent(models.Model):
+    """One scraped death event.
+
+    The ``announced_on_discord`` flag is the state used by the announcement
+    task to find rows that still need to be pushed to Discord channels.
+    Once flipped to ``True`` a row is never sent again — back-fills for
+    channels that lower their threshold after the fact are explicitly out
+    of scope (see services docstring).
+    """
+
     character_name = models.CharField(max_length=64, db_index=True)
     level_at_death = models.PositiveIntegerField()
     killed_by = models.TextField(blank=True, default="")

--- a/apps/deaths/schema.py
+++ b/apps/deaths/schema.py
@@ -1,3 +1,5 @@
+"""GraphQL schema for the deaths app."""
+
 from typing import cast
 import strawberry
 import strawberry_django
@@ -8,6 +10,8 @@ from apps.deaths.models import DeathEvent
 
 @strawberry_django.type(DeathEvent)
 class DeathEventType:
+    """GraphQL projection of :class:`apps.deaths.models.DeathEvent`."""
+
     id: auto
     character_name: auto
     level_at_death: auto
@@ -18,6 +22,8 @@ class DeathEventType:
 
 @strawberry.type
 class Query:
+    """Authenticated death-list queries."""
+
     @strawberry.field
     async def recent_deaths(
         self,
@@ -25,6 +31,12 @@ class Query:
         min_level: int | None = None,
         limit: int = 50,
     ) -> list[DeathEventType]:
+        """Return recent deaths above ``min_level``, newest first.
+
+        ``min_level`` falls back to ``settings.DEATH_LEVEL_THRESHOLD``. The
+        ``limit`` is clamped to the [1, 200] range to stop clients from
+        requesting arbitrarily large pages.
+        """
         request = info.context.request
         if not request.user.is_authenticated:
             raise PermissionError("Authentication required")

--- a/apps/deaths/services.py
+++ b/apps/deaths/services.py
@@ -1,3 +1,14 @@
+"""Service layer for the deaths app.
+
+Owns two concerns:
+
+* dedup-safe insertion of new :class:`DeathEvent` rows from the spider
+  (``save_death_event``);
+* the fan-out announcement loop that delivers unannounced deaths to every
+  Discord channel whose configured threshold is met
+  (``announce_unannounced_deaths``).
+"""
+
 from datetime import datetime
 from typing import TypedDict
 import logging
@@ -13,6 +24,8 @@ logger = logging.getLogger(__name__)
 
 
 class DeathPayload(TypedDict):
+    """Strongly-typed payload produced by the deaths spider pipeline."""
+
     character_name: str
     level_at_death: int
     killed_by: str

--- a/apps/deaths/tasks.py
+++ b/apps/deaths/tasks.py
@@ -1,3 +1,10 @@
+"""Celery tasks for the deaths app.
+
+Beat fires :func:`scrape_deaths` periodically; the task delegates the actual
+HTTP work to a subprocess management command (Twisted reactor isolation,
+see M1 retro #8) and then triggers the channel announcement loop.
+"""
+
 import logging
 import subprocess
 import sys

--- a/apps/deathwatch/management/commands/scrape_character_deaths.py
+++ b/apps/deathwatch/management/commands/scrape_character_deaths.py
@@ -1,3 +1,10 @@
+"""Management command that scrapes the Latest Deaths block of one character.
+
+Subprocess entry point used by the DW-5 Celery task. Keeping the Twisted
+reactor isolated from the worker process avoids the "reactor cannot be
+restarted" problem that bit the project in M3 retro #8.
+"""
+
 import asyncio
 import os
 import sys

--- a/apps/deathwatch/models.py
+++ b/apps/deathwatch/models.py
@@ -1,8 +1,28 @@
+"""Models for the deathwatch app.
+
+DeathWatch is a per-user public death subscription: every active row produces
+a notification on the configured channel(s) whenever the watched character
+dies. Three models cooperate:
+
+* :class:`DeathWatch` — user → character subscription.
+* :class:`WatchedDeathEvent` — immutable event recorded by the spider once a
+  qualifying death is found.
+* :class:`DeathWatchChannel` — per-guild announcement target configured by
+  the bot's ``/deathwatch channel`` command.
+"""
+
 from django.conf import settings
 from django.db import models
 
 
 class DeathWatch(models.Model):
+    """A user's subscription to deaths of a single character.
+
+    Identifying pair is ``(user, character)``; ``created_at`` is also the
+    floor used by :func:`apps.deathwatch.services.record_watched_death` to
+    drop historical deaths emitted by the spider's "Latest Deaths" table.
+    """
+
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
@@ -30,6 +50,15 @@ class DeathWatch(models.Model):
 
 
 class WatchedDeathEvent(models.Model):
+    """A death recorded by the deathwatch pipeline.
+
+    Distinct from :class:`apps.deaths.models.DeathEvent` — that one is a
+    global high-level deaths feed; this one is scoped to characters that at
+    least one user has subscribed to. ``announced_on_discord`` mirrors the
+    semantics in the deaths app: flipped to ``True`` once every configured
+    channel has acknowledged the message.
+    """
+
     character = models.ForeignKey(
         "characters.Character",
         on_delete=models.CASCADE,
@@ -58,6 +87,13 @@ class WatchedDeathEvent(models.Model):
 
 
 class DeathWatchChannel(models.Model):
+    """The Discord channel that receives deathwatch notifications per guild.
+
+    Both IDs are Discord snowflakes, hence ``BigIntegerField``. One row per
+    guild is enforced by the unique constraint; the GraphQL admin mutation
+    and the bot's ``/deathwatch channel`` command upsert into the same row.
+    """
+
     guild_id = models.BigIntegerField()
     channel_id = models.BigIntegerField()
     created_at = models.DateTimeField(auto_now_add=True)

--- a/apps/deathwatch/schema.py
+++ b/apps/deathwatch/schema.py
@@ -37,6 +37,8 @@ from apps.deathwatch.services import (
 
 @strawberry_django.type(DeathWatch)
 class DeathWatchType:
+    """GraphQL projection of :class:`apps.deathwatch.models.DeathWatch`."""
+
     id: auto
     created_at: auto
     active: auto
@@ -62,6 +64,8 @@ class DeathWatchType:
 
 @strawberry_django.type(WatchedDeathEvent)
 class WatchedDeathEventType:
+    """GraphQL projection of :class:`WatchedDeathEvent`."""
+
     id: auto
     level_at_death: auto
     killed_by: auto
@@ -85,6 +89,7 @@ class DeathWatchChannelType:
 
 
 def _require_auth(info: strawberry.Info) -> User:
+    """Resolve the authenticated user from the GraphQL context or raise."""
     request = info.context.request
     if not request.user.is_authenticated:
         raise PermissionError("Authentication required")
@@ -92,6 +97,7 @@ def _require_auth(info: strawberry.Info) -> User:
 
 
 def _require_superuser(info: strawberry.Info) -> User:
+    """Same as :func:`_require_auth` but also enforces ``is_superuser``."""
     user = _require_auth(info)
     if not user.is_superuser:
         raise PermissionError("Superuser required")
@@ -138,10 +144,13 @@ class Query:
 
 @strawberry.type
 class Mutation:
+    """Authenticated mutations for the deathwatch app."""
+
     @strawberry.mutation
     async def add_death_watch(
         self, info: strawberry.Info, character_name: str
     ) -> DeathWatchType:
+        """Subscribe the user to deaths of ``character_name``."""
         user = _require_auth(info)
         watch = await sync_to_async(add_death_watch)(user, character_name)
         return cast("DeathWatchType", watch)
@@ -150,6 +159,7 @@ class Mutation:
     async def remove_death_watch(
         self, info: strawberry.Info, character_name: str
     ) -> bool:
+        """Drop the user's deathwatch for ``character_name``; idempotent."""
         user = _require_auth(info)
         deleted = await sync_to_async(remove_death_watch)(user, character_name)
         return deleted

--- a/apps/notifications/__init__.py
+++ b/apps/notifications/__init__.py
@@ -1,3 +1,10 @@
+"""Notifications package.
+
+Resolves the notification handler implementations from settings on every call
+so that ``@override_settings`` in tests can swap them out without rebuilding
+any cached state. Real implementations live in :mod:`apps.notifications.handlers`.
+"""
+
 from typing import cast
 
 from django.conf import settings
@@ -22,6 +29,7 @@ def get_bedmage_handler() -> BedmageNotificationHandler:
 
 
 def get_death_handler() -> DeathAnnouncementHandler:  # NEW M8
+    """Resolve :class:`DeathAnnouncementHandler` from ``DEATH_NOTIFICATION_HANDLER``."""
     handler_class = import_string(settings.DEATH_NOTIFICATION_HANDLER)
     return cast(DeathAnnouncementHandler, handler_class())
 

--- a/apps/notifications/discord_client.py
+++ b/apps/notifications/discord_client.py
@@ -1,3 +1,10 @@
+"""Synchronous Discord REST client used by the notification handlers.
+
+The bot itself runs as a separate process built on top of ``discord.py``; this
+module is the path used by Celery tasks that just need to push a message and
+do not want to open a gateway connection.
+"""
+
 from __future__ import annotations
 
 import logging
@@ -11,11 +18,11 @@ logger = logging.getLogger(__name__)
 
 
 class DiscordRESTClient:
-    """Sync httpx client dla Discord REST API.
+    """Thin synchronous wrapper around the Discord REST API.
 
-    Bot token z settings.DISCORD_BOT_TOKEN (lazy, per-instance). Każdy
-    send_* call otwiera/zamyka httpx.Client przez context manager —
-    connection pooling lokalne dla jednego callu, no leak risk.
+    The bot token is read from ``settings.DISCORD_BOT_TOKEN`` on construction.
+    Every ``send_*`` call opens and closes its own :class:`httpx.Client` via a
+    context manager so no connection leaks across requests.
     """
 
     BASE_URL = "https://discord.com/api/v10"
@@ -25,11 +32,12 @@ class DiscordRESTClient:
         self.bot_token = bot_token or settings.DISCORD_BOT_TOKEN
 
     def send_dm(self, user_discord_id: int, content: str) -> bool:
-        """Wyślij DM do user'a po Discord snowflake.
+        """Send a direct message identified by the user's Discord snowflake.
 
-        2-step flow: POST /users/@me/channels {"recipient_id": id} →
-        channel_id, potem POST /channels/{channel_id}/messages.
-        Returns True przy 2xx (final message), False przy 4xx/5xx (po retry).
+        Two-step flow: ``POST /users/@me/channels {"recipient_id": id}`` to
+        get a DM channel, then ``POST /channels/{channel_id}/messages``.
+        Returns ``True`` on a successful final message response, ``False`` on
+        any 4xx/5xx (after the single retry handled by :meth:`_post`).
         """
         channel_response = self._post(
             f"{self.BASE_URL}/users/@me/channels",
@@ -57,7 +65,7 @@ class DiscordRESTClient:
         content: str | None = None,
         embed: dict[str, Any] | None = None,
     ) -> bool:
-        """Wyślij wiadomość do kanału. Content LUB embed (oba dozwolone)."""
+        """Send a message to ``channel_id``; ``content`` and ``embed`` are both optional."""
         body: dict[str, Any] = {}
         if content is not None:
             body["content"] = content
@@ -71,7 +79,7 @@ class DiscordRESTClient:
         return response is not None
 
     def _post(self, url: str, json_body: dict[str, Any]) -> httpx.Response | None:
-        """POST helper z 1-retry na 5xx/429. Returns Response (2xx) or None."""
+        """POST helper with one retry on 5xx/429; returns the 2xx response or ``None``."""
         if not self.bot_token:
             logger.error("DISCORD_BOT_TOKEN empty — outbound disabled")
             return None

--- a/apps/notifications/handlers.py
+++ b/apps/notifications/handlers.py
@@ -1,3 +1,11 @@
+"""Notification handlers for the three event sources.
+
+Bedmage notifications (DMs), deaths announcements (channel posts) and
+deathwatch announcements (channel posts) each use their own Protocol so the
+service layer can swap implementations purely through settings — handy for
+tests (logging-only handler) and dev (no Discord token required).
+"""
+
 from __future__ import annotations
 
 import logging
@@ -21,7 +29,9 @@ class BedmageNotificationHandler(Protocol):
     Implementations swap via settings.BEDMAGE_NOTIFICATION_HANDLER (dotted path).
     """
 
-    def notify(self, watch: BedmageWatch) -> None: ...
+    def notify(self, watch: BedmageWatch) -> None:
+        """Send the bedmage notification for ``watch``; never raises."""
+        ...
 
 
 class LoggingHandler:
@@ -31,6 +41,7 @@ class LoggingHandler:
     """
 
     def notify(self, watch: BedmageWatch) -> None:
+        """Log the notification at INFO level."""
         logger.info(
             "BEDMAGE: user=%s character=%s last_login=%s",
             watch.user.username,
@@ -48,6 +59,12 @@ class DiscordDMHandler:
     """
 
     def notify(self, watch: BedmageWatch) -> None:
+        """Send the notification as a Discord DM.
+
+        Failures (HTTP error, user disabled DMs, missing ``discord_id``) are
+        logged and swallowed — the service layer treats the watch as notified
+        either way to avoid the next scrape cycle producing another attempt.
+        """
         from apps.notifications.discord_client import DiscordRESTClient
 
         try:
@@ -102,7 +119,9 @@ class DeathAnnouncementHandler(Protocol):
 
     def announce(
         self, death_event: DeathEvent, discord_channel: DiscordChannel
-    ) -> bool: ...
+    ) -> bool:
+        """Push ``death_event`` to ``discord_channel``; return ``True`` on success."""
+        ...
 
 
 class DiscordChannelHandler:
@@ -111,6 +130,7 @@ class DiscordChannelHandler:
     def announce(
         self, death_event: DeathEvent, discord_channel: DiscordChannel
     ) -> bool:
+        """Render the embed and POST it to the configured channel."""
         from apps.notifications.discord_client import DiscordRESTClient
 
         client = DiscordRESTClient()
@@ -161,6 +181,7 @@ class DeathLoggingHandler:
     def announce(
         self, death_event: DeathEvent, discord_channel: DiscordChannel
     ) -> bool:
+        """Log the announcement and report success."""
         logger.info(
             "DEATH ANNOUNCE: %s (lvl %s) → guild=%s channel=%s",
             death_event.character_name,
@@ -188,15 +209,16 @@ class DeathWatchAnnouncementHandler(Protocol):
     Implementations swap via settings.DEATHWATCH_NOTIFICATION_HANDLER.
     """
 
-    def announce(
-        self, event: WatchedDeathEvent, channel: DeathWatchChannel
-    ) -> bool: ...
+    def announce(self, event: WatchedDeathEvent, channel: DeathWatchChannel) -> bool:
+        """Push ``event`` to ``channel``; return ``True`` on success."""
+        ...
 
 
 class DeathWatchChannelHandler:
     """Implements DeathWatchAnnouncementHandler. Posts purple embed to per-guild channel."""
 
     def announce(self, event: WatchedDeathEvent, channel: DeathWatchChannel) -> bool:
+        """Render the embed and POST it to the configured deathwatch channel."""
         from apps.notifications.discord_client import DiscordRESTClient
 
         client = DiscordRESTClient()
@@ -233,6 +255,7 @@ class DeathWatchLoggingHandler:
     """Test/dev variant — logs only, returns True (success). No Discord call."""
 
     def announce(self, event: WatchedDeathEvent, channel: DeathWatchChannel) -> bool:
+        """Log the announcement and report success."""
         logger.info(
             "DEATHWATCH ANNOUNCE: %s (lvl %s) → guild=%s channel=%s",
             event.character.name,

--- a/config/celery.py
+++ b/config/celery.py
@@ -1,3 +1,11 @@
+"""Celery application factory.
+
+Imported as ``config.celery:app`` by the worker, beat and any module that
+needs to enqueue tasks. ``autodiscover_tasks`` walks every installed Django
+app for a ``tasks`` module so new feature apps do not have to be wired in
+here.
+"""
+
 import os
 from celery import Celery
 

--- a/config/schema.py
+++ b/config/schema.py
@@ -1,3 +1,10 @@
+"""Merged GraphQL schema exposed at ``/graphql/``.
+
+Each Django app keeps its slice of the schema in ``apps/<feature>/schema.py``
+and this module just merges them — adding a new app means importing its
+``Query`` / ``Mutation`` and listing it in the merge call.
+"""
+
 import strawberry
 from strawberry.tools import merge_types
 from apps.accounts.schema import Query as AccountsQuery

--- a/config/views.py
+++ b/config/views.py
@@ -1,3 +1,11 @@
+"""Project-level GraphQL view wired with JWT authentication.
+
+Strawberry's stock async view does not understand DRF SimpleJWT tokens, so
+we subclass it and run :class:`JWTAuthentication` before each request to
+populate ``request.user``. Schema resolvers can then check
+``info.context.request.user.is_authenticated`` exactly like REST views do.
+"""
+
 from typing import Any
 from django.http import HttpRequest, HttpResponseBase
 from asgiref.sync import sync_to_async
@@ -9,9 +17,12 @@ from rest_framework.request import Request as DRFRequest
 
 
 class JWTAsyncGraphQLView(AsyncGraphQLView):
+    """Async GraphQL view that authenticates JWT tokens before dispatching."""
+
     async def dispatch(  # type: ignore[override]
         self, request: HttpRequest, *args: Any, **kwargs: Any
     ) -> HttpResponseBase:
+        """Resolve the JWT token to a user, then delegate to the parent view."""
         _authenticator = JWTAuthentication()
         try:
             auth_result: tuple[Any, Any] | None = await sync_to_async(

--- a/discord_bot/admin.py
+++ b/discord_bot/admin.py
@@ -1,9 +1,13 @@
+"""Django admin registration for the Discord bot models."""
+
 from django.contrib import admin
 from discord_bot.models import DiscordChannel
 
 
 @admin.register(DiscordChannel)
 class DiscordChannelAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
+    """Admin view for :class:`DiscordChannel`."""
+
     list_display = ("guild_id", "channel_id", "death_level_threshold", "updated_at")
     search_fields = ("guild_id",)
     readonly_fields = ("created_at", "updated_at")

--- a/discord_bot/bot.py
+++ b/discord_bot/bot.py
@@ -1,3 +1,11 @@
+"""Discord bot entry point.
+
+The bot exposes a single module-level :class:`discord.Bot` singleton so cog
+registration in tests and in the live process happen against the same
+instance. The actual loop is started by the ``run_discord_bot`` management
+command.
+"""
+
 from __future__ import annotations
 
 import logging
@@ -13,6 +21,12 @@ bot = discord.Bot(intents=intents)  # type: ignore[no-untyped-call]
 
 @bot.event
 async def on_ready() -> None:
+    """Sync slash commands once the gateway connection is established.
+
+    When ``DISCORD_DEV_GUILD_ID`` is set the sync is scoped to that one
+    guild (instant), otherwise it goes global (Discord-side propagation
+    can take up to an hour).
+    """
     assert bot.user is not None  # on_ready fires only after login
     logger.info("Bot logged in as %s (id=%s)", bot.user, bot.user.id)
     if settings.DISCORD_DEV_GUILD_ID:
@@ -27,6 +41,7 @@ async def on_ready() -> None:
 async def on_application_command_error(
     ctx: discord.ApplicationContext, error: discord.DiscordException
 ) -> None:
+    """Global slash-command error handler — never leaks a stack trace to chat."""
     logger.exception("Slash command error in /%s: %s", ctx.command, error)
     msg = "❌ Something went wrong. The admins have been notified."
     if ctx.response.is_done():

--- a/discord_bot/cogs/bedmages.py
+++ b/discord_bot/cogs/bedmages.py
@@ -13,6 +13,8 @@ from discord_bot.services import (
 
 
 class BedmageCog(commands.Cog):
+    """Slash commands for the per-user bedmage list (``/bedmage add|remove|list``)."""
+
     bedmage = discord.SlashCommandGroup("bedmage", "Manage your bedmage tracking list")
 
     def __init__(self, bot: discord.Bot) -> None:

--- a/discord_bot/cogs/deaths.py
+++ b/discord_bot/cogs/deaths.py
@@ -9,6 +9,8 @@ from discord_bot.services import set_death_threshold_for_guild
 
 
 class DeathsCog(commands.Cog):
+    """Admin-side death-monitor configuration commands (``/deaths threshold``)."""
+
     deaths = discord.SlashCommandGroup("deaths", "Death monitor configuration")
 
     def __init__(self, bot: discord.Bot) -> None:

--- a/discord_bot/management/commands/run_discord_bot.py
+++ b/discord_bot/management/commands/run_discord_bot.py
@@ -1,3 +1,9 @@
+"""Management command that boots the Discord bot loop.
+
+Run as a long-lived process, typically inside its own container so it can be
+restarted independently of the web/Celery workers.
+"""
+
 from __future__ import annotations
 from typing import Any
 from django.conf import settings
@@ -6,9 +12,12 @@ from discord_bot.bot import setup_bot
 
 
 class Command(BaseCommand):
+    """``manage.py run_discord_bot`` — start the bot and block."""
+
     help = "Run the Discord bot (blocks until interrupted)"
 
     def handle(self, *args: Any, **options: Any) -> None:
+        """Refuse to start without a bot token, otherwise hand control to py-cord."""
         if not settings.DISCORD_BOT_TOKEN:
             self.stderr.write("DISCORD_BOT_TOKEN not set in env")
             return

--- a/discord_bot/models.py
+++ b/discord_bot/models.py
@@ -1,7 +1,20 @@
+"""Models owned by the Discord bot.
+
+Currently a single :class:`DiscordChannel` row per guild, configured by
+``/deaths threshold`` and consumed by :func:`apps.deaths.services.announce_unannounced_deaths`.
+"""
+
 from django.db import models
 
 
 class DiscordChannel(models.Model):
+    """The death-announcement target configured per Discord guild.
+
+    ``death_level_threshold`` is the minimum character level a death must
+    have for the announcement task to push it into this channel. The
+    ``guild_id`` unique constraint ensures one configuration row per guild.
+    """
+
     guild_id = models.BigIntegerField()
     channel_id = models.BigIntegerField()
     death_level_threshold = models.PositiveIntegerField(default=30)

--- a/discord_bot/services.py
+++ b/discord_bot/services.py
@@ -1,3 +1,11 @@
+"""Bot-side service layer.
+
+Cogs are kept small and delegate everything to this module so the Django ORM
+calls live in one place. Functions here also bridge the Discord-side identity
+(``discord_id``) with the Django ``User`` model, auto-creating users on first
+contact.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/logs_backend/__init__.py
+++ b/logs_backend/__init__.py
@@ -1,3 +1,11 @@
+"""MongoDB access layer for project-wide log storage.
+
+Mongo is used **only** for logs in this project (CLAUDE.md §4). The helpers
+here lazily build a singleton :class:`pymongo.MongoClient` and create
+collection-specific indexes on first use so the logging and Scrapy pipelines
+can stay schema-free.
+"""
+
 from __future__ import annotations
 
 from typing import Optional
@@ -29,6 +37,7 @@ def get_mongo_client() -> pymongo.MongoClient:
 
 
 def get_database() -> Database:
+    """Return the configured :class:`Database` from the lazy client."""
     return get_mongo_client()[settings.MONGO_DB]
 
 

--- a/logs_backend/handlers.py
+++ b/logs_backend/handlers.py
@@ -1,3 +1,10 @@
+"""Logging handlers that push records into MongoDB.
+
+Wired into Django's ``LOGGING`` setting via the ``()`` factory pattern so the
+config can fall back to a :class:`logging.NullHandler` when ``MONGO_URL`` is
+empty (dev mode without Mongo).
+"""
+
 from __future__ import annotations
 
 import logging
@@ -18,10 +25,17 @@ class MongoLogHandler(logging.Handler):
     """
 
     def __init__(self) -> None:
+        """Use a default :class:`logging.Formatter` so ``emit`` can format exceptions."""
         super().__init__()
         self.setFormatter(logging.Formatter())
 
     def emit(self, record: logging.LogRecord) -> None:
+        """Serialise ``record`` into a Mongo document and insert it.
+
+        On any error (Mongo down, network blip, serialisation oddity) the
+        handler delegates to :meth:`logging.Handler.handleError`, which writes
+        a formatted message to ``stderr``. Logging must never break the app.
+        """
         try:
             doc: dict[str, object] = {
                 "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc),

--- a/scrapers/tibiantis_scrapers/extensions.py
+++ b/scrapers/tibiantis_scrapers/extensions.py
@@ -1,3 +1,5 @@
+"""Scrapy extensions that the project plugs into the framework's signal bus."""
+
 from __future__ import annotations
 
 import logging
@@ -17,10 +19,11 @@ logger = logging.getLogger(__name__)
 
 
 class MongoStatsExtension:
-    """Persist 1 document per `scrapy crawl <spider>` to scrape_logs (§3.2).
+    """Persist one ``scrape_logs`` document per spider run.
 
-    Wired via EXTENSIONS dict. Disabled cleanly via NotConfigured when
-    MONGO_URL is empty (dev mode without Mongo).
+    Wired through Scrapy's ``EXTENSIONS`` setting; raises
+    :class:`NotConfigured` when ``MONGO_URL`` is empty so it disables
+    cleanly in environments without Mongo (e.g. unit tests).
     """
 
     def __init__(self) -> None:
@@ -28,6 +31,7 @@ class MongoStatsExtension:
 
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> "MongoStatsExtension":
+        """Subscribe to spider open/close signals or refuse to load."""
         if not django_settings.MONGO_URL:
             raise NotConfigured(
                 "MONGO_URL not configured — MongoStatsExtension disabled"
@@ -39,9 +43,11 @@ class MongoStatsExtension:
         return instance
 
     def spider_opened(self, spider: Spider) -> None:
+        """Record the run start time."""
         self.started_at = datetime.now(tz=timezone.utc)
 
     def spider_closed(self, spider: Spider, reason: str) -> None:
+        """Flush a summary document with run stats to Mongo."""
         finished_at = datetime.now(tz=timezone.utc)
         stats: dict[str, Any] = spider.crawler.stats.get_stats()
         error_count = stats.get("log_count/ERROR", 0)

--- a/scrapers/tibiantis_scrapers/items.py
+++ b/scrapers/tibiantis_scrapers/items.py
@@ -1,7 +1,15 @@
+"""Scrapy item definitions for the Tibiantis spiders.
+
+Items are deliberately schema-less ``Item`` subclasses — typing happens at the
+service boundary via the ``TypedDict`` payloads in ``apps/*/types.py``.
+"""
+
 from scrapy import Item, Field
 
 
 class CharacterItem(Item):
+    """Profile fields emitted by :class:`CharacterSpider`."""
+
     name = Field()
     sex = Field()
     vocation = Field()
@@ -15,6 +23,8 @@ class CharacterItem(Item):
 
 
 class DeathItem(Item):
+    """A row from the global ``tibiantis.info`` deaths feed."""
+
     character_name = Field()
     level_at_death = Field()
     killed_by = Field()

--- a/scrapers/tibiantis_scrapers/pipelines.py
+++ b/scrapers/tibiantis_scrapers/pipelines.py
@@ -1,3 +1,9 @@
+"""Scrapy item pipeline that hands every item to the Django service layer.
+
+CLAUDE.md §6 forbids spiders from touching the Django ORM directly — the
+pipeline is the only place that bridges Scrapy items into ``apps.*.services``.
+"""
+
 from asgiref.sync import sync_to_async
 from scrapers.tibiantis_scrapers.items import (
     CharacterDeathItem,
@@ -7,7 +13,14 @@ from scrapers.tibiantis_scrapers.items import (
 
 
 class DjangoPipeline:
+    """Route each item type to the right Django service function.
+
+    Service calls are sync, but the Scrapy 2.11+ pipeline interface is async,
+    hence the ``sync_to_async`` wrapper around every dispatch.
+    """
+
     async def process_item(self, item, spider):
+        """Dispatch ``item`` to the matching service and return it unchanged."""
         if isinstance(item, CharacterItem):
             from apps.characters.services import upsert_character
 

--- a/scrapers/tibiantis_scrapers/spiders/character_deaths_spider.py
+++ b/scrapers/tibiantis_scrapers/spiders/character_deaths_spider.py
@@ -18,9 +18,15 @@ _DEATH_TEXT_RE = re.compile(r"Killed at Level (\d+)(?: by (.+?))?\.?$")
 
 
 class CharacterDeathsSpider(scrapy.Spider):
+    """Per-character deaths spider used by the deathwatch pipeline.
+
+    Driven by a Scrapy argument: ``-a name=<character>``.
+    """
+
     name = "character_deaths"
 
     def __init__(self, name=None, *args, **kwargs):
+        """Validate ``name`` and build the profile URL."""
         super().__init__(*args, **kwargs)
         if not name:
             raise ValueError("CharacterDeathsSpider requires -a name=<character>")

--- a/scrapers/tibiantis_scrapers/spiders/character_spider.py
+++ b/scrapers/tibiantis_scrapers/spiders/character_spider.py
@@ -1,3 +1,5 @@
+"""Spider that scrapes a single character profile from ``tibiantis.online``."""
+
 from datetime import datetime
 
 import scrapy
@@ -7,9 +9,15 @@ from scrapers.tibiantis_scrapers.utils.dates import parse_tibiantis_timestamp
 
 
 class CharacterSpider(scrapy.Spider):
+    """Crawl one character's profile and emit a :class:`CharacterItem`.
+
+    The character name is passed as a Scrapy argument: ``-a name=Yhral``.
+    """
+
     name = "character"
 
     def __init__(self, name=None, *args, **kwargs):
+        """Validate the ``name`` argument and build the start URL."""
         super().__init__(*args, **kwargs)
 
         if not name:
@@ -27,6 +35,13 @@ class CharacterSpider(scrapy.Spider):
         return parse_tibiantis_timestamp(raw)
 
     def parse(self, response):
+        """Parse the profile table into a :class:`CharacterItem`.
+
+        Walks the ``<tr class="hover">`` rows of the first ``table.tabi``,
+        treating the first cell as the field name and the second cell as the
+        value. Returns silently when the page does not contain the expected
+        table (e.g. the character does not exist).
+        """
         rows = response.css("table.tabi tr.hover")
 
         if not rows:

--- a/scrapers/tibiantis_scrapers/spiders/deaths_spider.py
+++ b/scrapers/tibiantis_scrapers/spiders/deaths_spider.py
@@ -1,3 +1,5 @@
+"""Spider that scrapes the global Latest Deaths feed from ``tibiantis.info``."""
+
 import re
 import scrapy
 from scrapers.tibiantis_scrapers.items import DeathItem
@@ -6,6 +8,13 @@ from zoneinfo import ZoneInfo
 
 
 class DeathsSpider(scrapy.Spider):
+    """Scrape the Concordia deaths list and emit one :class:`DeathItem` per row.
+
+    The Tibiantis stats portal keeps the chosen server in a session cookie,
+    so every crawl first hits the "set server" URL and only then loads the
+    deaths page.
+    """
+
     name = "deaths"
 
     _LEVEL_RE = re.compile(r"\((\d+)\)")
@@ -13,7 +22,7 @@ class DeathsSpider(scrapy.Spider):
     _DEATHS_URL = "https://tibiantis.info/stats/deaths"
 
     def start_requests(self):
-        # najpierw przełącz sesję na Concordia
+        """Switch the session to the Concordia server before scraping."""
         yield scrapy.Request(
             self._SET_SERVER_URL,
             callback=self._after_server_switch,
@@ -21,9 +30,15 @@ class DeathsSpider(scrapy.Spider):
         )
 
     def _after_server_switch(self, response):
+        """Once the cookie is set, fetch the deaths page."""
         yield scrapy.Request(self._DEATHS_URL, callback=self.parse)
 
     def parse(self, response):
+        """Yield one :class:`DeathItem` per data row of the deaths table.
+
+        Skips the header row (slice ``[1:]``) and silently drops malformed
+        rows with a warning instead of aborting the whole crawl.
+        """
         rows = response.css("table.mytab.long tr")[1:]
 
         if not rows:


### PR DESCRIPTION
## Summary
- Rewrites `README.md` in English with project overview, tech stack table, repo layout, and a full local-setup walkthrough (compose dev services, Poetry, migrations, Celery `-P solo` on Windows, Discord bot, tests, pre-commit).
- Adds module/class/function docstrings across `apps/`, `scrapers/`, `discord_bot/`, `config/` and `logs_backend/` so the codebase reads consistently in English. Polish docstrings that already existed (`discord_client`, `health`, `extensions`) translated in place. No behavior changes.

## Test plan
- [x] `poetry run ruff check .` passes
- [x] `poetry run ruff format --check .` passes
- [x] `poetry run pre-commit run --all-files` passes (ruff, ruff-format, mypy, django-upgrade, gitleaks, conventional-commit)
- [x] CI green